### PR TITLE
feat: provide configuration for a custom PXE endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The bare metal machine should be configured to boot from the URL provided by thi
 
 ```text
 #!ipxe
-chain --replace --autofree https://image.factory/pxe/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.5.0/metal-${buildarch}
+chain --replace --autofree https://pxe.talos.dev/pxe/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/v1.5.0/metal-${buildarch}
 ```
 
 ### `GET /pxe/:schematic/:version/:path`
@@ -134,8 +134,8 @@ In non-SecureBoot schematic, the following iPXE script is returned:
 
 ```text
 #!ipxe
-kernel https://image.factory/image/:schematic/:version/kernel-<arch> <kernel-cmdline>
-initrd https://image.factory/image/:schematic/:version/initramfs-<arch>.xz
+kernel https://pxe.talos.dev/image/:schematic/:version/kernel-<arch> <kernel-cmdline>
+initrd https://pxe.talos.dev/image/:schematic/:version/initramfs-<arch>.xz
 boot
 ```
 
@@ -143,7 +143,7 @@ For SecureBoot schematic, the following iPXE script is returned:
 
 ```text
 #!ipxe
-kernel https://image.factory/image/:schematic/:version/<platform>-<arch>-secureboot.uki.efi
+kernel https://pxe.talos.dev/image/:schematic/:version/<platform>-<arch>-secureboot.uki.efi
 boot
 ```
 

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -27,6 +27,8 @@ type Options struct { //nolint:govet
 
 	// External URL of the image factory HTTP frontend.
 	ExternalURL string
+	// External URL of the image factory PXE frontend.
+	ExternalPXEURL string
 
 	// Schematic service OCI registry prefix.
 	// It stores schematics for the image factory as blobs under that path.

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -79,6 +79,15 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to parse self URL: %w", err)
 	}
 
+	if opts.ExternalPXEURL != "" {
+		frontendOptions.ExternalPXEURL, err = url.Parse(opts.ExternalPXEURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse self PXE URL: %w", err)
+		}
+	} else {
+		frontendOptions.ExternalPXEURL = frontendOptions.ExternalURL
+	}
+
 	var repoOpts []name.Option
 
 	if opts.InsecureInstallerInternalRepository {

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -26,6 +26,7 @@ func initFlags() cmd.Options {
 	flag.IntVar(&opts.AssetBuildMaxConcurrency, "asset-builder-max-concurrency", cmd.DefaultOptions.AssetBuildMaxConcurrency, "maximum concurrency for asset builder")
 
 	flag.StringVar(&opts.ExternalURL, "external-url", cmd.DefaultOptions.ExternalURL, "factory external endpoint URL")
+	flag.StringVar(&opts.ExternalPXEURL, "external-pxe-url", cmd.DefaultOptions.ExternalPXEURL, "factory external PXE endpoint URL, if not set defaults to --external-url")
 
 	flag.StringVar(&opts.SchematicServiceRepository, "schematic-service-repository", cmd.DefaultOptions.SchematicServiceRepository, "image repository for the schematic service")
 

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -52,7 +52,8 @@ type Frontend struct {
 
 // Options configures the HTTP frontend.
 type Options struct {
-	ExternalURL *url.URL
+	ExternalURL    *url.URL
+	ExternalPXEURL *url.URL
 
 	InstallerInternalRepository name.Repository
 	InstallerExternalRepository name.Repository

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -69,7 +69,7 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 				struct {
 					UKIURL string
 				}{
-					UKIURL: f.options.ExternalURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("%s-%s-secureboot.uki.efi", prof.Platform, prof.Arch)).String(),
+					UKIURL: f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("%s-%s-secureboot.uki.efi", prof.Platform, prof.Arch)).String(),
 				},
 			)
 	}
@@ -100,9 +100,9 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 				Cmdline      string
 				InitramfsURL string
 			}{
-				KernelURL:    f.options.ExternalURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("kernel-%s", prof.Arch)).String(),
+				KernelURL:    f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("kernel-%s", prof.Arch)).String(),
 				Cmdline:      string(cmdline),
-				InitramfsURL: f.options.ExternalURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("initramfs-%s.xz", prof.Arch)).String(),
+				InitramfsURL: f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("initramfs-%s.xz", prof.Arch)).String(),
 			},
 		)
 }

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -165,7 +165,7 @@ func (f *Frontend) handleUISchematics(ctx context.Context, w http.ResponseWriter
 		Schematic:                schematicID,
 		Marshaled:                string(marshaled),
 		ImageBaseURL:             f.options.ExternalURL.JoinPath("image", schematicID, version),
-		PXEBaseURL:               f.options.ExternalURL.JoinPath("pxe", schematicID, version),
+		PXEBaseURL:               f.options.ExternalPXEURL.JoinPath("pxe", schematicID, version),
 		InstallerImage:           fmt.Sprintf("%s/installer/%s:%s", f.options.ExternalURL.Host, schematicID, version),
 		SecureBootInstallerImage: fmt.Sprintf("%s/installer-secureboot/%s:%s", f.options.ExternalURL.Host, schematicID, version),
 		Architectures: []string{


### PR DESCRIPTION
iPXE can't support booting from modern certificate chains issued by Let's Encrypt, so provide an option to use custom (less secure?) endpoint for PXE booting.