### PR TITLE
fix: translation ID

### DIFF
--- a/internal/frontend/http/templates/wizard-final.html
+++ b/internal/frontend/http/templates/wizard-final.html
@@ -55,7 +55,7 @@
         {{ if eq .Target "metal" }}
         <li><a target="_blank" href="https://www.talos.dev/{{ short_version .Version }}/talos-guides/install/bare-metal-platforms/network-config/">{{ t .Localizer "final.documentation.metal" }}</a></li>
         {{ else if eq .Target "cloud" }}
-        <li><a target="_blank" href="https://www.talos.dev/{{ short_version .Version }}{{ .PlatformMeta.Documentation }}">{{ .PlatformMeta.Label }} {{ t .Localizer "final.docuentation.cloud" }}</a></li>
+        <li><a target="_blank" href="https://www.talos.dev/{{ short_version .Version }}{{ .PlatformMeta.Documentation }}">{{ .PlatformMeta.Label }} {{ t .Localizer "final.documentation.cloud" }}</a></li>
         {{ else if eq .Target "sbc" }}
         <li><a target="_blank" href="https://www.talos.dev/{{ short_version .Version }}{{ .BoardMeta.Documentation }}">{{ .BoardMeta.Label }} {{ t .Localizer "final.documentation.sbc" }}</a></li>
         {{ end }}

--- a/internal/integration/download_test.go
+++ b/internal/integration/download_test.go
@@ -414,7 +414,7 @@ func testDownloadFrontend(ctx context.Context, t *testing.T, baseURL string) {
 	const MiB = 1024 * 1024
 
 	talosVersions := []string{
-		"v1.11.0-beta.0",
+		"v1.11.0",
 		"v1.10.2",
 		"v1.9.4",
 		"v1.8.2",

--- a/internal/integration/pxe_test.go
+++ b/internal/integration/pxe_test.go
@@ -85,7 +85,7 @@ func fixupCmdline(cmdline string, talosVersion string) string {
 func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) {
 	talosVersions := []string{
 		"v1.5.0",
-		"v1.11.0-beta.0",
+		"v1.11.0",
 	}
 
 	const (

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -216,7 +216,7 @@ func testRegistryFrontend(ctx context.Context, t *testing.T, registryAddr string
 		"v1.5.0",
 		"v1.5.1",
 		"v1.10.2",
-		"v1.11.0-beta.0",
+		"v1.11.0",
 	}
 
 	registry, err := name.NewRegistry(registryAddr)

--- a/internal/integration/talosctl_test.go
+++ b/internal/integration/talosctl_test.go
@@ -44,7 +44,7 @@ func downloadTalosctl(ctx context.Context, t *testing.T, baseURL string, talosVe
 
 func testTalosctlFrontend(ctx context.Context, t *testing.T, baseURL string) {
 	talosVersions := map[string][]string{
-		"v1.11.0-beta.0": {
+		"v1.11.0": {
 			"talosctl-linux-amd64", "talosctl-linux-arm64", "talosctl-linux-armv7",
 			"talosctl-darwin-amd64", "talosctl-darwin-arm64",
 			"talosctl-freebsd-amd64", "talosctl-freebsd-arm64",


### PR DESCRIPTION
It was showing as 'missing translation' confusingly.