### PR TITLE
fix: default options on startup

### DIFF
--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -12,13 +12,15 @@ import (
 )
 
 func initFlags() cmd.Options {
-	var opts cmd.Options
+	opts := cmd.DefaultOptions
 
 	flag.StringVar(&opts.HTTPListenAddr, "http-port", cmd.DefaultOptions.HTTPListenAddr, "HTTP listen address")
 
 	flag.StringVar(&opts.MinTalosVersion, "min-talos-version", cmd.DefaultOptions.MinTalosVersion, "minimum Talos version")
 	flag.StringVar(&opts.ImageRegistry, "image-registry", cmd.DefaultOptions.ImageRegistry, "image registry for imager, extensions, etc.")
 	flag.BoolVar(&opts.InsecureImageRegistry, "insecure-image-registry", cmd.DefaultOptions.InsecureImageRegistry, "allow an insecure connection to the image registry")
+
+	flag.DurationVar(&opts.RegistryRefreshInterval, "registry-refresh-interval", cmd.DefaultOptions.RegistryRefreshInterval, "image registry refresh interval")
 
 	flag.StringVar(&opts.ContainerSignatureSubjectRegExp, "container-signature-subject-regexp", cmd.DefaultOptions.ContainerSignatureSubjectRegExp, "container signature subject regexp")
 	flag.StringVar(&opts.ContainerSignatureIssuerRegExp, "container-signature-issuer-regexp", cmd.DefaultOptions.ContainerSignatureIssuerRegExp, "container signature issuer regexp")


### PR DESCRIPTION
Fixes #244

The problem was that the default value was unused unless passed explicitly via the flag.

Fix by exposing the registry refresh interval, but also ensure that options defaults are set even if they don't have a flag.