### PR TITLE
feat(images): allow key-based image verification as option

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -19,9 +19,11 @@ type Options struct { //nolint:govet
 	InsecureImageRegistry bool
 
 	// Options to verify container signatures for imager, extensions, etc.
-	ContainerSignatureSubjectRegExp string
-	ContainerSignatureIssuerRegExp  string
-	ContainerSignatureIssuer        string
+	ContainerSignatureSubjectRegExp     string
+	ContainerSignatureIssuerRegExp      string
+	ContainerSignatureIssuer            string
+	ContainerSignaturePublicKeyFile     string
+	ContainerSignaturePublicKeyHashAlgo string
 
 	// Maximum number of concurrent asset builds.
 	AssetBuildMaxConcurrency int
@@ -90,9 +92,10 @@ var DefaultOptions = Options{
 	MinTalosVersion: "1.2.0",
 	ImageRegistry:   "ghcr.io",
 
-	ContainerSignatureSubjectRegExp: `@siderolabs\.com$`,
-	ContainerSignatureIssuerRegExp:  "",
-	ContainerSignatureIssuer:        "https://accounts.google.com",
+	ContainerSignatureSubjectRegExp:     `@siderolabs\.com$`,
+	ContainerSignatureIssuerRegExp:      "",
+	ContainerSignatureIssuer:            "https://accounts.google.com",
+	ContainerSignaturePublicKeyHashAlgo: "sha256",
 
 	AssetBuildMaxConcurrency: 6,
 

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -23,6 +23,8 @@ func initFlags() cmd.Options {
 	flag.StringVar(&opts.ContainerSignatureSubjectRegExp, "container-signature-subject-regexp", cmd.DefaultOptions.ContainerSignatureSubjectRegExp, "container signature subject regexp")
 	flag.StringVar(&opts.ContainerSignatureIssuerRegExp, "container-signature-issuer-regexp", cmd.DefaultOptions.ContainerSignatureIssuerRegExp, "container signature issuer regexp")
 	flag.StringVar(&opts.ContainerSignatureIssuer, "container-signature-issuer", cmd.DefaultOptions.ContainerSignatureIssuer, "container signature issuer")
+	flag.StringVar(&opts.ContainerSignaturePublicKeyFile, "container-signature-pubkey", cmd.DefaultOptions.ContainerSignaturePublicKeyFile, "container signature public key (optional)")
+	flag.StringVar(&opts.ContainerSignaturePublicKeyHashAlgo, "container-signature-pubkey-hashalgo", cmd.DefaultOptions.ContainerSignaturePublicKeyHashAlgo, "hash algo of the container signature public key (optional)") //nolint:lll
 
 	flag.IntVar(&opts.AssetBuildMaxConcurrency, "asset-builder-max-concurrency", cmd.DefaultOptions.AssetBuildMaxConcurrency, "maximum concurrency for asset builder")
 

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -24,7 +24,7 @@ type Options struct { //nolint:govet
 	// MinVersion is the minimum version of Talos to use.
 	MinVersion semver.Version
 	// ImageVerifyOptions are the options for verifying the image signature.
-	ImageVerifyOptions cosign.CheckOpts
+	ImageVerifyOptions []cosign.CheckOpts
 	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.
 	TalosVersionRecheckInterval time.Duration
 	// RemoteOptions is the list of remote options for the puller.


### PR DESCRIPTION
This PR enables the image-factory to optionally verify images using a supplied public key. If both OIDC and public key are configured both options will be tried when verifying an image.