### PR TITLE
Update readme to highlight registration is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Output is a JSON-encoded schematic ID:
 {"id":"2a63b6e7dab90ec9d44f213339b9545bd39c6499b22a14cf575c1ca4b6e39ff8"}
 ```
 
-This ID can be used to download images with this schematic.
+After creation ID can be used to download images with this schematic.
+Creation through the factory is required for the images associated with the ID to be build.
 
 Well-known schematic IDs:
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ boot
 
 The Talos Linux `installer` image is used for the initial install and upgrades.
 It can be pulled from the Image Factory OCI registry.
-If the image hasn't been created yet, it will be built on demand automatically.
+If the image hasn't been created yet, it will be built on demand automatically. As long as the ID has been created before.
 
 ### `docker pull <registry>/installer[-secureboot]/<schematic>:<version>`
 


### PR DESCRIPTION
It's not fully clear that creation through the API is required for images to be build.
This change highlights that for images to be made available an API call is mandatory.

