### PR TITLE
fix(ci): image factory cron

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-17T10:39:42Z by kres fd5cab0.
+# Generated on 2025-05-21T08:07:26Z by kres 9f64b0d.
 
 version: "2"
 
@@ -48,6 +48,7 @@ linters:
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - musttag # seems to be broken - goes into imported libraries and reports issues there
+    - nolintlint # gives false positives - disable until https://github.com/golangci/golangci-lint/issues/3228 is resolved
   # all available settings of specific linters
   settings:
     cyclop:
@@ -89,11 +90,6 @@ linters:
       simple: true
       range-loops: true # Report preallocation suggestions on range loops, true by default
       for-loops: false # Report preallocation suggestions on for loops, false by default
-    nolintlint:
-      allow-unused: false
-      allow-no-explanation: [ ]
-      require-explanation: false
-      require-specific: true
     rowserrcheck: { }
     testpackage: { }
     unparam:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -334,7 +334,7 @@ spec:
     enabled: true
     phony: true
     script:
-      - "@$(MAKE) local-copy-out-go-mod DEST=."
+      - "@$(MAKE) local-copy-out-go-mod DEST=. TARGET_ARGS=\"--no-cache-filter=update-to-talos-main\""
 ---
 kind: custom.Step
 name: integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-30T10:18:31Z by kres fd5cab0-dirty.
+# Generated on 2025-05-21T08:07:26Z by kres 9f64b0d.
 
 ARG TOOLCHAIN
 ARG PKGS_PREFIX
 ARG PKGS
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.2.11-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.2.13-alpine AS lint-markdown
 WORKDIR /src
-RUN bun i markdownlint-cli@0.44.0 sentences-per-line@0.3.0
+RUN bun i markdownlint-cli@0.45.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .
 COPY ./CHANGELOG.md ./CHANGELOG.md
 COPY ./README.md ./README.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-30T14:48:55Z by kres 6cbcbd1.
+# Generated on 2025-05-21T08:07:26Z by kres 9f64b0d.
 
 # common variables
 
@@ -21,12 +21,12 @@ PROTOBUF_GO_VERSION ?= 1.36.6
 GRPC_GO_VERSION ?= 1.5.1
 GRPC_GATEWAY_VERSION ?= 2.26.3
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.32.0
+GOIMPORTS_VERSION ?= 0.33.0
 GOMOCK_VERSION ?= 0.5.2
 DEEPCOPY_VERSION ?= v0.5.6
-GOLANGCILINT_VERSION ?= v2.1.5
+GOLANGCILINT_VERSION ?= v2.1.6
 GOFUMPT_VERSION ?= v0.8.0
-GO_VERSION ?= 1.24.2
+GO_VERSION ?= 1.24.3
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -250,7 +250,7 @@ integration: integration.test
 
 .PHONY: update-to-talos-main
 update-to-talos-main:
-	@$(MAKE) local-copy-out-go-mod DEST=.
+	@$(MAKE) local-copy-out-go-mod DEST=. TARGET_ARGS="--no-cache-filter=update-to-talos-main"
 
 .PHONY: integration-talos-main
 integration-talos-main: update-to-talos-main


### PR DESCRIPTION
The cron job that updates to Talos main used a docker step that got cached, fix by always re-running `go get -u` commands.