### PR TITLE
add imgfree to standard.ipxe boot script

### DIFF
--- a/internal/frontend/http/secureboot.ipxe
+++ b/internal/frontend/http/secureboot.ipxe
@@ -1,4 +1,5 @@
 #!ipxe
 
+imgfree
 kernel {{ .UKIURL }} {{ .Cmdline }}
 boot

--- a/internal/frontend/http/standard.ipxe
+++ b/internal/frontend/http/standard.ipxe
@@ -1,5 +1,6 @@
 #!ipxe
 
+imgfree
 kernel {{ .KernelURL }} {{ .Cmdline }}
 initrd {{ .InitramfsURL }}
 boot

--- a/internal/integration/pxe_test.go
+++ b/internal/integration/pxe_test.go
@@ -43,9 +43,9 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL string) {
 	}
 
 	const (
-		metalInsecureExpected   = "#!ipxe\n\nkernel ENDPOINT/image/CONFIG/VERSION/kernel-amd64 talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512\ninitrd ENDPOINT/image/CONFIG/VERSION/initramfs-amd64.xz\nboot\n"    //nolint:lll
-		equinixInsecureExpected = "#!ipxe\n\nkernel ENDPOINT/image/CONFIG/VERSION/kernel-amd64 talos.platform=equinixMetal console=ttyS1,115200n8 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512\ninitrd ENDPOINT/image/CONFIG/VERSION/initramfs-amd64.xz\nboot\n" //nolint:lll
-		securebootExpected      = "#!ipxe\n\nkernel ENDPOINT/image/CONFIG/VERSION/metal-amd64-secureboot-uki.efi talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality\nboot\n"
+		metalInsecureExpected   = "#!ipxe\n\nimgfree\nkernel ENDPOINT/image/CONFIG/VERSION/kernel-amd64 talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512\ninitrd ENDPOINT/image/CONFIG/VERSION/initramfs-amd64.xz\nboot\n"    //nolint:lll
+		equinixInsecureExpected = "#!ipxe\n\nimgfree\nkernel ENDPOINT/image/CONFIG/VERSION/kernel-amd64 talos.platform=equinixMetal console=ttyS1,115200n8 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512\ninitrd ENDPOINT/image/CONFIG/VERSION/initramfs-amd64.xz\nboot\n" //nolint:lll
+		securebootExpected      = "#!ipxe\n\nimgfree\nkernel ENDPOINT/image/CONFIG/VERSION/metal-amd64-secureboot-uki.efi talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality\nboot\n"
 	)
 
 	for _, talosVersion := range talosVersions {


### PR DESCRIPTION
fix for `Initramfs unpacking failed: invalid magic at start of compressed`

While using image generated from the image factory I was getting `Initramfs unpacking failed: invalid magic at start of compressed` when booting. https://github.com/ipxe/ipxe/discussions/1329. I tried the suggestion adding `imgfree` before kernel command and was able to boot into talos.