### PR TITLE
feat: implement HTTP API client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-28T14:31:58Z by kres latest.
+# Generated on 2023-11-30T12:42:01Z by kres latest.
 
 name: default
 concurrency:

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-21T16:57:47Z by kres latest.
+# Generated on 2023-11-30T12:42:01Z by kres latest.
 
 name: slack-notify
 "on":

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-30T10:18:19Z by kres 902f3bd-dirty.
+# Generated on 2023-11-30T12:42:01Z by kres latest.
 
 ARG TOOLCHAIN
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-30T10:20:41Z by kres 902f3bd-dirty.
+# Generated on 2023-11-30T12:36:19Z by kres latest.
 
 # common variables
 

--- a/internal/frontend/http/meta.go
+++ b/internal/frontend/http/meta.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/image-factory/internal/artifacts"
+	"github.com/siderolabs/image-factory/pkg/client"
 )
 
 // handleVersions handles list of Talos versions available.
@@ -49,15 +50,9 @@ func (f *Frontend) handleOfficialExtensions(ctx context.Context, w http.Response
 		return err
 	}
 
-	type extensionInfo struct {
-		Name   string `json:"name"`
-		Ref    string `json:"ref"`
-		Digest string `json:"digest"`
-	}
-
 	return json.NewEncoder(w).Encode(
-		xslices.Map(extensions, func(e artifacts.ExtensionRef) extensionInfo {
-			return extensionInfo{
+		xslices.Map(extensions, func(e artifacts.ExtensionRef) client.ExtensionInfo {
+			return client.ExtensionInfo{
 				Name:   e.TaggedReference.RepositoryStr(),
 				Ref:    e.TaggedReference.String(),
 				Digest: e.Digest,

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -181,10 +182,13 @@ func testRegistryFrontend(ctx context.Context, t *testing.T, registryAddr string
 	registry, err := name.NewRegistry(registryAddr)
 	require.NoError(t, err)
 
+	c, err := client.New("http://" + registryAddr)
+	require.NoError(t, err)
+
 	// create a new random schematic, so that we can make sure new installer is generated
 	randomKernelArg := hex.EncodeToString(randomBytes(t, 32))
 
-	randomSchematicID := createSchematicGetID(ctx, t, "http://"+registryAddr,
+	randomSchematicID := createSchematicGetID(ctx, t, c,
 		schematic.Schematic{
 			Customization: schematic.Customization{
 				ExtraKernelArgs: []string{randomKernelArg},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package client implements image factory HTTP API client.
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/siderolabs/gen/xerrors"
+
+	"github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+// InvalidSchematicError is parsed from 400 response from the server.
+type InvalidSchematicError struct {
+	Details string
+}
+
+// Error implements error interface.
+func (e *InvalidSchematicError) Error() string {
+	return fmt.Sprintf("invalid schematic: %s", e.Details)
+}
+
+// IsInvalidSchematicError checks if the error is invalid schematic.
+func IsInvalidSchematicError(err error) bool {
+	return xerrors.TypeIs[*InvalidSchematicError](err)
+}
+
+// ExtensionInfo defines extensions versions list response item.
+type ExtensionInfo struct {
+	Name   string `json:"name"`
+	Ref    string `json:"ref"`
+	Digest string `json:"digest"`
+}
+
+// Client is the Image Factory HTTP API client.
+type Client struct {
+	baseURL *url.URL
+	client  http.Client
+}
+
+// New creates a new Image Factory API client.
+func New(baseURL string, options ...Option) (*Client, error) {
+	opts := withDefaults(options)
+
+	bURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		baseURL: bURL,
+		client:  opts.Client,
+	}
+
+	return c, nil
+}
+
+// SchematicCreate generates new schematic from the configuration.
+func (c *Client) SchematicCreate(ctx context.Context, schematic schematic.Schematic) (string, error) {
+	data, err := schematic.Marshal()
+	if err != nil {
+		return "", err
+	}
+
+	var response struct {
+		ID string `json:"id"`
+	}
+
+	if err = c.do(ctx, http.MethodPost, "/schematics", data, &response, map[string]string{
+		"Content-Type": "application/yaml",
+	}); err != nil {
+		return "", err
+	}
+
+	return response.ID, nil
+}
+
+// Versions gets the list of Talos versions available.
+func (c *Client) Versions(ctx context.Context) ([]string, error) {
+	var versions []string
+
+	if err := c.do(ctx, http.MethodGet, "/versions", nil, &versions, nil); err != nil {
+		return nil, err
+	}
+
+	return versions, nil
+}
+
+// ExtensionsVersions gets the version of the extension for a Talos version.
+func (c *Client) ExtensionsVersions(ctx context.Context, talosVersion string) ([]ExtensionInfo, error) {
+	var versions []ExtensionInfo
+
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/version/%s/extensions/official", talosVersion), nil, &versions, nil); err != nil {
+		return nil, err
+	}
+
+	return versions, nil
+}
+
+func (c *Client) do(ctx context.Context, method, uri string, requestData []byte, responseData any, headers map[string]string) error {
+	var reader io.Reader
+
+	if requestData != nil {
+		reader = bytes.NewReader(requestData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL.JoinPath(uri).String(), reader)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	if err = c.checkError(resp); err != nil {
+		return err
+	}
+
+	if responseData != nil {
+		decoder := json.NewDecoder(resp.Body)
+
+		return decoder.Decode(responseData)
+	}
+
+	return nil
+}
+
+func (c *Client) checkError(resp *http.Response) error {
+	if resp.StatusCode == http.StatusBadRequest {
+		details, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return &InvalidSchematicError{
+			Details: string(details),
+		}
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("request failed, code %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package client implements image factory HTTP API client.
+package client
+
+import "net/http"
+
+// Options defines client options.
+type Options struct {
+	// Client is the http client.
+	Client http.Client
+}
+
+// Option defines a single client option setter.
+type Option func(*Options)
+
+// WithClient overrides default client instance.
+func WithClient(client http.Client) Option {
+	return func(o *Options) {
+		o.Client = client
+	}
+}
+
+func withDefaults(options []Option) *Options {
+	opts := &Options{}
+
+	for _, o := range options {
+		o(opts)
+	}
+
+	return opts
+}


### PR DESCRIPTION
The client provides methods to create schematics, Talos versions, and extensions version.

Fixes: #21 