### PR TITLE
fix: don't filter out `rc` versions

### DIFF
--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -64,8 +64,11 @@ func (m *Manager) fetchTalosVersions() (any, error) {
 				return false
 			}
 
-			if version.Pre[0].VersionStr != "alpha" && version.Pre[0].VersionStr != "beta" {
-				return false
+			switch version.Pre[0].VersionStr {
+			case "alpha", "beta", "rc":
+				// allow
+			default:
+				return false // ignore other pre-release versions
 			}
 
 			if !version.Pre[1].IsNumeric() {


### PR DESCRIPTION
Without this fix, Talos v1.11.0-rc.0 is not visible.