### PR TITLE
fix: parse profiles for 'digital-ocean' platform

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -44,6 +44,12 @@ func parsePlatformArch(s string, prof *profile.Profile) error {
 		return xerrors.NewTaggedf[InvalidErrorTag]("invalid platform-arch: %q", s)
 	}
 
+	// special case for 'digital-ocean' platform which has a dash in it
+	if platform == "digital" && strings.HasPrefix(rest, "ocean-") {
+		platform = "digital-ocean"
+		rest = strings.TrimPrefix(rest, "ocean-")
+	}
+
 	prof.Platform = platform
 
 	if platform == constants.PlatformMetal && strings.HasSuffix(rest, "-"+string(artifacts.ArchArm64)) {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -197,6 +197,22 @@ func TestParseFromPath(t *testing.T) {
 				},
 			},
 		},
+		{
+			path: "digital-ocean-amd64.raw.gz",
+
+			expectedProfile: profile.Profile{
+				Platform: "digital-ocean",
+				Arch:     "amd64",
+				Output: profile.Output{
+					Kind:      profile.OutKindImage,
+					OutFormat: profile.OutFormatGZ,
+					ImageOptions: &profile.ImageOptions{
+						DiskFormat: profile.DiskFormatRaw,
+						DiskSize:   profile.DefaultRAWDiskSize,
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.path, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
As `digital-ocean` has a dash, we need to do a little trick, as we should support both:

* `digital-ocean-amd64`
* `metal-rpi_generic-arm64`

The first has platform `digital-ocean`, while the second is platform `metal` and board `rpi_generic`.