### PR TITLE
chore: alias nvidia extensions to lts versions

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -276,6 +276,14 @@ func extensionNameAlias(extensionName string) (string, bool) {
 		return "siderolabs/vmtoolsd-guest-agent", true
 	case "siderolabs/xe-guest-utilities": // extension got renamed
 		return "siderolabs/xen-guest-agent", true
+	case "siderolabs/nvidia-container-toolkit": // extension got renamed
+		return "siderolabs/nvidia-container-toolkit-lts", true
+	case "siderolabs/nvidia-open-gpu-kernel-modules": // extension got renamed
+		return "siderolabs/nvidia-open-gpu-kernel-modules-lts", true
+	case "siderolabs/nonfree-kmod-nvidia": // extension got renamed
+		return "siderolabs/nonfree-kmod-nvidia-lts", true
+	case "siderolabs/nvidia-fabricmanager": // extension got renamed
+		return "siderolabs/nvidia-fabric-manager-lts", true
 	default:
 		return "", false
 	}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -310,6 +310,22 @@ func (mockArtifactProducer) GetOfficialExtensions(context.Context, string) ([]ar
 			TaggedReference: ensure.Value(name.NewTag("ghcr.io/siderolabs/gasket-driver:20240101")),
 			Digest:          "sha256:abcdef123456",
 		},
+		{
+			TaggedReference: ensure.Value(name.NewTag("ghcr.io/siderolabs/nvidia-container-toolkit-lts:v535.0.0-v1.15.0")),
+			Digest:          "sha256:nvidia-toolkit",
+		},
+		{
+			TaggedReference: ensure.Value(name.NewTag("ghcr.io/siderolabs/nvidia-open-gpu-kernel-modules-lts:v535.0.0")),
+			Digest:          "sha256:nvidia-open",
+		},
+		{
+			TaggedReference: ensure.Value(name.NewTag("ghcr.io/siderolabs/nonfree-kmod-nvidia-lts:v535.0.0")),
+			Digest:          "sha256:nvidia-nonfree",
+		},
+		{
+			TaggedReference: ensure.Value(name.NewTag("ghcr.io/siderolabs/nvidia-fabricmanager:v535.0.0")),
+			Digest:          "sha256:nvidia-fabric",
+		},
 	}, nil
 }
 
@@ -469,6 +485,58 @@ func TestEnhanceFromSchematic(t *testing.T) {
 						},
 						{
 							TarballPath: "9f14d3d939d420f57d8ee3e64c4c2cd29ecb6fa10da4e1c8ac99da4b04d5e463.tar",
+						},
+					},
+				},
+				Output: profile.Output{
+					Kind:      profile.OutKindImage,
+					OutFormat: profile.OutFormatZSTD,
+					ImageOptions: &profile.ImageOptions{
+						DiskSize:   profile.MinRAWDiskSize,
+						DiskFormat: profile.DiskFormatRaw,
+					},
+				},
+			},
+		},
+		{
+			name:        "aliased nvidia extensions",
+			baseProfile: baseProfile,
+			schematic: schematic.Schematic{
+				Customization: schematic.Customization{
+					SystemExtensions: schematic.SystemExtensions{
+						OfficialExtensions: []string{
+							"siderolabs/nvidia-container-toolkit",
+							"siderolabs/nvidia-open-gpu-kernel-modules",
+							"siderolabs/nonfree-kmod-nvidia",
+							"siderolabs/nvidia-fabricmanager",
+						},
+					},
+				},
+			},
+			versionString: "v1.7.0",
+
+			expectedProfile: profile.Profile{
+				Platform:      constants.PlatformMetal,
+				SecureBoot:    pointer.To(false),
+				Arch:          "amd64",
+				Version:       "v1.7.0",
+				Customization: profile.CustomizationProfile{},
+				Input: profile.Input{
+					SystemExtensions: []profile.ContainerAsset{
+						{
+							OCIPath: "amd64-sha256:nvidia-toolkit.oci",
+						},
+						{
+							OCIPath: "amd64-sha256:nvidia-open.oci",
+						},
+						{
+							OCIPath: "amd64-sha256:nvidia-nonfree.oci",
+						},
+						{
+							OCIPath: "amd64-sha256:nvidia-fabric.oci",
+						},
+						{
+							TarballPath: "2335edfd1451ebc3e268956e4b12f2afc5a0799a082e8ffdbbd5dc55af123a27.tar",
 						},
 					},
 				},


### PR DESCRIPTION
Alias old nvidia extensions schema to LTS versions so upgrades work and users are not surprised with a new major version.

Part of: https://github.com/siderolabs/talos/issues/9086