### PR TITLE
fix: various (small) fixes for registry operations

### DIFF
--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -68,6 +68,8 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to parse external installer repository: %w", err)
 	}
 
+	frontendOptions.RemoteOptions = append(frontendOptions.RemoteOptions, remoteOptions()...)
+
 	frontendHTTP, err := frontendhttp.NewFrontend(logger, configFactory, assetBuilder, artifactsManager, frontendOptions)
 	if err != nil {
 		return fmt.Errorf("failed to initialize HTTP frontend: %w", err)


### PR DESCRIPTION
Pass auth to the registry frontend so that it correctly authenticates to the registry on uploads/checks.

Refactor the code in the registry frontend to use digest instead of tag when redirecting request for additional security.

In the schematic registry storage, push a manifest on top of raw blob to make sure it doesn't get garbage collected as orphaned. We never use the manifest though.