### PR TITLE
feat: sign generated installer image

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,37 @@ Example: `docker pull factory.talos.dev/installer/376567988ad370138ad8b269821236
 Pulls the Talos Linux `installer` image with the specified schematic and Talos Linux version.
 The image platform (architecture) will be determined by the architecture of the Talos Linux Linux machine.
 
+### `GET /oci/cosign/signing-key.pub`
+
+Returns PEM-encoded public key used to sign the Talos Linux `installer` images.
+
+The key can be used to verify the installer images with `cosign`:
+
+```shell
+cosign verify --offline --insecure-ignore-tlog --insecure-ignore-sct --key signing-key.pub factory.talos.dev/...
+```
+
 ## Development
 
 Run integration tests in local mode, with registry mirrors:
 
 ```bash
 make integration TEST_FLAGS="-test.image-registry=127.0.0.1:5004 -test.schematic-service-repository=127.0.0.1:5005/image-factory/schematic -test.installer-external-repository=127.0.0.1:5005/test -test.installer-internal-repository=127.0.0.1:5005/test" REGISTRY=127.0.0.1:5005
+```
+
+In order to run the Image Factory, generate a ECDSA key pair:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out cache-signing-key.key
+```
+
+Run the Image Factory passing the flags:
+
+```text
+-image-registry 127.0.0.1:5004 # registry mirror for ghcr.io
+-external-url https://example.com/ # external URL the Image Factory is available at
+-schematic-service-repository 127.0.0.1:5005/image-factory/schematic # private registry for schematics
+-installer-internal-repository 127.0.0.1:5005/siderolabs # internal registry to push installer images to
+-installer-external-repository 127.0.0.1:5005/siderolabs # external registry to redirect users to pull installer
+-cache-signing-key-path ./cache-signing-key.key # path to the ECDSA private key (to sign cached assets)
 ```

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -42,6 +42,11 @@ type Options struct { //nolint:govet
 
 	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.
 	TalosVersionRecheckInterval time.Duration
+
+	// CacheSigningKeyPath is the path to the signing key for the cache.
+	//
+	// Best choice is to use ECDSA key.
+	CacheSigningKeyPath string
 }
 
 // DefaultOptions are the default options.

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -40,6 +40,8 @@ func initFlags() cmd.Options {
 
 	flag.DurationVar(&opts.TalosVersionRecheckInterval, "talos-versions-recheck-interval", cmd.DefaultOptions.TalosVersionRecheckInterval, "interval to recheck Talos versions")
 
+	flag.StringVar(&opts.CacheSigningKeyPath, "cache-signing-key-path", cmd.DefaultOptions.CacheSigningKeyPath, "path to the default cache signing key (PEM-encoded, ECDSA private key)")
+
 	flag.Parse()
 
 	return opts

--- a/internal/image/signer/signer.go
+++ b/internal/image/signer/signer.go
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package signer implements simplified cosign-compatible OCI image signer.
+package signer
+
+import (
+	"context"
+	"crypto"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/oci/empty"
+	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
+	cosignremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/sigstore/cosign/v2/pkg/oci/static"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+// Signer holds a key used to sign the images.
+//
+// We are not using directly 'cosign' implementation here, as it's behind
+// series of internal/ packages.
+type Signer struct {
+	sv           signature.SignerVerifier
+	publicKeyPEM []byte
+}
+
+// NewSigner creates a new signer.
+func NewSigner(key crypto.PrivateKey) (*Signer, error) {
+	sv, err := signature.LoadSignerVerifier(key, crypto.SHA256)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signer: %w", err)
+	}
+
+	pubKey, err := sv.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve public key: %w", err)
+	}
+
+	pubKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key to PEM: %w", err)
+	}
+
+	return &Signer{
+		sv:           sv,
+		publicKeyPEM: pubKeyPEM,
+	}, nil
+}
+
+// GetVerifier returns the verifier for the signature.
+func (s *Signer) GetVerifier() signature.Verifier {
+	return s.sv
+}
+
+// GetCheckOpts returns cosign compatible image signature verification options.
+func (s *Signer) GetCheckOpts() *cosign.CheckOpts {
+	return &cosign.CheckOpts{
+		SigVerifier: s.GetVerifier(),
+		IgnoreSCT:   true,
+		IgnoreTlog:  true,
+		Offline:     true,
+	}
+}
+
+// GetPublicKeyPEM returns the public key in PEM format.
+func (s *Signer) GetPublicKeyPEM() []byte {
+	return s.publicKeyPEM
+}
+
+// SignImage signs the image in the OCI repository.
+func (s *Signer) SignImage(ctx context.Context, imageRef name.Digest, pusher *remote.Pusher) error {
+	payload, signature, err := signature.SignImage(s.sv, imageRef, nil)
+	if err != nil {
+		return fmt.Errorf("error generating signature: %w", err)
+	}
+
+	b64Signature := base64.StdEncoding.EncodeToString(signature)
+
+	signatureTag, err := cosignremote.SignatureTag(imageRef)
+	if err != nil {
+		return fmt.Errorf("error generating signature tag: %w", err)
+	}
+
+	signatureLayer, err := static.NewSignature(payload, b64Signature)
+	if err != nil {
+		return fmt.Errorf("error generating signature layer: %w", err)
+	}
+
+	signatures, err := mutate.AppendSignatures(empty.Signatures(), signatureLayer)
+	if err != nil {
+		return fmt.Errorf("error appending signatures: %w", err)
+	}
+
+	if err = pusher.Push(ctx, signatureTag, signatures); err != nil {
+		return fmt.Errorf("error pushing signature: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Image Factory now signs the generated asset using cosign flow with a fixed key. Image Factory also verifies the signature before redirecting to the image. This way we ensure the consistency of the cache.

The signing ECDSA private key (PEM-encoded) should be supplied as `--signing-key-path` flag.

Fixes #29