### PR TITLE
feat: allow a user to skip the Talos version filter

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -13,6 +13,8 @@ type Options struct { //nolint:govet
 
 	// Asset builder options: minimum supported Talos version.
 	MinTalosVersion string
+	// Whether to skip beta/alpha versions and such when obtaining valid Talos versions
+	SkipVersionFilter bool
 	// Image registry for source images: imager, extensions, etc..
 	ImageRegistry string
 	// Allow insecure connection to the image registry
@@ -89,8 +91,9 @@ type SecureBootOptions struct { //nolint:govet
 var DefaultOptions = Options{
 	HTTPListenAddr: ":8080",
 
-	MinTalosVersion: "1.2.0",
-	ImageRegistry:   "ghcr.io",
+	MinTalosVersion:   "1.2.0",
+	SkipVersionFilter: false,
+	ImageRegistry:     "ghcr.io",
 
 	ContainerSignatureSubjectRegExp:     `@siderolabs\.com$`,
 	ContainerSignatureIssuerRegExp:      "",

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -245,6 +245,7 @@ func buildArtifactsManager(ctx context.Context, logger *zap.Logger, opts Options
 
 	artifactsManager, err := artifacts.NewManager(logger, artifacts.Options{
 		MinVersion:                  minVersion,
+		SkipVersionFilter:           opts.SkipVersionFilter,
 		ImageRegistry:               opts.ImageRegistry,
 		InsecureImageRegistry:       opts.InsecureImageRegistry,
 		ImageVerifyOptions:          checkOpts,

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -17,6 +17,7 @@ func initFlags() cmd.Options {
 	flag.StringVar(&opts.HTTPListenAddr, "http-port", cmd.DefaultOptions.HTTPListenAddr, "HTTP listen address")
 
 	flag.StringVar(&opts.MinTalosVersion, "min-talos-version", cmd.DefaultOptions.MinTalosVersion, "minimum Talos version")
+	flag.BoolVar(&opts.SkipVersionFilter, "skip-version-filter", cmd.DefaultOptions.SkipVersionFilter, "whether to skip the version filter when obtaining valid Talos versions")
 	flag.StringVar(&opts.ImageRegistry, "image-registry", cmd.DefaultOptions.ImageRegistry, "image registry for imager, extensions, etc.")
 	flag.BoolVar(&opts.InsecureImageRegistry, "insecure-image-registry", cmd.DefaultOptions.InsecureImageRegistry, "allow an insecure connection to the image registry")
 

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -23,6 +23,8 @@ type Options struct { //nolint:govet
 	InsecureImageRegistry bool
 	// MinVersion is the minimum version of Talos to use.
 	MinVersion semver.Version
+	// SkipVersionFilter indicated whether obtained Talos versions should be filtered
+	SkipVersionFilter bool
 	// ImageVerifyOptions are the options for verifying the image signature.
 	ImageVerifyOptions []cosign.CheckOpts
 	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.

--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -50,7 +50,12 @@ func (m *Manager) fetchTalosVersions() (any, error) {
 	maxVersion := slices.MaxFunc(versions, semver.Version.Compare)
 
 	// allow non-prerelease versions, and allow pre-release for the "latest" release (maxVersion)
+	// skip this filter completely if the respective flag is set
 	versions = xslices.Filter(versions, func(version semver.Version) bool {
+		if m.options.SkipVersionFilter {
+			return true
+		}
+
 		if version.LT(m.options.MinVersion) {
 			return false // ignore versions below minimum
 		}


### PR DESCRIPTION
This commit introduces a new flag '-skip-version-filter' which skips the filtering of available versions in the artifactManager.