### PR TITLE
feat: add Turing RK1 as option

### DIFF
--- a/pkg/metadata/sbcs.go
+++ b/pkg/metadata/sbcs.go
@@ -181,5 +181,16 @@ func SBCs() []SBC {
 
 			MinVersion: semver.MustParse("1.8.0-alpha.2"),
 		},
+		{
+			Name: "turingrk1",
+
+			OverlayName:  "turingrk1",
+			OverlayImage: "siderolabs/sbc-rockchip",
+
+			Label:         "Turing RK1",
+			Documentation: "/talos-guides/install/single-board-computers/turing_rk1/",
+
+			MinVersion: semver.MustParse("1.9.0-beta.0"),
+		},
 	}
 }


### PR DESCRIPTION
Adds the SBC Turing RK1 as an option to the factory.talos.dev interactive web interface.