### PR TITLE
fix: specify each language natively

### DIFF
--- a/internal/frontend/http/locales/active.en.yaml
+++ b/internal/frontend/http/locales/active.en.yaml
@@ -5,7 +5,7 @@
   translation: English
 
 - id: lang.ru
-  translation: Russian
+  translation: Русский
 
 - id: app.name
   translation: "Image Factory"

--- a/internal/frontend/http/locales/active.ru.yaml
+++ b/internal/frontend/http/locales/active.ru.yaml
@@ -2,7 +2,7 @@
   translation: Язык
 
 - id: lang.en
-  translation: Английский
+  translation: English
 
 - id: lang.ru
   translation: Русский
@@ -276,4 +276,3 @@
 
 - id: final.board_image
   translation: "Дисковый образ"
-


### PR DESCRIPTION
In each translation, use native language name, so that if someone accidentally switches to the language they don't understand, they know a way to switch back.