### PR TITLE
feat: add support for insecure image registry

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -15,6 +15,8 @@ type Options struct { //nolint:govet
 	MinTalosVersion string
 	// Image registry for source images: imager, extensions, etc..
 	ImageRegistry string
+	// Allow insecure connection to the image registry
+	InsecureImageRegistry bool
 
 	// Options to verify container signatures for imager, extensions, etc.
 	ContainerSignatureSubjectRegExp string

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -132,8 +132,9 @@ func buildArtifactsManager(ctx context.Context, logger *zap.Logger, opts Options
 	}
 
 	artifactsManager, err := artifacts.NewManager(logger, artifacts.Options{
-		MinVersion:    minVersion,
-		ImageRegistry: opts.ImageRegistry,
+		MinVersion:            minVersion,
+		ImageRegistry:         opts.ImageRegistry,
+		InsecureImageRegistry: opts.InsecureImageRegistry,
 		ImageVerifyOptions: cosign.CheckOpts{
 			Identities: []cosign.Identity{
 				{

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -18,6 +18,7 @@ func initFlags() cmd.Options {
 
 	flag.StringVar(&opts.MinTalosVersion, "min-talos-version", cmd.DefaultOptions.MinTalosVersion, "minimum Talos version")
 	flag.StringVar(&opts.ImageRegistry, "image-registry", cmd.DefaultOptions.ImageRegistry, "image registry for imager, extensions, etc.")
+	flag.BoolVar(&opts.InsecureImageRegistry, "insecure-image-registry", cmd.DefaultOptions.InsecureImageRegistry, "allow an insecure connection to the image registry")
 
 	flag.StringVar(&opts.ContainerSignatureSubjectRegExp, "container-signature-subject-regexp", cmd.DefaultOptions.ContainerSignatureSubjectRegExp, "container signature subject regexp")
 	flag.StringVar(&opts.ContainerSignatureIssuer, "container-signature-issuer", cmd.DefaultOptions.ContainerSignatureIssuer, "container signature issuer")

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -19,6 +19,8 @@ type Options struct { //nolint:govet
 	//
 	// For official images, this is "ghcr.io".
 	ImageRegistry string
+	// Option to allow using an image registry without TLS.
+	InsecureImageRegistry bool
 	// MinVersion is the minimum version of Talos to use.
 	MinVersion semver.Version
 	// ImageVerifyOptions are the options for verifying the image signature.

--- a/internal/artifacts/manager.go
+++ b/internal/artifacts/manager.go
@@ -52,7 +52,12 @@ func NewManager(logger *zap.Logger, options Options) (*Manager, error) {
 		return nil, fmt.Errorf("failed to create schematics directory: %w", err)
 	}
 
-	imageRegistry, err := name.NewRegistry(options.ImageRegistry)
+	opts := []name.Option{}
+	if options.InsecureImageRegistry {
+		opts = append(opts, name.Insecure)
+	}
+
+	imageRegistry, err := name.NewRegistry(options.ImageRegistry, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image registry: %w", err)
 	}


### PR DESCRIPTION
Adds support for using an insecure image registry without having to specify it as IP:PORT.