### PR TITLE
fix: log mount error

### DIFF
--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -289,6 +290,9 @@ func (b *Builder) build(ctx context.Context, prof profile.Profile, versionString
 
 	tmpDir.assetPath, err = imgr.Execute(ctx, tmpDir.directoryPath, reporter.New())
 	if err != nil {
+		if strings.Contains(err.Error(), "error mounting partitions") {
+			b.logger.Error("failed to mount, talos kernel may include features that are not present", zap.String("talos_version", prof.Version))
+		}
 		return nil, fmt.Errorf("error generating asset: %w", err)
 	}
 


### PR DESCRIPTION
When you build Talos 1.10 on 5.15:
```
error:error generating asset: failed to install: failed to install bootloader: error mounting partitions: error mounting /dev/loop3p3: 2 error(s) occurred:
        invalid argument
        timeout
```
Added log about possible differences between the kernel it runs on and the one it is being built on.