### PR TITLE
fix: refresh remote pullers and pushers on interval

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-30T10:10:43Z by kres fd5cab0-dirty.
+# Generated on 2025-06-05T06:08:49Z by kres fc6afbe.
 
 name: default
 concurrency:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -118,7 +118,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           REGISTRY: registry.dev.siderolabs.io
-          TEST_FLAGS: -test.schematic-service-repository=registry.dev.siderolabs.io/image-factory/schematic -test.installer-external-repository=registry.dev.siderolabs.io/siderolabs -test.installer-internal-repository=registry.dev.siderolabs.io/siderolabs -test.cache-repository=registry.dev.siderolabs.io/image-factory/cache
+          TEST_FLAGS: -test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-external-repository=127.0.0.1:5100/siderolabs -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache
         run: |
           make integration
       - name: Retrieve PR labels
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/.github/workflows/integration-talos-main-cron.yaml
+++ b/.github/workflows/integration-talos-main-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-29T15:56:17Z by kres fd5cab0.
+# Generated on 2025-06-03T16:05:20Z by kres fc6afbe.
 
 name: integration-talos-main-cron
 concurrency:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.0
+        uses: kenchan0130/actions-system-info@v1.3.1
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -358,13 +358,14 @@ spec:
     script:
       - "@$(MAKE) image-image-factory PUSH=true"
       - docker pull $(REGISTRY)/$(USERNAME)/image-factory:$(TAG)
+      - docker run -d -p 5100:5000 --name=local registry:3
       - docker run --rm --net=host --privileged -v /dev:/dev -v $(PWD)/$(ARTIFACTS)/integration.test:/bin/integration.test:ro --entrypoint /bin/integration.test $(REGISTRY)/$(USERNAME)/image-factory:$(TAG) -test.v $(TEST_FLAGS) -test.run $(RUN_TESTS)
   ghaction:
     enabled: true
     condition: on-pull-request
     environment:
       REGISTRY: registry.dev.siderolabs.io
-      TEST_FLAGS: "-test.schematic-service-repository=registry.dev.siderolabs.io/image-factory/schematic -test.installer-external-repository=registry.dev.siderolabs.io/siderolabs -test.installer-internal-repository=registry.dev.siderolabs.io/siderolabs -test.cache-repository=registry.dev.siderolabs.io/image-factory/cache"
+      TEST_FLAGS: "-test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-external-repository=127.0.0.1:5100/siderolabs -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache"
 ---
 kind: custom.Step
 name: integration-talos-main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-# syntax = docker/dockerfile-upstream:1.15.1-labs
+# syntax = docker/dockerfile-upstream:1.16.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-21T13:20:38Z by kres 9f64b0d.
+# Generated on 2025-06-03T16:05:20Z by kres fc6afbe.
 
 ARG TOOLCHAIN
 ARG PKGS_PREFIX
 ARG PKGS
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.2.13-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.2.15-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.45.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-21T13:20:38Z by kres 9f64b0d.
+# Generated on 2025-06-05T06:10:04Z by kres fc6afbe.
 
 # common variables
 
@@ -246,6 +246,7 @@ integration.test:
 integration: integration.test
 	@$(MAKE) image-image-factory PUSH=true
 	docker pull $(REGISTRY)/$(USERNAME)/image-factory:$(TAG)
+	docker run -d -p 5100:5000 --name=local registry:3
 	docker run --rm --net=host --privileged -v /dev:/dev -v $(PWD)/$(ARTIFACTS)/integration.test:/bin/integration.test:ro --entrypoint /bin/integration.test $(REGISTRY)/$(USERNAME)/image-factory:$(TAG) -test.v $(TEST_FLAGS) -test.run $(RUN_TESTS)
 
 .PHONY: update-to-talos-main

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -18,6 +18,9 @@ type Options struct { //nolint:govet
 	// Allow insecure connection to the image registry
 	InsecureImageRegistry bool
 
+	// RegistryRefreshInterval is the interval for refreshing the image registry connections.
+	RegistryRefreshInterval time.Duration
+
 	// Options to verify container signatures for imager, extensions, etc.
 	ContainerSignatureSubjectRegExp     string
 	ContainerSignatureIssuerRegExp      string
@@ -91,6 +94,8 @@ var DefaultOptions = Options{
 
 	MinTalosVersion: "1.2.0",
 	ImageRegistry:   "ghcr.io",
+
+	RegistryRefreshInterval: 5 * time.Minute,
 
 	ContainerSignatureSubjectRegExp:     `@siderolabs\.com$`,
 	ContainerSignatureIssuerRegExp:      "",

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-containerregistry v0.20.3
 	github.com/h2non/filetype v1.1.3
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.0
@@ -151,7 +152,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -29,6 +29,8 @@ type Options struct { //nolint:govet
 	TalosVersionRecheckInterval time.Duration
 	// RemoteOptions is the list of remote options for the puller.
 	RemoteOptions []remote.Option
+	// RegistryRefreshInterval is the interval for refreshing the image registry connections.
+	RegistryRefreshInterval time.Duration
 }
 
 // Kind is the artifact kind.

--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	factoryprofile "github.com/siderolabs/image-factory/internal/profile"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
 )
 
 // BootAsset is an interface to access a boot asset.
@@ -53,9 +54,10 @@ type Builder struct {
 
 // Options configures the asset builder.
 type Options struct {
-	CacheRepository name.Repository
-	CacheSigningKey crypto.PrivateKey
-	RemoteOptions   []remote.Option
+	CacheRepository         name.Repository
+	CacheSigningKey         crypto.PrivateKey
+	RemoteOptions           []remote.Option
+	RegistryRefreshInterval time.Duration
 
 	AllowedConcurrency int
 }
@@ -69,12 +71,12 @@ func NewBuilder(logger *zap.Logger, artifactsManager *artifacts.Manager, options
 
 	var err error
 
-	cache.puller, err = remote.NewPuller(options.RemoteOptions...)
+	cache.puller, err = remotewrap.NewPuller(options.RegistryRefreshInterval, options.RemoteOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating puller: %w", err)
 	}
 
-	cache.pusher, err = remote.NewPusher(options.RemoteOptions...)
+	cache.pusher, err = remotewrap.NewPusher(options.RegistryRefreshInterval, options.RemoteOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating pusher: %w", err)
 	}

--- a/internal/asset/cache.go
+++ b/internal/asset/cache.go
@@ -14,18 +14,18 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	"github.com/siderolabs/image-factory/internal/regtransport"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
 )
 
 // registryCache is using OCI registry to cache assets.
 type registryCache struct {
-	puller          *remote.Puller
-	pusher          *remote.Pusher
+	puller          remotewrap.Puller
+	pusher          remotewrap.Pusher
 	imageSigner     *signer.Signer
 	logger          *zap.Logger
 	cacheRepository name.Repository

--- a/internal/image/signer/signer.go
+++ b/internal/image/signer/signer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci/empty"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
@@ -20,6 +19,8 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+
+	"github.com/siderolabs/image-factory/internal/remotewrap"
 )
 
 // Signer holds a key used to sign the images.
@@ -75,7 +76,7 @@ func (s *Signer) GetPublicKeyPEM() []byte {
 }
 
 // SignImage signs the image in the OCI repository.
-func (s *Signer) SignImage(ctx context.Context, imageRef name.Digest, pusher *remote.Pusher) error {
+func (s *Signer) SignImage(ctx context.Context, imageRef name.Digest, pusher remotewrap.Pusher) error {
 	payload, signature, err := signature.SignImage(s.sv, imageRef, nil)
 	if err != nil {
 		return fmt.Errorf("error generating signature: %w", err)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
 )
 
 func setupFactory(t *testing.T) (context.Context, string) {
@@ -41,9 +42,12 @@ func setupFactory(t *testing.T) (context.Context, string) {
 	options.InstallerExternalRepository = installerExternalRepository
 	options.InstallerInternalRepository = installerInternalRepository
 	options.CacheRepository = cacheRepository
+	options.RegistryRefreshInterval = time.Minute // use a short interval for the tests
 
 	setupSecureBoot(t, &options)
 	setupCacheSigningKey(t, &options)
+
+	t.Cleanup(remotewrap.ShutdownTransport)
 
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/internal/remotewrap/internal/refresher/refresher.go
+++ b/internal/remotewrap/internal/refresher/refresher.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package refresher implements a simple refresh on interval mechanism.
+package refresher
+
+import (
+	"sync"
+	"time"
+)
+
+// Refresher is a generic type that holds an instance of type T and refreshes it
+// at a specified interval using the provided refresh function.
+//
+// It acts a bit like sync.Once, but allows for periodic refreshes of the instance.
+type Refresher[T any] struct { //nolint:govet
+	mu       sync.Mutex
+	instance T
+	err      error
+
+	refreshFunc     func() (T, error)
+	lastRefresh     time.Time
+	refreshInterval time.Duration
+}
+
+// New creates a new Refresher instance with the given refresh function and interval.
+func New[T any](refreshFunc func() (T, error), refreshInterval time.Duration) *Refresher[T] {
+	if refreshInterval <= 0 {
+		panic("refresh interval must be greater than zero")
+	}
+
+	return &Refresher[T]{
+		refreshFunc:     refreshFunc,
+		refreshInterval: refreshInterval,
+	}
+}
+
+// Get returns the current instance of type T, refreshing it if the
+// refresh interval has passed since the last refresh.
+//
+// If the refresh function returns an error, it will be stored and returned
+// on subsequent calls until the next successful refresh.
+func (r *Refresher[T]) Get() (T, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if time.Since(r.lastRefresh) < r.refreshInterval {
+		return r.instance, r.err
+	}
+
+	r.instance, r.err = r.refreshFunc()
+	r.lastRefresh = time.Now()
+
+	return r.instance, r.err
+}

--- a/internal/remotewrap/internal/refresher/refresher_test.go
+++ b/internal/remotewrap/internal/refresher/refresher_test.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package refresher_test
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/image-factory/internal/remotewrap/internal/refresher"
+)
+
+func TestRefresher(t *testing.T) {
+	t.Parallel()
+
+	var counter int32
+
+	r := refresher.New(func() (int32, error) {
+		counter++
+
+		if counter > 2 {
+			return 0, errors.New("too big")
+		}
+
+		return counter, nil
+	}, time.Second)
+
+	v, err := r.Get()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), v)
+
+	v, err = r.Get()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), v)
+
+	time.Sleep(time.Second + time.Millisecond)
+
+	v, err = r.Get()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), v)
+
+	var eg errgroup.Group
+
+	for range 10 {
+		eg.Go(func() error {
+			vv, verr := r.Get()
+			if verr != nil {
+				return verr
+			}
+
+			if vv != 2 {
+				return errors.New("expected 2, got " + strconv.Itoa(int(vv)))
+			}
+
+			return nil
+		})
+	}
+
+	require.NoError(t, eg.Wait())
+
+	time.Sleep(time.Second + time.Millisecond)
+
+	_, err = r.Get()
+	require.Error(t, err)
+	require.EqualError(t, err, "too big")
+}

--- a/internal/remotewrap/remotewrap.go
+++ b/internal/remotewrap/remotewrap.go
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package remotewrap implements a wrapper around go-containerregistry's remote package.
+package remotewrap
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/hashicorp/go-cleanhttp"
+
+	"github.com/siderolabs/image-factory/internal/remotewrap/internal/refresher"
+)
+
+var transport = sync.OnceValue(func() *http.Transport {
+	t := cleanhttp.DefaultPooledTransport()
+	t.MaxIdleConnsPerHost = t.MaxIdleConns / 2 // use half of the default max idle connections per host
+
+	return t
+})
+
+// ShutdownTransport shuts down the transport used by the remote package.
+func ShutdownTransport() {
+	transport().CloseIdleConnections()
+}
+
+// Pusher is an interface which is implemented by go-containerregistry's *remote.Pusher.
+type Pusher interface {
+	Push(ctx context.Context, ref name.Reference, t remote.Taggable) error
+}
+
+type pusherWrapper struct {
+	refresher *refresher.Refresher[*remote.Pusher]
+}
+
+func (p *pusherWrapper) Push(ctx context.Context, ref name.Reference, t remote.Taggable) error {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return err
+	}
+
+	return instance.Push(ctx, ref, t)
+}
+
+// NewPusher creates a new Pusher with the given options.
+func NewPusher(refreshInterval time.Duration, opts ...remote.Option) (Pusher, error) {
+	return &pusherWrapper{
+		refresher: refresher.New(
+			func() (*remote.Pusher, error) {
+				return remote.NewPusher(slices.Concat(opts, []remote.Option{remote.WithTransport(transport())})...)
+			},
+			refreshInterval,
+		),
+	}, nil
+}
+
+// Puller is an interface which is implemented by go-containerregistry's *remote.Puller.
+type Puller interface {
+	Head(ctx context.Context, ref name.Reference) (*v1.Descriptor, error)
+	Get(ctx context.Context, ref name.Reference) (*remote.Descriptor, error)
+	List(ctx context.Context, repo name.Repository) ([]string, error)
+	Layer(ctx context.Context, ref name.Digest) (v1.Layer, error)
+}
+
+type pullerWrapper struct {
+	refresher *refresher.Refresher[*remote.Puller]
+}
+
+func (p *pullerWrapper) Head(ctx context.Context, ref name.Reference) (*v1.Descriptor, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.Head(ctx, ref)
+}
+
+func (p *pullerWrapper) Get(ctx context.Context, ref name.Reference) (*remote.Descriptor, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.Get(ctx, ref)
+}
+
+func (p *pullerWrapper) List(ctx context.Context, repo name.Repository) ([]string, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.List(ctx, repo)
+}
+
+func (p *pullerWrapper) Layer(ctx context.Context, ref name.Digest) (v1.Layer, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return instance.Layer(ctx, ref)
+}
+
+// NewPuller creates a new Puller with the given options.
+func NewPuller(refreshInterval time.Duration, opts ...remote.Option) (Puller, error) {
+	return &pullerWrapper{
+		refresher: refresher.New(
+			func() (*remote.Puller, error) {
+				return remote.NewPuller(slices.Concat(opts, []remote.Option{remote.WithTransport(transport())})...)
+			},
+			refreshInterval,
+		),
+	}, nil
+}


### PR DESCRIPTION
This is not a fix, but a bit of a workaround for issues in the upstream library.

Use a refresh on interval strategy to ensure that both remote pushers and pullers are refreshed.

Fixes #231

Fixes #235