### PR TITLE
fix: gsa signer pull during verify

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -730,7 +730,7 @@ spec:
     stages:
       - name: tailwind-base
         description: "Installs tailwindcss"
-        from: docker.io/oven/bun:1.2.4-alpine
+        from: docker.io/oven/bun:1.3.9-alpine
         platform: "${BUILDPLATFORM}"
         workdir: /src
         steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-14T06:27:51Z by kres b6d29bf.
+# Generated on 2026-04-16T10:23:55Z by kres b6d29bf.
 
 ARG TOOLCHAIN=scratch
 ARG PKGS_PREFIX=scratch
@@ -89,7 +89,7 @@ FROM ${PKGS_PREFIX}/zlib:${PKGS} AS pkg-zlib
 FROM ${PKGS_PREFIX}/zstd:${PKGS} AS pkg-zstd
 
 # Installs tailwindcss
-FROM --platform=${BUILDPLATFORM} docker.io/oven/bun:1.2.4-alpine AS tailwind-base
+FROM --platform=${BUILDPLATFORM} docker.io/oven/bun:1.3.9-alpine AS tailwind-base
 WORKDIR /src
 COPY package.json package-lock.json .
 RUN bun install

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -494,7 +494,6 @@ func buildCacheSigner(opts Options) (signer.Signer, error) {
 			FulcioURL:           opts.Cache.GSA.FulcioURL,
 			RekorURL:            opts.Cache.GSA.RekorURL,
 			Insecure:            opts.Artifacts.Installer.Internal.Insecure,
-			RemoteOptions:       remoteOptions(),
 		})
 	}
 

--- a/internal/image/signer/gsa.go
+++ b/internal/image/signer/gsa.go
@@ -16,7 +16,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"slices"
 	"strings"
 
 	"cloud.google.com/go/auth"
@@ -59,9 +58,6 @@ type GSASignerOptions struct {
 	FulcioURL string
 	// RekorURL is the Rekor transparency log URL. Defaults to DefaultRekorURL.
 	RekorURL string
-	// RemoteOptions are go-containerregistry remote options (auth, transport, etc.)
-	// used to push OCI referrer bundles and to look up referrers during verification.
-	RemoteOptions []gcremote.Option
 	// Insecure allows pushing/pulling bundles to registries over plain HTTP.
 	Insecure bool
 }
@@ -74,7 +70,7 @@ type GSASigner struct {
 	fulcio         *sigsign.Fulcio
 	trustedRoot    sigstoreroot.TrustedMaterial
 	rekorURL       string
-	ociRemoteOpts  []ociremote.Option
+	nameOpts       []name.Option
 }
 
 // NewGSASigner creates a new GSA-based keyless signer.
@@ -111,11 +107,10 @@ func NewGSASigner(opts GSASignerOptions) (*GSASigner, error) {
 		Retries: 3,
 	})
 
-	remoteOpts := slices.Concat(opts.RemoteOptions, []gcremote.Option{gcremote.WithTransport(remotewrap.GetTransport())})
+	var nameOpts []name.Option
 
-	ociRemoteOpts := []ociremote.Option{ociremote.WithRemoteOptions(remoteOpts...)}
 	if opts.Insecure {
-		ociRemoteOpts = append(ociRemoteOpts, ociremote.WithNameOptions(name.Insecure))
+		nameOpts = append(nameOpts, name.Insecure)
 	}
 
 	return &GSASigner{
@@ -124,7 +119,7 @@ func NewGSASigner(opts GSASignerOptions) (*GSASigner, error) {
 		fulcio:         fulcio,
 		trustedRoot:    trustedRoot,
 		rekorURL:       rekorURL,
-		ociRemoteOpts:  ociRemoteOpts,
+		nameOpts:       nameOpts,
 	}, nil
 }
 
@@ -137,9 +132,8 @@ func (s *GSASigner) GetCheckOpts() *cosign.CheckOpts {
 				Subject: s.serviceAccount,
 			},
 		},
-		NewBundleFormat:    true,
-		TrustedMaterial:    s.trustedRoot,
-		RegistryClientOpts: s.ociRemoteOpts,
+		NewBundleFormat: true,
+		TrustedMaterial: s.trustedRoot,
 	}
 }
 
@@ -150,7 +144,7 @@ func (s *GSASigner) GetPublicKeyPEM() []byte {
 
 // SignImage signs the image using GSA OIDC token-based keyless signing and stores
 // the result as an OCI referrer bundle (new bundle format).
-func (s *GSASigner) SignImage(ctx context.Context, imageRef name.Digest, _ remotewrap.Pusher) error {
+func (s *GSASigner) SignImage(ctx context.Context, imageRef name.Digest, pusher remotewrap.Pusher) error {
 	tok, err := s.creds.Token(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get GSA OIDC token: %w", err)
@@ -210,10 +204,17 @@ func (s *GSASigner) SignImage(ctx context.Context, imageRef name.Digest, _ remot
 		return fmt.Errorf("failed to build sigstore bundle: %w", err)
 	}
 
-	// Push as an OCI 1.1 referrer of the signed image.
-	ociOpts := slices.Concat(s.ociRemoteOpts, []ociremote.Option{ociremote.WithRemoteOptions(gcremote.WithContext(ctx))})
+	// Get fresh remote options from the refreshing pusher to avoid stale auth tokens.
+	pushRemoteOpts, err := pusher.RemoteOptions()
+	if err != nil {
+		return fmt.Errorf("failed to get remote options for push: %w", err)
+	}
 
-	if err := ociremote.WriteAttestationNewBundleFormat(imageRef, bundleBytes, costypes.CosignSignPredicateType, ociOpts...); err != nil {
+	// Push as an OCI 1.1 referrer of the signed image.
+	if err := ociremote.WriteAttestationNewBundleFormat(imageRef, bundleBytes, costypes.CosignSignPredicateType,
+		ociremote.WithRemoteOptions(append(pushRemoteOpts, gcremote.WithContext(ctx))...),
+		ociremote.WithNameOptions(s.nameOpts...),
+	); err != nil {
 		return fmt.Errorf("failed to push bundle referrer: %w", err)
 	}
 
@@ -223,7 +224,7 @@ func (s *GSASigner) SignImage(ctx context.Context, imageRef name.Digest, _ remot
 // VerifyImage verifies the OCI referrer bundle for imageRef against the GSA identity.
 // Implements Signer.VerifyImage.
 func (s *GSASigner) VerifyImage(ctx context.Context, imageRef name.Digest) error {
-	_, _, err := cosign.VerifyImageAttestations(ctx, imageRef, s.GetCheckOpts())
+	_, _, err := cosign.VerifyImageAttestations(ctx, imageRef, s.GetCheckOpts(), s.nameOpts...)
 
 	return err
 }

--- a/internal/remotewrap/remotewrap.go
+++ b/internal/remotewrap/remotewrap.go
@@ -40,6 +40,11 @@ func ShutdownTransport() {
 // Pusher is an interface which is implemented by go-containerregistry's *remote.Pusher.
 type Pusher interface {
 	Push(ctx context.Context, ref name.Reference, t remote.Taggable) error
+	// RemoteOptions returns a fresh set of go-containerregistry remote options backed by
+	// the current (possibly refreshed) *remote.Pusher instance. Use this when a library
+	// accepts []remote.Option directly (e.g. cosign's ociremote package) so that it
+	// benefits from the same credential-refresh guarantee as Push.
+	RemoteOptions() ([]remote.Option, error)
 }
 
 type pusherWrapper struct {
@@ -53,6 +58,15 @@ func (p *pusherWrapper) Push(ctx context.Context, ref name.Reference, t remote.T
 	}
 
 	return instance.Push(ctx, ref, t)
+}
+
+func (p *pusherWrapper) RemoteOptions() ([]remote.Option, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return []remote.Option{remote.Reuse(instance)}, nil
 }
 
 // NewPusher creates a new Pusher with the given options.


### PR DESCRIPTION
Previous fix #419 fixed the push, but that was not enough to fix the pull for verify. The error message returned from sigstore library was not helpful to debug this.