### PR TITLE
feat: support insecure endpoint for internal repository

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -37,6 +37,8 @@ type Options struct { //nolint:govet
 	// - external one for the redirects
 	InstallerInternalRepository string
 	InstallerExternalRepository string
+	// Allow insecure connection to the internal installer repository
+	InsecureInstallerInternalRepository bool
 
 	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.
 	TalosVersionRecheckInterval time.Duration

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -58,7 +58,12 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to parse self URL: %w", err)
 	}
 
-	frontendOptions.InstallerInternalRepository, err = name.NewRepository(opts.InstallerInternalRepository)
+	repoOpts := []name.Option{}
+	if opts.InsecureInstallerInternalRepository {
+		repoOpts = append(repoOpts, name.Insecure)
+	}
+
+	frontendOptions.InstallerInternalRepository, err = name.NewRepository(opts.InstallerInternalRepository, repoOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to parse internal installer repository: %w", err)
 	}

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -31,6 +31,12 @@ func initFlags() cmd.Options {
 
 	flag.StringVar(&opts.InstallerExternalRepository, "installer-external-repository", cmd.DefaultOptions.InstallerExternalRepository, "image repository for the installer (external)")
 	flag.StringVar(&opts.InstallerInternalRepository, "installer-internal-repository", cmd.DefaultOptions.InstallerInternalRepository, "image repository for the installer (internal)")
+	flag.BoolVar(
+		&opts.InsecureInstallerInternalRepository,
+		"insecure-installer-internal-repository",
+		cmd.DefaultOptions.InsecureInstallerInternalRepository,
+		"allow an insecure connection to the image repository for the installer (internal)",
+	)
 
 	flag.DurationVar(&opts.TalosVersionRecheckInterval, "talos-versions-recheck-interval", cmd.DefaultOptions.TalosVersionRecheckInterval, "interval to recheck Talos versions")
 


### PR DESCRIPTION
Adds support for connecting to the internal endpoint of the public image repository without TLS.