### PR TITLE
feat: Set Secure Boot support in metadata for nocloud platform

### DIFF
--- a/pkg/metadata/platforms.go
+++ b/pkg/metadata/platforms.go
@@ -194,6 +194,7 @@ func Platforms() []Platform {
 				"iso",
 				"pxe",
 			},
+			SecureBootSupported: true,
 		},
 		// OpenNebula: no documentation on Talos side, skipping.
 		{


### PR DESCRIPTION
Per https://github.com/siderolabs/terraform-provider-talos/issues/222, set SecureBootSupported flag for nocloud images. Images are available and confirmed to work with Secure Boot on Proxmox, setting this here so the Terraform provider can decern that Secure Boot images are available.