### PR TITLE
fix: update Talos version listing

### DIFF
--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -56,3 +56,6 @@ const (
 )
 
 const tmpSuffix = "-tmp"
+
+// ErrNotFoundTag tags the errors when the artifact is not found.
+type ErrNotFoundTag = struct{}

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/julienschmidt/httprouter"
-	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/version"
@@ -60,10 +59,6 @@ func (f *Frontend) handleUIVersions(ctx context.Context, w http.ResponseWriter, 
 	if err != nil {
 		return err
 	}
-
-	versions = xslices.Filter(versions, func(v semver.Version) bool {
-		return len(v.Pre) == 0
-	})
 
 	slices.Reverse(versions)
 

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/siderolabs/gen/xerrors"
+)
+
+// HTTPError is a generic HTTP error wrapper.
+type HTTPError struct {
+	Message string
+	Code    int
+}
+
+// Error implements error interface.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.Code, e.Message)
+}
+
+// IsHTTPErrorCode checks if the error is HTTP error with a specific doe.
+func IsHTTPErrorCode(err error, code int) bool {
+	var expected *HTTPError
+
+	return errors.As(err, &expected) && expected.Code == code
+}
+
+// InvalidSchematicError is parsed from 400 response from the server.
+type InvalidSchematicError struct {
+	e error
+}
+
+// Error implements error interface.
+func (e *InvalidSchematicError) Error() string {
+	return fmt.Sprintf("invalid schematic: %s", e.e)
+}
+
+// IsInvalidSchematicError checks if the error is invalid schematic.
+func IsInvalidSchematicError(err error) bool {
+	return xerrors.TypeIs[*InvalidSchematicError](err)
+}


### PR DESCRIPTION
Now Image Factory filters out pre-release versions for all releases but the last one.

In the UI, now pre-release versions are shown.

Return proper 404 not found when someone requests something for an unsupported version.

Fixes #75 

(the versions before 1.4.0 are not yet enabled in Image Factory, see #20)