### PR TITLE
chore: define public const for the schematic ID extension name

### DIFF
--- a/internal/artifacts/schematic.go
+++ b/internal/artifacts/schematic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/extensions"
 	"gopkg.in/yaml.v3"
 
+	"github.com/siderolabs/image-factory/pkg/constants"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -49,7 +50,7 @@ func schematicExtension(schematicID string) (io.Reader, error) {
 	manifest := extensions.Manifest{
 		Version: "v1alpha1",
 		Metadata: extensions.Metadata{
-			Name:        "schematic",
+			Name:        constants.SchematicIDExtensionName,
 			Version:     schematicID,
 			Author:      "Image Factory",
 			Description: "Virtual extension which specifies the schematic of the image built with Image Factory.",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package constants defines image factory public constants.
+package constants
+
+// SchematicIDExtensionName when the image factory generates a Talos image
+// it adds special extension into the image that constains schematic ID information.
+const SchematicIDExtensionName = "schematic"


### PR DESCRIPTION
Make it const to simplify discovery of the Talos machine schematic IDs by third party services.