### PR TITLE
fix: hide kernel args warning for Talos >= 1.10

### DIFF
--- a/internal/frontend/http/templates/wizard-cmdline.html
+++ b/internal/frontend/http/templates/wizard-cmdline.html
@@ -22,7 +22,7 @@
         </p>
         {{ if eq .SecureBoot "true" }}
         <p>{{ t .Localizer "customization.cmdline.secure_boot" }}</p>
-        {{ else }}
+        {{ else if version_less .Version "v1.10.0" }}
         <p>
             {{ t .Localizer "customization.cmdline.note" }}<code>installer</code>{{ t .Localizer "customization.cmdline.upgrade" }}<code>machine.install.extraKernelArgs</code>{{ t .Localizer "customization.cmdline.configuration" }}
         </p>

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -73,6 +73,19 @@ func init() {
 
 			return template.HTML(out.String()), nil
 		},
+		"version_less": func(a, b string) (bool, error) {
+			av, err := semver.ParseTolerant(a)
+			if err != nil {
+				return false, fmt.Errorf("error parsing version %q: %w", a, err)
+			}
+
+			bv, err := semver.ParseTolerant(b)
+			if err != nil {
+				return false, fmt.Errorf("error parsing version %q: %w", b, err)
+			}
+
+			return av.LT(bv), nil
+		},
 		"t": func(localizer *i18n.Localizer, key string) string {
 			translated, err := localizer.Localize(&i18n.LocalizeConfig{MessageID: key})
 			if err != nil {


### PR DESCRIPTION
Now with UKIs kernel args can be and should be customized via the schematic/Image Factory.

Fixes #255