### PR TITLE
feat: hide Talos metal agent extension on the UI

### DIFF
--- a/internal/integration/download_test.go
+++ b/internal/integration/download_test.go
@@ -172,7 +172,7 @@ func testDownloadFrontend(ctx context.Context, t *testing.T, baseURL string) {
 	const MiB = 1024 * 1024
 
 	talosVersions := []string{
-		"v1.8.0-alpha.2",
+		"v1.8.2",
 		"v1.5.1",
 	}
 


### PR DESCRIPTION
It is an internal extension, so we don't want to list it on the UI.