### PR TITLE
fix: misreported error

### DIFF
--- a/internal/artifacts/manager.go
+++ b/internal/artifacts/manager.go
@@ -137,7 +137,7 @@ func (m *Manager) Get(ctx context.Context, versionString string, arch Arch, kind
 		select {
 		case result := <-resultCh:
 			if result.Err != nil {
-				return "", err
+				return "", result.Err
 			}
 		case <-ctx.Done():
 			return "", ctx.Err()


### PR DESCRIPTION
It should report the actual error from the task, not the `err`.