### PR TITLE
feat: implement authentication support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-21T13:19:04Z by kres 1ffefb6.
+# Generated on 2026-01-26T12:29:39Z by kres b1ab497.
 
 version: "2"
 
@@ -9,7 +9,7 @@ run:
   modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  build-tags: []
+  build-tags: ["enterprise"]
 
 # output configuration options
 output:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -962,3 +962,12 @@ spec:
       runnerGroup: generic
     environment:
       REGISTRY: registry.dev.siderolabs.io
+---
+kind: golang.UnitTests
+spec:
+  extraArgs: "-tags=enterprise"
+---
+kind: golang.GolangciLint
+spec:
+  buildTags:
+    - enterprise

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-21T13:19:04Z by kres 1ffefb6.
+# Generated on 2026-01-26T12:29:39Z by kres b1ab497.
 
 ARG TOOLCHAIN=scratch
 ARG PKGS_PREFIX=scratch
@@ -223,13 +223,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache
 FROM base AS unit-tests-race
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=image-factory/go/pkg --mount=type=cache,target=/tmp,id=image-factory/tmp CGO_ENABLED=1 go test -race ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=image-factory/go/pkg --mount=type=cache,target=/tmp,id=image-factory/tmp CGO_ENABLED=1 go test -race -tags=enterprise ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=image-factory/go/pkg --mount=type=cache,target=/tmp,id=image-factory/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=image-factory/go/pkg --mount=type=cache,target=/tmp,id=image-factory/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -tags=enterprise ${TESTPKGS}
 
 # updates go.mod to use the latest talos main
 FROM base AS update-to-talos-main

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Options configures the behavior of the image factory.
-type Options struct {
+type Options struct { //nolint:govet // keeping order for semantic clarity
 	// HTTP configuration for the image factory frontend.
 	HTTP HTTPOptions `koanf:"http"`
 
@@ -31,6 +31,11 @@ type Options struct {
 
 	// Artifacts defines names and references for various images used by the factory.
 	Artifacts ArtifactsOptions `koanf:"artifacts"`
+
+	// Authentication settings.
+	//
+	// Note: only available in the Enterprise edition.
+	Authentication AuthenticationOptions `koanf:"authentication"`
 }
 
 // AssetBuilderOptions contains settings for building assets.
@@ -346,6 +351,16 @@ type ComponentsOptions struct {
 
 	// Talosctl is the image containing the Talos CLI tool.
 	Talosctl string `koanf:"talosctl"`
+}
+
+// AuthenticationOptions holds authentication settings.
+type AuthenticationOptions struct { //nolint:govet // keeping order for semantic clarity
+	// Enabled enables authentication.
+	Enabled bool `koanf:"enabled"`
+	// ConfigPath is the path to the authentication configuration file.
+	//
+	// It is required if authentication is enabled.
+	ConfigPath string `koanf:"configPath"`
 }
 
 // DefaultOptions are the default options.

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -109,8 +109,18 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return fmt.Errorf("failed to initialize SecureBoot service: %w", err)
 	}
 
+	var authProvider enterprise.AuthProvider
+
+	if opts.Authentication.Enabled {
+		authProvider, err = enterprise.NewAuthProvider(opts.Authentication.ConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to initialize authentication provider: %w", err)
+		}
+	}
+
 	var frontendOptions frontendhttp.Options
 
+	frontendOptions.AuthProvider = authProvider
 	frontendOptions.CacheSigningKey = cacheSigningKey
 
 	frontendOptions.ExternalURL, err = url.Parse(opts.HTTP.ExternalURL)

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,9 @@ Well-known schematic IDs:
 
 * `376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba` - default schematic (without any customizations)
 
+The schematic in Enterprise edition may contain an `owner` field, which restricts access to the schematic to the specified owner only.
+This requires authentication to be enabled.
+
 ### `GET /schematics/:schematic`
 
 Retrieve a specific schematic by its ID.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -597,6 +597,26 @@ RefreshInterval specifies how often the image factory should refresh its connect
 
 ---
 
+### `authentication.enabled`
+
+- **Type:** `bool`
+- **Env:** `AUTHENTICATION_ENABLED`
+
+Enabled enables authentication.
+
+---
+
+### `authentication.configPath`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_CONFIGPATH`
+
+ConfigPath is the path to the authentication configuration file.
+
+It is required if authentication is enabled.
+
+---
+
 ## Default Configuration
 
 ### YAML
@@ -631,6 +651,9 @@ artifacts:
         registry: ghcr.io
         repository: schematics
     talosVersionRecheckInterval: 15m0s
+authentication:
+    configPath: ""
+    enabled: false
 build:
     maxConcurrency: 6
     minTalosVersion: 1.2.0
@@ -711,6 +734,8 @@ IF_ARTIFACTS_SCHEMATIC_NAMESPACE=siderolabs/image-factory
 IF_ARTIFACTS_SCHEMATIC_REGISTRY=ghcr.io
 IF_ARTIFACTS_SCHEMATIC_REPOSITORY=schematics
 IF_ARTIFACTS_TALOSVERSIONRECHECKINTERVAL=15m0s
+IF_AUTHENTICATION_CONFIGPATH=
+IF_AUTHENTICATION_ENABLED=false
 IF_BUILD_MAXCONCURRENCY=6
 IF_BUILD_MINTALOSVERSION=1.2.0
 IF_CACHE_CDN_ENABLED=false

--- a/enterprise/auth/auth.go
+++ b/enterprise/auth/auth.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package auth provides authentication mechanisms.
+package auth
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"slices"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+// NewProvider initializes a new authentication provider.
+func NewProvider(configPath string) (*provider, error) {
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	users := make(map[string][]string)
+
+	for _, token := range config.APITokens {
+		users[token.Token] = token.Passwords
+	}
+
+	return &provider{
+		users: users,
+	}, nil
+}
+
+type provider struct {
+	users map[string][]string
+}
+
+func (provider *provider) Middleware(
+	handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error,
+) func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			return handler(ctx, w, r, p)
+		}
+
+		if !provider.verifyCredentials(username, password) {
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("invalid credentials"))
+		}
+
+		ctx = context.WithValue(ctx, authContextKey{}, username)
+
+		return handler(ctx, w, r, p)
+	}
+}
+
+func (provider *provider) verifyCredentials(username, password string) bool {
+	log.Printf("%s %s, %v", username, password, provider.users)
+
+	return slices.Contains(provider.users[username], password)
+}

--- a/enterprise/auth/auth_test.go
+++ b/enterprise/auth/auth_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/enterprise/auth"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+func TestAuthProvider(t *testing.T) {
+	t.Parallel()
+
+	provider, err := auth.NewProvider("testdata/auth.yaml")
+	require.NoError(t, err)
+
+	handler := func(t *testing.T, expectUser bool, expectUsername string) func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+			username, ok := auth.GetAuthUsername(ctx)
+
+			if expectUser {
+				require.True(t, ok)
+				require.Equal(t, expectUsername, username)
+			} else {
+				require.False(t, ok)
+			}
+
+			return nil
+		}
+	}
+
+	for _, test := range []struct {
+		name string
+
+		username string
+		password string
+
+		expectAuthError bool
+	}{
+		{
+			name: "no auth",
+		},
+		{
+			name: "valid user1/pass1",
+
+			username: "user1",
+			password: "pass1",
+		},
+		{
+			name: "valid user1/pass1.1",
+
+			username: "user1",
+			password: "pass1.1",
+		},
+		{
+			name: "valid user2/pass2",
+
+			username: "user2",
+			password: "pass2",
+		},
+		{
+			name: "invalid user",
+
+			username: "invalid",
+			password: "pass",
+
+			expectAuthError: true,
+		},
+		{
+			name: "invalid password for user1",
+
+			username: "user1",
+			password: "wrongpass",
+
+			expectAuthError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			if test.username != "" && test.password != "" {
+				req.SetBasicAuth(test.username, test.password)
+			}
+
+			middleware := provider.Middleware(handler(t, test.username != "", test.username))
+
+			err = middleware(ctx, nil, req, nil)
+			if !test.expectAuthError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, xerrors.TagIs[schematicpkg.RequiresAuthenticationTag](err))
+		})
+	}
+}

--- a/enterprise/auth/config.go
+++ b/enterprise/auth/config.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth
+
+import (
+	"os"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// ConfigFile represents the authentication configuration file structure.
+type ConfigFile struct {
+	APITokens []APIToken `yaml:"apiTokens"`
+}
+
+// APIToken represents an API token with associated username and passwords.
+type APIToken struct {
+	Token     string   `yaml:"token"`
+	Passwords []string `yaml:"passwords"`
+}
+
+// LoadConfig loads the authentication configuration from the specified file path.
+func LoadConfig(filePath string) (*ConfigFile, error) {
+	in, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer in.Close() //nolint:errcheck
+
+	var config ConfigFile
+
+	dec := yaml.NewDecoder(in)
+	dec.KnownFields(true)
+
+	if err = dec.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/enterprise/auth/context.go
+++ b/enterprise/auth/context.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth
+
+import "context"
+
+type authContextKey struct{}
+
+func GetAuthUsername(ctx context.Context) (string, bool) {
+	username, ok := ctx.Value(authContextKey{}).(string)
+
+	return username, ok
+}

--- a/enterprise/auth/testdata/auth.yaml
+++ b/enterprise/auth/testdata/auth.yaml
@@ -1,0 +1,9 @@
+# authentication configuration
+apiTokens:
+  - token: user1
+    passwords:
+      - pass1
+      - pass1.1
+  - token: user2
+    passwords:
+      - pass2

--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -14,7 +14,7 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 
 	"github.com/siderolabs/image-factory/internal/schematic/storage"
-	"github.com/siderolabs/image-factory/pkg/schematic"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
 // handleSchematicCreate handles creation of the schematic.
@@ -28,12 +28,12 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
-	cfg, err := schematic.Unmarshal(data)
+	schematic, err := schematicpkg.Unmarshal(data)
 	if err != nil {
 		return err
 	}
 
-	id, err := f.schematicFactory.Put(ctx, cfg)
+	id, err := f.schematicFactory.Put(ctx, schematic)
 	if err != nil {
 		return err
 	}

--- a/internal/integration/frontend_test.go
+++ b/internal/integration/frontend_test.go
@@ -11,30 +11,75 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/image-factory/pkg/enterprise"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func testFrontend(ctx context.Context, t *testing.T, baseURL string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, baseURL+"/", nil)
-	require.NoError(t, err)
+func testFrontend(ctx context.Context, baseURL string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+		t.Run("Server Header", func(t *testing.T) {
+			t.Parallel()
 
-	t.Cleanup(func() {
-		require.NoError(t, resp.Body.Close())
-	})
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, baseURL+"/", nil)
+			require.NoError(t, err)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
 
-	server := resp.Header.Get("Server")
+			t.Cleanup(func() {
+				require.NoError(t, resp.Body.Close())
+			})
 
-	if enterprise.Enabled() {
-		assert.Contains(t, server, "Enterprise Image Factory")
-	} else {
-		assert.Contains(t, server, "Image Factory")
-		assert.NotContains(t, server, "Enterprise")
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			server := resp.Header.Get("Server")
+
+			if enterprise.Enabled() {
+				assert.Contains(t, server, "Enterprise Image Factory")
+			} else {
+				assert.Contains(t, server, "Image Factory")
+				assert.NotContains(t, server, "Enterprise")
+			}
+		})
+
+		t.Run("Auth", testFrontendAuth(ctx, baseURL))
+	}
+}
+
+func testFrontendAuth(ctx context.Context, baseURL string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		if !enterprise.Enabled() {
+			t.Skip("enterprise features are disabled")
+		}
+
+		t.Run("Correct Credentials", func(t *testing.T) {
+			t.Parallel()
+
+			client, err := client.New(baseURL, clientAuthCredentials()...)
+			require.NoError(t, err)
+
+			_, err = client.Versions(ctx)
+			require.NoError(t, err)
+		})
+
+		t.Run("Incorrect Credentials", func(t *testing.T) {
+			t.Parallel()
+
+			username, password := authCredentials()
+			password += "x"
+
+			client, err := client.New(baseURL, client.WithBasicAuth(username, password))
+			require.NoError(t, err)
+
+			_, err = client.Versions(ctx)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "HTTP 401: authentication required")
+		})
 	}
 }

--- a/internal/integration/testdata/auth-config.yaml
+++ b/internal/integration/testdata/auth-config.yaml
@@ -1,0 +1,9 @@
+# Fixture for authentication configuration in the integration tests.
+apiTokens:
+  - token: alice
+    passwords:
+      - alicesecret
+      - alicetopsecret
+  - token: bob
+    passwords:
+      - bobsecret

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -36,8 +37,9 @@ type OverlayInfo struct {
 
 // Client is the Image Factory HTTP API client.
 type Client struct {
-	baseURL *url.URL
-	client  http.Client
+	baseURL      *url.URL
+	extraHeaders http.Header
+	client       http.Client
 }
 
 // New creates a new Image Factory API client.
@@ -50,8 +52,9 @@ func New(baseURL string, options ...Option) (*Client, error) {
 	}
 
 	c := &Client{
-		baseURL: bURL,
-		client:  opts.Client,
+		baseURL:      bURL,
+		client:       opts.Client,
+		extraHeaders: opts.ExtraHeaders,
 	}
 
 	return c, nil
@@ -140,6 +143,8 @@ func (c *Client) do(ctx context.Context, method, uri string, requestData []byte,
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
+
+	maps.Copy(req.Header, c.extraHeaders)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -4,10 +4,15 @@
 
 package client
 
-import "net/http"
+import (
+	"encoding/base64"
+	"net/http"
+)
 
 // Options defines client options.
 type Options struct {
+	// ExtraHeaders represents extra headers to be added to each request.
+	ExtraHeaders http.Header
 	// Client is the http client.
 	Client http.Client
 }
@@ -19,6 +24,19 @@ type Option func(*Options)
 func WithClient(client http.Client) Option {
 	return func(o *Options) {
 		o.Client = client
+	}
+}
+
+// WithBasicAuth adds basic authentication to each request.
+func WithBasicAuth(username, password string) Option {
+	return func(o *Options) {
+		if o.ExtraHeaders == nil {
+			o.ExtraHeaders = http.Header{}
+		}
+
+		auth := username + ":" + password
+
+		o.ExtraHeaders.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 	}
 }
 

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package enterprise provide glue to Enterprise code.
+package enterprise
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// AuthProvider defines an authentication provider.
+type AuthProvider interface {
+	Middleware(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error,
+	) func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error
+}

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -4,10 +4,16 @@
 
 //go:build !enterprise
 
-// Package enterprise provide glue to Enterprise code.
 package enterprise
+
+import "errors"
 
 // Enabled indicates whether Enterprise features are enabled.
 func Enabled() bool {
 	return false
+}
+
+// NewAuthProvider creates a new authentication provider.
+func NewAuthProvider(configPath string) (AuthProvider, error) {
+	return nil, errors.New("authentication is not supported in the non-enterprise version")
 }

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -4,10 +4,18 @@
 
 //go:build enterprise
 
-// Package enterprise provide glue to Enterprise code.
 package enterprise
+
+import (
+	"github.com/siderolabs/image-factory/enterprise/auth"
+)
 
 // Enabled indicates whether Enterprise features are enabled.
 func Enabled() bool {
 	return true
+}
+
+// NewAuthProvider creates a new authentication provider.
+func NewAuthProvider(configPath string) (AuthProvider, error) {
+	return auth.NewProvider(configPath)
 }

--- a/pkg/schematic/schematic.go
+++ b/pkg/schematic/schematic.go
@@ -17,6 +17,13 @@ import (
 
 // Schematic represents the requested image customization.
 type Schematic struct {
+	// Owner is the name (username) of the schematic owner.
+	//
+	// If owner is set, the schematic is only accessible to the owner and
+	// requires authentication to access.
+	//
+	// Note: this field is only supported in Enterprise edition.
+	Owner string `yaml:"owner,omitempty"`
 	// Overlay represents the overlay options for image generation.
 	Overlay Overlay `yaml:"overlay,omitempty"`
 	// Customization represents the Talos image customization.
@@ -68,6 +75,9 @@ type SecureBootCustomization struct {
 
 // InvalidErrorTag is a tag for invalid schematic errors.
 type InvalidErrorTag struct{}
+
+// RequiresAuthenticationTag is a tag for schematics that require authentication to access.
+type RequiresAuthenticationTag struct{}
 
 // Unmarshal the schematic from text representation.
 func Unmarshal(data []byte) (*Schematic, error) {


### PR DESCRIPTION
This feature is Enterprise only (requires BUSL).

Any access to the schematic requires the user to be authenticated before access.

Moreover, any schematic stores the owner in the schematic, so each schematic becomes private (owned by the user which created it).

Authentication is configured using a set of usernames and keys associates with each user (API key).