### PR TITLE
fix: implement insecure option for cache repository

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -51,6 +51,8 @@ type Options struct { //nolint:govet
 	// OCI registry to use to store cached boot assets.
 	// Only used internally by the image factory.
 	CacheRepository string
+	// Allow insecure connection to the cache repository.
+	InsecureCacheRepository bool
 }
 
 // DefaultOptions are the default options.

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -71,7 +71,8 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to parse self URL: %w", err)
 	}
 
-	repoOpts := []name.Option{}
+	var repoOpts []name.Option
+
 	if opts.InsecureInstallerInternalRepository {
 		repoOpts = append(repoOpts, name.Insecure)
 	}
@@ -183,9 +184,15 @@ func buildAssetBuilder(logger *zap.Logger, artifactsManager *artifacts.Manager, 
 
 	builderOptions.RemoteOptions = append(builderOptions.RemoteOptions, remoteOptions()...)
 
+	var repoOpts []name.Option
+
+	if opts.InsecureCacheRepository {
+		repoOpts = append(repoOpts, name.Insecure)
+	}
+
 	var err error
 
-	builderOptions.CacheRepository, err = name.NewRepository(opts.CacheRepository)
+	builderOptions.CacheRepository, err = name.NewRepository(opts.CacheRepository, repoOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse cache repository: %w", err)
 	}

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -43,6 +43,12 @@ func initFlags() cmd.Options {
 	flag.StringVar(&opts.CacheSigningKeyPath, "cache-signing-key-path", cmd.DefaultOptions.CacheSigningKeyPath, "path to the default cache signing key (PEM-encoded, ECDSA private key)")
 
 	flag.StringVar(&opts.CacheRepository, "cache-repository", cmd.DefaultOptions.CacheRepository, "cache repository for boot assets")
+	flag.BoolVar(
+		&opts.InsecureCacheRepository,
+		"insecure-cache-repository",
+		cmd.DefaultOptions.InsecureCacheRepository,
+		"allow an insecure connection to the cache repository",
+	)
 
 	flag.Parse()
 


### PR DESCRIPTION
I forgot to implement it while doing asset caching.