### PR TITLE
fix(docs): correct path to hack/copy-artifacts.sh

### DIFF
--- a/docs/air-gapped.md
+++ b/docs/air-gapped.md
@@ -3,7 +3,7 @@
 The Image Factory can be run in air-gapped mode, where it uses a local registry to pull the required images and their signatures.
 
 Let's assume that the local registry is running at `localhost:5000`, and official images from `ghcr.io/siderolabs` are copied to it.
-Use the script [`hack/copy-artifacts.sh`](hack/copy-artifacts.sh) to copy the required images and their signatures to the local registry, replacing `TALOS_VERSION` with the desired Talos Linux version:
+Use the script [`hack/copy-artifacts.sh`](../hack/copy-artifacts.sh) to copy the required images and their signatures to the local registry, replacing `TALOS_VERSION` with the desired Talos Linux version:
 
 ```bash
 hack/copy-artifacts.sh ghcr.io localhost:5000 TALOS_VERSION


### PR DESCRIPTION
Clicking on the link would lead you to `docs/hack/copy-artifacts.sh` fixed so it leads to `../hack/copy-artifacts.sh`