### PR TITLE
fix: add missing libarchive dependency

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -23,7 +23,7 @@ spec:
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: PKGS
-        defaultValue: v1.13.0-alpha.0-21-g59241bd
+        defaultValue: v1.13.0-alpha.0-28-gdf4b4c8
   docker:
     extraArgs:
       - PKGS_PREFIX
@@ -137,6 +137,8 @@ spec:
         from: ${PKGS_PREFIX}/installer:v1.9.4
       - name: pkg-kmod
         from: ${PKGS_PREFIX}/kmod:${PKGS}
+      - name: pkg-libarchive
+        from: ${PKGS_PREFIX}/libarchive:${PKGS}
       - name: pkg-libattr
         from: ${PKGS_PREFIX}/libattr:${PKGS}
       - name: pkg-libinih
@@ -230,6 +232,10 @@ spec:
               dst: /usr/share/grub/unicode.pf2
           - copy:
               from: pkg-kmod
+              src: /
+              dst: /
+          - copy:
+              from: pkg-libarchive
               src: /
               dst: /
           - copy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-08T09:01:34Z by kres 0e8da31.
+# Generated on 2026-01-09T11:46:00Z by kres 0e8da31.
 
 ARG TOOLCHAIN=scratch
 ARG PKGS_PREFIX=scratch
@@ -39,6 +39,8 @@ FROM --platform=linux/arm64 ${PKGS_PREFIX}/grub:${PKGS} AS pkg-grub-arm64
 FROM ${PKGS_PREFIX}/installer:v1.9.4 AS pkg-grub-unicode
 
 FROM ${PKGS_PREFIX}/kmod:${PKGS} AS pkg-kmod
+
+FROM ${PKGS_PREFIX}/libarchive:${PKGS} AS pkg-libarchive
 
 FROM ${PKGS_PREFIX}/libattr:${PKGS} AS pkg-libattr
 
@@ -102,6 +104,7 @@ COPY --from=pkg-grub-amd64 /usr/lib/grub /usr/lib/grub
 COPY --from=pkg-grub-arm64 /usr/lib/grub /usr/lib/grub
 COPY --from=pkg-grub-unicode /usr/share/grub/unicode.pf2 /usr/share/grub/unicode.pf2
 COPY --from=pkg-kmod / /
+COPY --from=pkg-libarchive / /
 COPY --from=pkg-libattr / /
 COPY --from=pkg-libinih / /
 COPY --from=pkg-liblzma / /

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-08T09:38:30Z by kres 0e8da31.
+# Generated on 2026-01-09T11:46:00Z by kres 0e8da31.
 
 # common variables
 
@@ -83,7 +83,7 @@ TOOLCHAIN ?= docker.io/golang:1.25-alpine
 # extra variables
 
 PKGS_PREFIX ?= ghcr.io/siderolabs
-PKGS ?= v1.13.0-alpha.0-21-g59241bd
+PKGS ?= v1.13.0-alpha.0-28-gdf4b4c8
 RUN_TESTS ?= TestIntegrationCDN
 TEST_FLAGS ?=
 


### PR DESCRIPTION
When using imager to generate image cache `libarchive` is needed as a dependency. Image Factory doesn't expose creating image caches yet, but it's better to have dependencies in sync with imager.