### PR TITLE
[WIP] add support for returning just the schematic id without json

### DIFF
--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -36,6 +36,13 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
+	if (r.Header.Get("Accept") == "text/plain") {
+		w.Header().Add("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusCreated)
+		
+		return 	io.WriteString(w, id)
+	}
+	
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 


### PR DESCRIPTION
Client can request to skip the json encoding by requesting `text/plain` in `Accept` header.

This is a non-working PoC written in browser. If you like the direction, I can add tests/clean-up etc and submit a proper PR.