### PR TITLE
fix: extra kernel args for overlays

### DIFF
--- a/internal/profile/hash.go
+++ b/internal/profile/hash.go
@@ -83,6 +83,12 @@ func Hash(p profile.Profile) (string, error) {
 		hasher.Write([]byte("vmware arm64 kernel args fix #11735"))
 	}
 
+	// 10. Overlays were missing extra kernel args on UKI/Installer images
+	// - https://github.com/siderolabs/image-factory/issues/376
+	if p.Overlay != nil && (p.Output.Kind == profile.OutKindUKI || p.Output.Kind == profile.OutKindInstaller) {
+		hasher.Write([]byte("overlay extra kernel args fix #376"))
+	}
+
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -456,9 +456,8 @@ func EnhanceFromSchematic(
 	// skip customizations for initramfs/kernel completely since it cannot support extra kernel args & META
 	case profile.OutKindInitramfs, profile.OutKindKernel:
 	// installer and UKI support extra kernel args if either secure boot is enabled or the version supports unified installer
-	// this is not supported for overlays since they don't use Unified Kernel Images.
 	case profile.OutKindInstaller, profile.OutKindUKI:
-		if prof.Overlay == nil && (prof.SecureBootEnabled() || quirks.New(versionTag).SupportsUnifiedInstaller()) {
+		if prof.SecureBootEnabled() || quirks.New(versionTag).SupportsUnifiedInstaller() {
 			prof.Customization.ExtraKernelArgs = append(prof.Customization.ExtraKernelArgs, schematic.Customization.ExtraKernelArgs...)
 		}
 	case profile.OutKindISO:

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -738,6 +738,10 @@ func defaultExpectedProfileWithExtensionsKernelArgs(version, arch string, outKin
 func defaultExpectedProfileWithOverlayExtensionsKernelArgs(version, arch string, outKind profile.OutputKind, secureboot bool) profile.Profile {
 	prof := defaultExpectedProfile(version, arch, outKind, secureboot)
 
+	if quirks.New(version).SupportsUnifiedInstaller() {
+		prof.Customization.ExtraKernelArgs = []string{"noapic", "nolapic"}
+	}
+
 	prof.Input.OverlayInstaller = profile.ContainerAsset{
 		OCIPath: "arm64-sha256:sbc-raspberrypi.oci",
 	}


### PR DESCRIPTION
Fix don't skip extra kernel args for overlay installers.

Fixes: #376