### PR TITLE
fix: check the already built installer image correctly

### DIFF
--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -149,6 +149,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, _ 
 		f.options.InstallerInternalRepository.Repo(
 			f.options.InstallerInternalRepository.RepositoryStr(),
 			img.Name(),
+			schematicID,
 		).Tag(versionTag),
 	)
 	if err == nil {


### PR DESCRIPTION
This was using wrong image name, so the check never succeeded resulting in re-build of the image each time.