### PR TITLE
feat: fetch extensions descriptions from the extensions image

### DIFF
--- a/internal/frontend/http/meta.go
+++ b/internal/frontend/http/meta.go
@@ -53,9 +53,11 @@ func (f *Frontend) handleOfficialExtensions(ctx context.Context, w http.Response
 	return json.NewEncoder(w).Encode(
 		xslices.Map(extensions, func(e artifacts.ExtensionRef) client.ExtensionInfo {
 			return client.ExtensionInfo{
-				Name:   e.TaggedReference.RepositoryStr(),
-				Ref:    e.TaggedReference.String(),
-				Digest: e.Digest,
+				Name:        e.TaggedReference.RepositoryStr(),
+				Ref:         e.TaggedReference.String(),
+				Digest:      e.Digest,
+				Author:      e.Author,
+				Description: e.Description,
 			}
 		}),
 	)

--- a/internal/frontend/http/templates/schematic-config.html
+++ b/internal/frontend/http/templates/schematic-config.html
@@ -14,6 +14,9 @@
         >
         <label
             for="{{ .TaggedReference.RepositoryStr }}"
+            {{ if .Author }}
+            title="{{ .Description }}Author {{ .Author }}"
+            {{ end }}
             class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300"
         >
             {{ .TaggedReference.RepositoryStr }} <span class="text-xs">({{ .TaggedReference.TagStr }})</span>

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,9 +19,11 @@ import (
 
 // ExtensionInfo defines extensions versions list response item.
 type ExtensionInfo struct {
-	Name   string `json:"name"`
-	Ref    string `json:"ref"`
-	Digest string `json:"digest"`
+	Name        string `json:"name"`
+	Ref         string `json:"ref"`
+	Digest      string `json:"digest"`
+	Author      string `json:"author"`
+	Description string `json:"description"`
 }
 
 // Client is the Image Factory HTTP API client.


### PR DESCRIPTION
Get `descriptions.yaml` from the same image as we use for getting `image-digests`.
Read it and add this data to each extension info.
Return that in the `version/:version/extensions/official` API response.