### PR TITLE
feat: add Radxa ROCK 5B as option

### DIFF
--- a/pkg/metadata/sbcs.go
+++ b/pkg/metadata/sbcs.go
@@ -149,6 +149,17 @@ func SBCs() []SBC {
 			MinVersion: semver.MustParse("1.8.0-alpha.1"),
 		},
 		{
+			Name: "rock5b",
+
+			OverlayName:  "rock5b",
+			OverlayImage: "siderolabs/sbc-rockchip",
+
+			Label:         "Radxa ROCK 5B",
+			Documentation: "/talos-guides/install/single-board-computers/rock5b/",
+
+			MinVersion: semver.MustParse("1.9.2"),
+		},
+		{
 			Name: "rockpi_4",
 
 			BoardName: "rockpi_4",


### PR DESCRIPTION
This adds the Radxa ROCK 5B SBC as an option.

SBC support was merged here: https://github.com/siderolabs/sbc-rockchip/pull/45
Documentation PR: https://github.com/siderolabs/talos/pull/10139