### PR TITLE
fix: sort extensions in the UI schematic generator

### DIFF
--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -141,6 +141,8 @@ func (f *Frontend) handleUISchematics(ctx context.Context, w http.ResponseWriter
 		extensions = append(extensions, name[4:])
 	}
 
+	slices.Sort(extensions)
+
 	overlayData := r.PostForm.Get("overlay")
 
 	overlayName, overlayImage, _ := strings.Cut(overlayData, "@")


### PR DESCRIPTION
In the UI, sort extensions alphabetically, so it doesn't matter which order you click the checkboxes.

Fixes #99