### PR TITLE
feat: better test matrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-17T16:18:55Z by kres 46e133d.
+# Generated on 2025-11-05T13:37:53Z by kres cd5a938-dirty.
 
-ARG TOOLCHAIN
-ARG PKGS_PREFIX
-ARG PKGS
+ARG TOOLCHAIN=scratch
+ARG PKGS_PREFIX=scratch
+ARG PKGS=scratch
 
 # runs markdownlint
 FROM docker.io/oven/bun:1.3.0-alpine AS lint-markdown

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -462,8 +462,9 @@ func EnhanceFromSchematic(
 	// skip customizations for initramfs/kernel completely since it cannot support extra kernel args & META
 	case profile.OutKindInitramfs, profile.OutKindKernel:
 	// installer and UKI support extra kernel args if either secure boot is enabled or the version supports unified installer
+	// this is not supported for overlays since they don't use Unified Kernel Images.
 	case profile.OutKindInstaller, profile.OutKindUKI:
-		if prof.SecureBootEnabled() || quirks.New(versionTag).SupportsUnifiedInstaller() {
+		if prof.Overlay == nil && (prof.SecureBootEnabled() || quirks.New(versionTag).SupportsUnifiedInstaller()) {
 			prof.Customization.ExtraKernelArgs = append(prof.Customization.ExtraKernelArgs, schematic.Customization.ExtraKernelArgs...)
 		}
 	// all other output supports cmdline & META

--- a/internal/regtransport/regtransport.go
+++ b/internal/regtransport/regtransport.go
@@ -7,6 +7,7 @@ package regtransport
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
@@ -20,11 +21,5 @@ func IsStatusCodeError(err error, statusCodes ...int) bool {
 		return false
 	}
 
-	for _, statusCode := range statusCodes {
-		if transportError.StatusCode == statusCode {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(statusCodes, transportError.StatusCode)
 }

--- a/internal/schematic/storage/cache/cache_test.go
+++ b/internal/schematic/storage/cache/cache_test.go
@@ -36,7 +36,7 @@ func (s *mockStorage) Get(_ context.Context, id string) ([]byte, error) {
 	case "failing":
 		return nil, fmt.Errorf("failing")
 	default:
-		return []byte(fmt.Sprintf("%s-%d", id, counter)), nil
+		return fmt.Appendf(nil, "%s-%d", id, counter), nil
 	}
 }
 


### PR DESCRIPTION
Better test matrix for `EnhanceFromSchematic`.

Less duplicates and covers all versions, easier to add newer Talos versions, this caught a very small bug where `extraKernelArgs` were populated when overlays were used.