### PR TITLE
feat: implement authentication support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T08:20:43Z by kres b6d29bf-dirty.
+# Generated on 2026-04-17T22:09:50Z by kres 15ff2fd.
 
 *
 !cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T13:29:30Z by kres ae3e740-dirty.
+# Generated on 2026-04-18T14:49:11Z by kres 4b58472.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T12:07:32Z by kres ae3e740.
+# Generated on 2026-04-17T22:09:50Z by kres 15ff2fd.
 
 ARG TOOLCHAIN=scratch
 ARG PKGS_PREFIX=scratch

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-17T13:38:16Z by kres ae3e740-dirty.
+# Generated on 2026-04-18T14:49:11Z by kres 4b58472.
 
 # common variables
 
@@ -473,4 +473,16 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
+
+.PHONY: renovate-local
+renovate-local:  ## runs renovate locally to check syntax and test configuration
+	@docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
+		-v $(PWD):/src \
+		-w /src \
+		-e GITHUB_TOKEN \
+		-e LOG_LEVEL=debug \
+		-e RENOVATE_PLATFORM=local \
+		-e RENOVATE_DRY_RUN=full \
+	renovate/renovate
 

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -5,12 +5,15 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 // Options configures the behavior of the image factory.
-type Options struct {
+type Options struct { //nolint:govet // keeping order for semantic clarity
 	// HTTP configuration for the image factory frontend.
 	HTTP HTTPOptions `koanf:"http"`
 
@@ -31,6 +34,11 @@ type Options struct {
 
 	// Artifacts defines names and references for various images used by the factory.
 	Artifacts ArtifactsOptions `koanf:"artifacts"`
+
+	// Authentication settings.
+	//
+	// Note: only available in the Enterprise edition.
+	Authentication AuthenticationOptions `koanf:"authentication"`
 }
 
 // AssetBuilderOptions contains settings for building assets.
@@ -246,6 +254,9 @@ type S3CacheOptions struct {
 
 	// Enabled enables S3 cache.
 	Enabled bool `koanf:"enabled"`
+
+	// PresignedURLTTL is the duration for which presigned URLs are valid.
+	PresignedURLTTL time.Duration `koanf:"presignedURLTTL"`
 }
 
 // SchematicCacheOptions configures caching of schematic blobs.
@@ -395,6 +406,34 @@ type ComponentsOptions struct {
 	Talosctl string `koanf:"talosctl"`
 }
 
+// AuthenticationOptions holds authentication settings.
+type AuthenticationOptions struct { //nolint:govet // keeping order for semantic clarity
+	// Enabled enables authentication.
+	Enabled bool `koanf:"enabled"`
+	// HTPasswdPath is the path to the htpasswd file containing user credentials.
+	//
+	// The file follows the standard htpasswd format (username:bcrypt_hash, one per line).
+	// Multiple entries with the same username are supported, allowing multiple API keys per user.
+	// Only bcrypt hashes ($2y$/$2a$/$2b$) are accepted.
+	//
+	// It is required if authentication is enabled.
+	HTPasswdPath string `koanf:"htpasswdPath"`
+}
+
+// Validate checks for invalid or conflicting configuration.
+func (o *Options) Validate() error {
+	var err error
+
+	if o.Authentication.Enabled && o.Cache.CDN.Enabled {
+		err = multierror.Append(err,
+			errors.New("CDN cache cannot be enabled when authentication is enabled: "+
+				"CDN would serve assets without authentication, effectively leaking secrets",
+			))
+	}
+
+	return err
+}
+
 // DefaultOptions are the default options.
 var DefaultOptions = Options{
 	HTTP: HTTPOptions{
@@ -422,7 +461,8 @@ var DefaultOptions = Options{
 			Repository: "cache",
 		},
 		S3: S3CacheOptions{
-			Bucket: "image-factory",
+			Bucket:          "image-factory",
+			PresignedURLTTL: time.Hour,
 		},
 		Schematic: SchematicCacheOptions{
 			Capacity:    100_000,

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
 )
 
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		opts        cmd.Options
+		expectedErr string
+	}{
+		{
+			name: "default options",
+			opts: cmd.DefaultOptions,
+		},
+		{
+			name: "empty options",
+			opts: cmd.Options{},
+		},
+		{
+			name: "CDN cache enabled with authentication",
+			opts: cmd.Options{
+				Cache: cmd.CacheOptions{
+					CDN: cmd.CDNCacheOptions{
+						Enabled: true,
+					},
+				},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled: true,
+				},
+			},
+			expectedErr: "CDN cache cannot be enabled when authentication is enabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.opts.Validate()
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
 func TestOCIRepositoryOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -97,12 +97,21 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return err
 	}
 
-	enterprisePlugins, err := buildEnterprisePlugins(logger, configFactory, artifactsManager, assetBuilder, cacheImageSigner, opts)
+	authProvider, err := buildAuthProvider(logger, opts)
 	if err != nil {
 		return err
 	}
 
-	frontendOptions, err := buildFrontendOptions(cacheImageSigner, opts)
+	if authProvider != nil {
+		eg.Go(func() error { return authProvider.Run(ctx) })
+	}
+
+	enterprisePlugins, err := buildEnterprisePlugins(logger, configFactory, artifactsManager, assetBuilder, cacheImageSigner, authProvider, opts)
+	if err != nil {
+		return err
+	}
+
+	frontendOptions, err := buildFrontendOptions(cacheImageSigner, authProvider, opts)
 	if err != nil {
 		return err
 	}
@@ -152,22 +161,41 @@ func buildSecureBootService(opts Options) (*secureboot.Service, error) {
 	return svc, nil
 }
 
+func buildAuthProvider(logger *zap.Logger, opts Options) (enterprise.AuthProvider, error) {
+	if !enterprise.Enabled() {
+		return nil, nil //nolint:nilnil
+	}
+
+	if !opts.Authentication.Enabled {
+		return nil, nil //nolint:nilnil
+	}
+
+	authProvider, err := enterprise.NewAuthProvider(logger, opts.Authentication.HTPasswdPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize authentication provider: %w", err)
+	}
+
+	return authProvider, nil
+}
+
 func buildEnterprisePlugins(
 	logger *zap.Logger,
 	configFactory *schematic.Factory,
 	artifactsManager *artifacts.Manager,
 	assetBuilder *asset.Builder,
 	cacheImageSigner signer.Signer,
+	authProvider enterprise.AuthProvider,
 	opts Options,
 ) ([]enterprise.FrontendPlugin, error) {
 	if !enterprise.Enabled() {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	spdxFrontend, err := enterprise.NewSpdxFrontend(logger, enterprise.SPDXOptions{
 		SchematicFactory:        configFactory,
 		ArtifactsManager:        artifactsManager,
 		AssetBuilder:            assetBuilder,
+		AuthProvider:            authProvider,
 		CacheInsecure:           opts.Cache.OCI.Insecure,
 		CacheRepository:         opts.Cache.OCI.String(),
 		CacheImageSigner:        cacheImageSigner,
@@ -181,12 +209,13 @@ func buildEnterprisePlugins(
 	return []enterprise.FrontendPlugin{spdxFrontend}, nil
 }
 
-func buildFrontendOptions(cacheImageSigner signer.Signer, opts Options) (frontendhttp.Options, error) {
+func buildFrontendOptions(cacheImageSigner signer.Signer, authProvider enterprise.AuthProvider, opts Options) (frontendhttp.Options, error) {
+	var err error
+
 	var frontendOptions frontendhttp.Options
 
 	frontendOptions.CacheImageSigner = cacheImageSigner
-
-	var err error
+	frontendOptions.AuthProvider = authProvider
 
 	frontendOptions.ExternalURL, err = url.Parse(opts.HTTP.ExternalURL)
 	if err != nil {
@@ -422,10 +451,11 @@ func buildAssetBuilder(logger *zap.Logger, artifactsManager *artifacts.Manager, 
 
 	if opts.Cache.S3.Enabled {
 		s3Options := assetcaches3.Options{
-			Bucket:   opts.Cache.S3.Bucket,
-			Endpoint: opts.Cache.S3.Endpoint,
-			Region:   opts.Cache.S3.Region,
-			Insecure: opts.Cache.S3.Insecure,
+			Bucket:          opts.Cache.S3.Bucket,
+			Endpoint:        opts.Cache.S3.Endpoint,
+			Region:          opts.Cache.S3.Region,
+			Insecure:        opts.Cache.S3.Insecure,
+			PresignedURLTTL: opts.Cache.S3.PresignedURLTTL,
 		}
 
 		cache, err = assetcaches3.New(logger, cache, s3Options)

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -57,5 +57,9 @@ func initConfig() (cmd.Options, error) {
 		return opts, err
 	}
 
+	if err := opts.Validate(); err != nil {
+		return opts, fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	return opts, nil
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,9 @@ Well-known schematic IDs:
 
 * `376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba` - default schematic (without any customizations)
 
+The schematic in Enterprise edition may contain an `owner` field, which restricts access to the schematic to the specified owner only.
+This requires authentication to be enabled.
+
 ### `GET /schematics/:schematic`
 
 Retrieve a specific schematic by its ID.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -360,6 +360,15 @@ Insecure allows connecting to S3 without TLS or with invalid certificates.
 
 ---
 
+### `cache.s3.presignedURLTTL`
+
+- **Type:** `time.Duration`
+- **Env:** `CACHE_S3_PRESIGNEDURLTTL`
+
+PresignedURLTTL is the duration for which presigned URLs are valid.
+
+---
+
 ### `cache.s3.enabled`
 
 - **Type:** `bool`
@@ -796,6 +805,38 @@ RefreshInterval specifies how often the image factory should refresh its connect
 
 ---
 
+### `authentication`
+
+Authentication settings.
+
+Note: only available in the Enterprise edition.
+
+---
+
+### `authentication.enabled`
+
+- **Type:** `bool`
+- **Env:** `AUTHENTICATION_ENABLED`
+
+Enabled enables authentication.
+
+---
+
+### `authentication.htpasswdPath`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_HTPASSWDPATH`
+
+HTPasswdPath is the path to the htpasswd file containing user credentials.
+
+The file follows the standard htpasswd format (username:bcrypt_hash, one per line).
+Multiple entries with the same username are supported, allowing multiple API keys per user.
+Only bcrypt hashes ($2y$/$2a$/$2b$) are accepted.
+
+It is required if authentication is enabled.
+
+---
+
 ## Default Configuration
 
 ### YAML
@@ -830,6 +871,9 @@ artifacts:
         registry: ghcr.io
         repository: schematics
     talosVersionRecheckInterval: 15m0s
+authentication:
+    enabled: false
+    htpasswdPath: ""
 build:
     maxConcurrency: 6
     minTalosVersion: 1.2.0
@@ -853,6 +897,7 @@ cache:
         enabled: false
         endpoint: ""
         insecure: false
+        presignedURLTTL: 1h0m0s
         region: ""
     schematic:
         capacity: 100000
@@ -918,6 +963,8 @@ IF_ARTIFACTS_SCHEMATIC_NAMESPACE=siderolabs/image-factory
 IF_ARTIFACTS_SCHEMATIC_REGISTRY=ghcr.io
 IF_ARTIFACTS_SCHEMATIC_REPOSITORY=schematics
 IF_ARTIFACTS_TALOSVERSIONRECHECKINTERVAL=15m0s
+IF_AUTHENTICATION_ENABLED=false
+IF_AUTHENTICATION_HTPASSWDPATH=
 IF_BUILD_MAXCONCURRENCY=6
 IF_BUILD_MINTALOSVERSION=1.2.0
 IF_CACHE_CDN_ENABLED=false
@@ -935,6 +982,7 @@ IF_CACHE_S3_BUCKET=image-factory
 IF_CACHE_S3_ENABLED=false
 IF_CACHE_S3_ENDPOINT=
 IF_CACHE_S3_INSECURE=false
+IF_CACHE_S3_PRESIGNEDURLTTL=1h0m0s
 IF_CACHE_S3_REGION=
 IF_CACHE_SCHEMATIC_CAPACITY=100000
 IF_CACHE_SCHEMATIC_NEGATIVETTL=30s

--- a/enterprise/auth/auth.go
+++ b/enterprise/auth/auth.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package auth provides authentication mechanisms.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+const reloadInterval = 30 * time.Second
+
+// NewProvider initializes a new authentication provider.
+// Call Run to start the background reload loop.
+func NewProvider(htpasswdPath string, logger *zap.Logger) (*Provider, error) {
+	// dummyHash is used as a timing equalizer in verifyCredentials. Without it,
+	// a non-existent username returns instantly while a valid username with a wrong
+	// password incurs full bcrypt latency, creating a timing oracle for username enumeration.
+	dummyHash, err := bcrypt.GenerateFromPassword([]byte("image-factory-auth-timing-dummy"), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("auth: failed to generate dummy timing hash: %w", err)
+	}
+
+	users, err := LoadHTPasswd(htpasswdPath)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Provider{
+		path:      htpasswdPath,
+		logger:    logger.With(zap.String("component", "auth-provider")),
+		dummyHash: dummyHash,
+	}
+
+	p.users.Store(&users)
+
+	return p, nil
+}
+
+// Provider is an authentication provider backed by an htpasswd file.
+type Provider struct {
+	users     atomic.Pointer[map[string][]string]
+	logger    *zap.Logger
+	path      string
+	dummyHash []byte
+}
+
+// Run starts the background file-watcher and reload loop.
+// It blocks until ctx is canceled.
+func (p *Provider) Run(ctx context.Context) error {
+	p.startWatcher(ctx)
+
+	return nil
+}
+
+func (p *Provider) startWatcher(ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		p.logger.Warn("htpasswd: failed to create fsnotify watcher, using polling only", zap.Error(err))
+		p.pollLoop(ctx)
+
+		return
+	}
+
+	defer watcher.Close() //nolint:errcheck
+
+	// Watch the directory so we catch k8s ConfigMap symlink rotations.
+	dir := filepath.Dir(p.path)
+
+	if watchErr := watcher.Add(dir); watchErr != nil {
+		p.logger.Warn("htpasswd: failed to watch directory, using polling only",
+			zap.String("dir", dir), zap.Error(watchErr))
+		p.pollLoop(ctx)
+
+		return
+	}
+
+	ticker := time.NewTicker(reloadInterval)
+	defer ticker.Stop()
+
+	cleanPath := filepath.Clean(p.path)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+
+			if filepath.Clean(event.Name) == cleanPath &&
+				(event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
+				p.reload()
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+
+			p.logger.Warn("htpasswd: watcher error", zap.Error(err))
+
+		case <-ticker.C:
+			p.reload()
+		}
+	}
+}
+
+func (p *Provider) pollLoop(ctx context.Context) {
+	ticker := time.NewTicker(reloadInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.reload()
+		}
+	}
+}
+
+func (p *Provider) reload() {
+	users, err := LoadHTPasswd(p.path)
+	if err != nil {
+		p.logger.Warn("htpasswd: reload failed", zap.Error(err))
+
+		return
+	}
+
+	p.users.Store(&users)
+	p.logger.Info("htpasswd: reloaded")
+}
+
+// Handler is the type of HTTP handlers used by the enterprise frontend.
+type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error
+
+// Middleware implements enterprise.AuthProvider.
+func (provider *Provider) Middleware(handler Handler) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+		}
+
+		if !provider.verifyCredentials(username, password) {
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("invalid credentials"))
+		}
+
+		ctx = context.WithValue(ctx, authContextKey{}, username)
+
+		return handler(ctx, w, r, p)
+	}
+}
+
+// VerifyCredentials implements enterprise.AuthProvider.
+func (provider *Provider) VerifyCredentials(username, password string) bool {
+	return provider.verifyCredentials(username, password)
+}
+
+// UsernameFromContext implements enterprise.AuthProvider.
+func (provider *Provider) UsernameFromContext(ctx context.Context) (string, bool) {
+	return GetAuthUsername(ctx)
+}
+
+func (provider *Provider) verifyCredentials(username, password string) bool {
+	users := provider.users.Load()
+	if users == nil {
+		bcrypt.CompareHashAndPassword(provider.dummyHash, []byte(password)) //nolint:errcheck
+
+		return false
+	}
+
+	hashes, ok := (*users)[username]
+	if !ok {
+		bcrypt.CompareHashAndPassword(provider.dummyHash, []byte(password)) //nolint:errcheck
+
+		return false
+	}
+
+	for _, hash := range hashes {
+		if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil {
+			return true
+		}
+	}
+
+	return false
+}

--- a/enterprise/auth/auth_test.go
+++ b/enterprise/auth/auth_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/image-factory/enterprise/auth"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+func TestAuthProvider(t *testing.T) {
+	t.Parallel()
+
+	provider, err := auth.NewProvider("testdata/htpasswd", zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	handler := func(t *testing.T, expectUser bool, expectUsername string) auth.Handler {
+		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+			username, ok := auth.GetAuthUsername(ctx)
+
+			if expectUser {
+				require.True(t, ok)
+				require.Equal(t, expectUsername, username)
+			} else {
+				require.False(t, ok)
+			}
+
+			return nil
+		}
+	}
+
+	for _, test := range []struct {
+		name string
+
+		username string
+		password string
+
+		expectAuthError bool
+	}{
+		{
+			name: "no auth",
+
+			expectAuthError: true,
+		},
+		{
+			name: "valid user1/pass1",
+
+			username: "user1",
+			password: "pass1",
+		},
+		{
+			name: "valid user1/pass1.1",
+
+			username: "user1",
+			password: "pass1.1",
+		},
+		{
+			name: "valid user2/pass2",
+
+			username: "user2",
+			password: "pass2",
+		},
+		{
+			name: "invalid user",
+
+			username: "invalid",
+			password: "pass",
+
+			expectAuthError: true,
+		},
+		{
+			name: "invalid password for user1",
+
+			username: "user1",
+			password: "wrongpass",
+
+			expectAuthError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			if test.username != "" && test.password != "" {
+				req.SetBasicAuth(test.username, test.password)
+			}
+
+			middleware := provider.Middleware(handler(t, test.username != "", test.username))
+
+			err = middleware(ctx, nil, req, nil)
+			if !test.expectAuthError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, xerrors.TagIs[schematicpkg.RequiresAuthenticationTag](err))
+		})
+	}
+}

--- a/enterprise/auth/config.go
+++ b/enterprise/auth/config.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LoadHTPasswd loads an htpasswd file and returns a map of username to bcrypt password hashes.
+//
+// The htpasswd file format is one entry per line: `username:bcrypt_hash`.
+// Multiple lines with the same username are allowed, enabling multiple API keys per user.
+// Blank lines and lines starting with `#` are ignored.
+// Only bcrypt hashes ($2y$, $2a$, $2b$) are supported.
+func LoadHTPasswd(filePath string) (map[string][]string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close() //nolint:errcheck
+
+	users := make(map[string][]string)
+
+	scanner := bufio.NewScanner(f)
+
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		username, hash, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("htpasswd line %d: missing ':' separator", lineNo)
+		}
+
+		username = strings.TrimSpace(username)
+		hash = strings.TrimSpace(hash)
+
+		if username == "" {
+			return nil, fmt.Errorf("htpasswd line %d: empty username", lineNo)
+		}
+
+		if !strings.HasPrefix(hash, "$2y$") && !strings.HasPrefix(hash, "$2a$") && !strings.HasPrefix(hash, "$2b$") {
+			return nil, fmt.Errorf("htpasswd line %d: unsupported hash format (only bcrypt $2y$/$2a$/$2b$ is supported)", lineNo)
+		}
+
+		users[username] = append(users[username], hash)
+	}
+
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}

--- a/enterprise/auth/context.go
+++ b/enterprise/auth/context.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth
+
+import "context"
+
+type authContextKey struct{}
+
+func GetAuthUsername(ctx context.Context) (string, bool) {
+	username, ok := ctx.Value(authContextKey{}).(string)
+
+	return username, ok
+}

--- a/enterprise/auth/testdata/htpasswd
+++ b/enterprise/auth/testdata/htpasswd
@@ -1,0 +1,6 @@
+# authentication configuration (htpasswd format)
+# user1 has two passwords: pass1 and pass1.1
+user1:$2a$10$NLmI25zvWkFGgG1LIrrXYOlIqTkZ4GgYYNChg7sY8VWVnh6A9o4bW
+user1:$2a$10$0oq8NSWo4/gHGgd2mOayi.BgbASSFRiboyTPQZ2u0RpkeJOqkSexu
+# user2 has one password: pass2
+user2:$2a$10$fgaftUgUAJ5crFoRhRoUT.fZtDhR8LQPVra33vluPJhX9XwCRzvqW

--- a/enterprise/spdx/frontend.go
+++ b/enterprise/spdx/frontend.go
@@ -10,6 +10,7 @@ package spdx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,7 +25,14 @@ import (
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/schematic"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
+
+// authProvider is a subset of enterprise.AuthProvider used for ownership checks.
+// Defined locally to avoid an import cycle with pkg/enterprise.
+type authProvider interface {
+	UsernameFromContext(ctx context.Context) (string, bool)
+}
 
 // spdxJSONMediaType is the IANA-registered media type for SPDX JSON documents.
 const spdxJSONMediaType = "application/spdx+json"
@@ -39,13 +47,15 @@ var availableFrom = semver.MustParse("1.11.0")
 type Frontend struct {
 	schematicFactory *schematic.Factory
 	spdxBuilder      *builder.Builder
+	authProvider     authProvider
 }
 
 // NewFrontend creates a new Frontend instance.
-func NewFrontend(schematicFactory *schematic.Factory, spdxBuilder *builder.Builder) *Frontend {
+func NewFrontend(schematicFactory *schematic.Factory, spdxBuilder *builder.Builder, auth authProvider) *Frontend {
 	return &Frontend{
 		schematicFactory: schematicFactory,
 		spdxBuilder:      spdxBuilder,
+		authProvider:     auth,
 	}
 }
 
@@ -59,6 +69,29 @@ func (f *Frontend) Methods() []string {
 	return []string{http.MethodGet, http.MethodHead}
 }
 
+// checkOwnership verifies the context user owns the schematic.
+// Returns nil if schematic has no owner or the authenticated user matches the owner.
+func (f *Frontend) checkOwnership(ctx context.Context, s *schematicpkg.Schematic) error {
+	if s.Owner == "" {
+		return nil
+	}
+
+	if f.authProvider == nil {
+		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	username, ok := f.authProvider.UsernameFromContext(ctx)
+	if !ok {
+		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	if username != s.Owner {
+		return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("access denied"))
+	}
+
+	return nil
+}
+
 // Handle implements enterprise.FrontendExtension.
 // It handles SPDX bundle download requests.
 //
@@ -70,8 +103,13 @@ func (f *Frontend) Methods() []string {
 func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
-	// Validate schematic exists
-	if _, err := f.schematicFactory.Get(ctx, schematicID); err != nil {
+	// Validate schematic exists and check ownership.
+	schematic, err := f.schematicFactory.Get(ctx, schematicID)
+	if err != nil {
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	cloud.google.com/go/auth v0.20.0
 	github.com/CalebQ42/squashfs v1.4.1
 	github.com/blang/semver/v4 v4.0.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-containerregistry v0.21.5
 	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/attestation v1.2.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/julienschmidt/httprouter v1.3.0
@@ -52,6 +54,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
+	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
@@ -126,7 +129,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/foxboron/go-uefi v0.0.0-20251010190908-d29549a44f29 // indirect
 	github.com/freddierice/go-losetup/v2 v2.0.1 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/g0rbe/go-chattr v1.0.1 // indirect
 	github.com/gertd/go-pluralize v0.2.1 // indirect
@@ -177,7 +179,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-envparse v0.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -270,7 +271,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect

--- a/hack/dev/compose.yaml
+++ b/hack/dev/compose.yaml
@@ -3,6 +3,8 @@ configs:
     file: config.yaml
   if_signing_key:
     file: ../../_out/cache-signing-key.key
+  # if_htpasswd:
+  #   file: htpasswd
 volumes:
   if-registry-ghcr-io-data:
   if-registry-local-data:
@@ -47,3 +49,5 @@ services:
         target: /etc/image-factory/config.yaml
       - source: if_signing_key
         target: /etc/image-factory/cache-signing-key.key
+      # - source: if_htpasswd
+      #   target: /etc/image-factory/htpasswd

--- a/hack/dev/config.yaml
+++ b/hack/dev/config.yaml
@@ -28,3 +28,7 @@ cache:
 http:
   # external URL the Image Factory is available at
   externalURL: http://localhost:8080
+
+# authentication:
+#   enabled: true
+#   htpasswdPath: /etc/image-factory/htpasswd

--- a/hack/dev/htpasswd
+++ b/hack/dev/htpasswd
@@ -1,0 +1,2 @@
+# htpasswd -cbB ./hack/dev/htpasswd developer SideroTest
+developer:$2y$05$Ga.JSlAzRE/CknCfprQgKel3uxo72oUP9VVwjiPWzVv6xzAn9QGuu

--- a/internal/artifacts/schematic.go
+++ b/internal/artifacts/schematic.go
@@ -39,7 +39,7 @@ func (m *Manager) GetSchematicExtension(ctx context.Context, versionTag string, 
 	var schematicInfo []byte
 
 	if quirks.New(versionTag).SupportsOverlay() {
-		schematicInfo, err = yaml.Marshal(schematic)
+		schematicInfo, err = schematic.Marshal()
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal schematic overlay info: %w", err)
 		}

--- a/internal/asset/cache/s3/s3.go
+++ b/internal/asset/cache/s3/s3.go
@@ -26,24 +26,26 @@ const (
 	// prefix for all asset IDs in the storage.
 	prefix = "assets"
 
-	// expires is the duration for which the presigned URL is valid.
-	expires = 24 * time.Hour
+	// defaultPresignedURLTTL is the fallback TTL for presigned URLs when none is configured.
+	defaultPresignedURLTTL = time.Hour
 )
 
 // Options contains options for the S3-compatible cache.
 type Options struct {
-	Bucket   string
-	Endpoint string
-	Region   string
-	Insecure bool
+	Bucket          string
+	Endpoint        string
+	Region          string
+	Insecure        bool
+	PresignedURLTTL time.Duration
 }
 
 // Cache is using S3-compatible storage to cache assets.
 type Cache struct {
-	signingCache cache.Cache
-	s3cli        *minio.Client
-	logger       *zap.Logger
-	bucketName   string
+	signingCache    cache.Cache
+	s3cli           *minio.Client
+	logger          *zap.Logger
+	bucketName      string
+	presignedURLTTL time.Duration
 }
 
 // Check interface.
@@ -58,6 +60,11 @@ func New(logger *zap.Logger, signingCache cache.Cache, options Options) (*Cache,
 		return nil, fmt.Errorf("registry cannot be nil")
 	}
 
+	ttl := options.PresignedURLTTL
+	if ttl <= 0 {
+		ttl = defaultPresignedURLTTL
+	}
+
 	c := &Cache{
 		logger: logger.With(
 			zap.String("component", "asset-cache-s3"),
@@ -65,8 +72,9 @@ func New(logger *zap.Logger, signingCache cache.Cache, options Options) (*Cache,
 			zap.String("s3.region", options.Region),
 			zap.String("s3.bucket", options.Bucket),
 		),
-		bucketName:   options.Bucket,
-		signingCache: signingCache,
+		bucketName:      options.Bucket,
+		signingCache:    signingCache,
+		presignedURLTTL: ttl,
 	}
 
 	var err error
@@ -137,7 +145,7 @@ func (c *Cache) Get(ctx context.Context, profileID string) (cache.BootAsset, err
 				reqParams.Set("response-content-disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 			}
 
-			redirect, err := c.s3cli.PresignedGetObject(ctx, c.bucketName, key, expires, reqParams)
+			redirect, err := c.s3cli.PresignedGetObject(ctx, c.bucketName, key, c.presignedURLTTL, reqParams)
 			if err != nil {
 				var minioErr minio.ErrorResponse
 				if errors.As(err, &minioErr) && minioErr.Code == minio.NoSuchKey {

--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -14,7 +14,7 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 
 	"github.com/siderolabs/image-factory/internal/schematic/storage"
-	"github.com/siderolabs/image-factory/pkg/schematic"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
 // handleSchematicCreate handles creation of the schematic.
@@ -28,12 +28,18 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
-	cfg, err := schematic.Unmarshal(data)
+	schematic, err := schematicpkg.Unmarshal(data)
 	if err != nil {
 		return err
 	}
 
-	id, err := f.schematicFactory.Put(ctx, cfg)
+	if f.options.AuthProvider != nil {
+		if username, ok := f.options.AuthProvider.UsernameFromContext(ctx); ok {
+			schematic.Owner = username
+		}
+	}
+
+	id, err := f.schematicFactory.Put(ctx, schematic)
 	if err != nil {
 		return err
 	}
@@ -62,6 +68,10 @@ func (f *Frontend) handleSchematicGet(ctx context.Context, w http.ResponseWriter
 			return nil
 		}
 
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -62,6 +62,7 @@ type Options struct {
 	CacheImageSigner                 signer.Signer
 	ExternalURL                      *url.URL
 	ExternalPXEURL                   *url.URL
+	AuthProvider                     enterprise.AuthProvider
 	InstallerInternalRepository      name.Repository
 	InstallerExternalRepository      name.Repository
 	MetricsNamespace                 string
@@ -70,6 +71,9 @@ type Options struct {
 	RegistryRefreshInterval          time.Duration
 	ProxyInstallerInternalRepository bool
 }
+
+// Handler is a custom handler type that includes the context and httprouter params, and returns an error.
+type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error
 
 // NewFrontend creates a new HTTP frontend.
 func NewFrontend(
@@ -114,8 +118,12 @@ func NewFrontend(
 		}),
 	})
 
-	registerRoute := func(registrator func(string, httprouter.Handle), path string, handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error) {
+	registerRoute := func(registrator func(string, httprouter.Handle), path string, handler Handler) {
 		registrator(path, httproutermiddleware.Handler(path, frontend.wrapper(handler), mdlw))
+	}
+
+	registerPublicRoute := func(registrator func(string, httprouter.Handle), path string, handler Handler) {
+		registrator(path, httproutermiddleware.Handler(path, frontend.wrapperPublic(handler), mdlw))
 	}
 
 	// enterprise
@@ -137,43 +145,45 @@ func NewFrontend(
 		}
 	}
 
-	// images
+	// /healthz is always public (Kubernetes probes, monitoring)
+	registerPublicRoute(frontend.router.GET, "/healthz", frontend.handleHealth)
+	registerPublicRoute(frontend.router.HEAD, "/healthz", frontend.handleHealth)
+
+	// images - require auth
 	registerRoute(frontend.router.GET, "/image/:schematic/:version/:path", frontend.handleImage)
 	registerRoute(frontend.router.HEAD, "/image/:schematic/:version/:path", frontend.handleImage)
 
-	// PXE
+	// PXE - require auth
 	registerRoute(frontend.router.GET, "/pxe/:schematic/:version/:path", frontend.handlePXE)
 
-	// registry
+	// registry - /v2 requires auth (OCI spec: 401 challenge when auth enabled)
 	registerRoute(frontend.router.GET, "/v2", frontend.handleHealth)
 	registerRoute(frontend.router.GET, "/v2/", frontend.handleHealth)
 	registerRoute(frontend.router.HEAD, "/v2", frontend.handleHealth)
 	registerRoute(frontend.router.HEAD, "/v2/", frontend.handleHealth)
-	registerRoute(frontend.router.GET, "/healthz", frontend.handleHealth)
-	registerRoute(frontend.router.HEAD, "/healthz", frontend.handleHealth)
 	registerRoute(frontend.router.GET, "/v2/:image/:schematic/blobs/:digest", frontend.handleBlob)
 	registerRoute(frontend.router.HEAD, "/v2/:image/:schematic/blobs/:digest", frontend.handleBlob)
 	registerRoute(frontend.router.GET, "/v2/:image/:schematic/manifests/:tag", frontend.handleManifest)
 	registerRoute(frontend.router.HEAD, "/v2/:image/:schematic/manifests/:tag", frontend.handleManifest)
-	registerRoute(frontend.router.GET, "/oci/cosign/signing-key.pub", frontend.handleCosignSigningKeyPub)
+	registerPublicRoute(frontend.router.GET, "/oci/cosign/signing-key.pub", frontend.handleCosignSigningKeyPub)
 
-	// schematic
+	// schematic - both POST and GET require auth
 	registerRoute(frontend.router.POST, "/schematics", frontend.handleSchematicCreate)
 	registerRoute(frontend.router.GET, "/schematics/:schematic", frontend.handleSchematicGet)
 
-	// meta
-	registerRoute(frontend.router.GET, "/versions", frontend.handleVersions)
-	registerRoute(frontend.router.GET, "/version/:version/extensions/official", frontend.handleOfficialExtensions)
-	registerRoute(frontend.router.GET, "/version/:version/overlays/official", frontend.handleOfficialOverlays)
+	// meta - public
+	registerPublicRoute(frontend.router.GET, "/versions", frontend.handleVersions)
+	registerPublicRoute(frontend.router.GET, "/version/:version/extensions/official", frontend.handleOfficialExtensions)
+	registerPublicRoute(frontend.router.GET, "/version/:version/overlays/official", frontend.handleOfficialOverlays)
 
-	// secureboot
-	registerRoute(frontend.router.GET, "/secureboot/signing-cert.pem", frontend.handleSecureBootSigningCert)
+	// secureboot - public
+	registerPublicRoute(frontend.router.GET, "/secureboot/signing-cert.pem", frontend.handleSecureBootSigningCert)
 
-	// talosctl
-	registerRoute(frontend.router.HEAD, "/talosctl/:version/:path", frontend.handleTalosctl)
-	registerRoute(frontend.router.GET, "/talosctl/:version/:path", frontend.handleTalosctl)
+	// talosctl - public
+	registerPublicRoute(frontend.router.HEAD, "/talosctl/:version/:path", frontend.handleTalosctl)
+	registerPublicRoute(frontend.router.GET, "/talosctl/:version/:path", frontend.handleTalosctl)
 
-	// UI
+	// UI - require auth (consistent with all other schematic-creating endpoints)
 	registerRoute(frontend.router.GET, "/", frontend.handleUI)
 	registerRoute(frontend.router.HEAD, "/", frontend.handleUI)
 	registerRoute(frontend.router.POST, "/ui/wizard", frontend.handleUIWizard)
@@ -201,7 +211,19 @@ func (f *Frontend) Handler() http.Handler {
 	}).Handler(f.router)
 }
 
-func (f *Frontend) wrapper(h func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error) httprouter.Handle {
+func (f *Frontend) wrapper(h Handler) httprouter.Handle {
+	return f.wrapHandler(h, true)
+}
+
+func (f *Frontend) wrapperPublic(h Handler) httprouter.Handle {
+	return f.wrapHandler(h, false)
+}
+
+func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
+	if requireAuth && f.options.AuthProvider != nil {
+		h = f.options.AuthProvider.Middleware(h)
+	}
+
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := r.Context()
 
@@ -214,6 +236,10 @@ func (f *Frontend) wrapper(h func(ctx context.Context, w http.ResponseWriter, r 
 		duration := time.Since(start)
 
 		level, status := MatchError(err, func(message string, code int) {
+			if code == http.StatusUnauthorized {
+				w.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise"`)
+			}
+
 			http.Error(w, message, code)
 		})
 
@@ -254,6 +280,16 @@ func MatchError(err error, callback func(message string, code int)) (zapcore.Lev
 		status = http.StatusBadRequest
 
 		callback(err.Error(), http.StatusBadRequest)
+	case xerrors.TagIs[schematicpkg.RequiresAuthenticationTag](err):
+		level = zap.WarnLevel
+		status = http.StatusUnauthorized
+
+		callback("authentication required to access this schematic", http.StatusUnauthorized)
+	case xerrors.TagIs[schematicpkg.ForbiddenTag](err):
+		level = zap.WarnLevel
+		status = http.StatusForbidden
+
+		callback("access denied", http.StatusForbidden)
 	case errors.Is(err, context.Canceled):
 		status = 499
 		// client closed connection
@@ -265,6 +301,29 @@ func MatchError(err error, callback func(message string, code int)) (zapcore.Lev
 	}
 
 	return level, status
+}
+
+// checkOwnership verifies the context user owns the schematic (for auth-protected routes).
+// Returns nil if schematic has no owner or the authenticated user matches the owner.
+func (f *Frontend) checkOwnership(ctx context.Context, s *schematicpkg.Schematic) error {
+	if s.Owner == "" {
+		return nil
+	}
+
+	if f.options.AuthProvider == nil {
+		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	username, ok := f.options.AuthProvider.UsernameFromContext(ctx)
+	if !ok {
+		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	if username != s.Owner {
+		return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("access denied"))
+	}
+
+	return nil
 }
 
 // Use several ways to detect language.

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -30,6 +30,8 @@ var checksumSuffixes = map[string]struct{}{
 }
 
 // handleImage handles downloading of boot assets.
+//
+//nolint:gocyclo,cyclop
 func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
@@ -61,6 +63,10 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 
 	schematic, err := f.schematicFactory.Get(ctx, schematicID)
 	if err != nil {
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 
@@ -107,7 +113,11 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		return f.checksummer.WriteChecksum(ctx, w, r, reader, asset.Size(), filename, checksumSuffix)
 	}
 
-	if asset, ok := asset.(cache.RedirectableAsset); ok && !disableRedirect && r.Method != http.MethodHead {
+	// When auth is active, never redirect to S3/CDN - bytes must flow through the
+	// factory so the auth boundary is maintained. S3/CDN URLs carry no user identity.
+	authActive := f.options.AuthProvider != nil
+
+	if asset, ok := asset.(cache.RedirectableAsset); ok && !disableRedirect && r.Method != http.MethodHead && !authActive {
 		var url string
 
 		url, err = asset.Redirect(ctx, filename)

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"text/template"
 
@@ -27,11 +28,15 @@ var standardIPXE string
 var securebootIPXE string
 
 // handlePXE delivers a PXE script to boot Talos.
-func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http.Request, p httprouter.Params) error {
+func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
 	schematic, err := f.schematicFactory.Get(ctx, schematicID)
 	if err != nil {
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 
@@ -76,6 +81,14 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 		return err
 	}
 
+	// Embed credentials in image asset URLs so iPXE can authenticate when fetching kernel/initramfs.
+	imageBaseURL := f.options.ExternalPXEURL
+	if username, password, ok := r.BasicAuth(); ok {
+		u := *f.options.ExternalPXEURL
+		u.User = url.UserPassword(username, password)
+		imageBaseURL = &u
+	}
+
 	if prof.SecureBootEnabled() {
 		return ensure.Value(template.New("secureboot.ipxe").
 			Parse(securebootIPXE)).
@@ -84,7 +97,7 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 					UKIURL  string
 					Cmdline string
 				}{
-					UKIURL:  f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("%s-%s-secureboot-uki.efi", prof.Platform, prof.Arch)).String(),
+					UKIURL:  imageBaseURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("%s-%s-secureboot-uki.efi", prof.Platform, prof.Arch)).String(),
 					Cmdline: string(cmdline),
 				},
 			)
@@ -98,9 +111,9 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, _ *http
 				Cmdline      string
 				InitramfsURL string
 			}{
-				KernelURL:    f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("kernel-%s", prof.Arch)).String(),
+				KernelURL:    imageBaseURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("kernel-%s", prof.Arch)).String(),
 				Cmdline:      string(cmdline),
-				InitramfsURL: f.options.ExternalPXEURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("initramfs-%s.xz", prof.Arch)).String(),
+				InitramfsURL: imageBaseURL.JoinPath("image", schematicID, versionTag, fmt.Sprintf("initramfs-%s.xz", prof.Arch)).String(),
 			},
 		)
 }

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -88,8 +88,12 @@ func (f *Frontend) handleBlob(ctx context.Context, w http.ResponseWriter, req *h
 	// verify that schematic exists
 	schematicID := p.ByName("schematic")
 
-	_, err := f.schematicFactory.Get(ctx, schematicID)
+	sc, err := f.schematicFactory.Get(ctx, schematicID)
 	if err != nil {
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, sc); err != nil {
 		return err
 	}
 
@@ -154,6 +158,10 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 
 	schematic, err := f.schematicFactory.Get(ctx, schematicID)
 	if err != nil {
+		return err
+	}
+
+	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -33,6 +33,35 @@ import (
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
+// placeholderURL wraps a *url.URL with an optional raw credential prefix for display.
+// When authInfo is non-empty (e.g. "user:<password>@"), String() injects it after "scheme://"
+// so that iPXE-context URLs show credential placeholders without URL-encoding angle brackets.
+type placeholderURL struct {
+	base     *url.URL
+	authInfo string
+}
+
+func newPlaceholderURL(base *url.URL, authInfo string) *placeholderURL {
+	return &placeholderURL{base: base, authInfo: authInfo}
+}
+
+func (p *placeholderURL) JoinPath(elem ...string) *placeholderURL {
+	return &placeholderURL{base: p.base.JoinPath(elem...), authInfo: p.authInfo}
+}
+
+func (p *placeholderURL) String() string {
+	s := p.base.String()
+	if p.authInfo == "" {
+		return s
+	}
+
+	if idx := strings.Index(s, "://"); idx != -1 {
+		return s[:idx+3] + p.authInfo + s[idx+3:]
+	}
+
+	return s
+}
+
 var templateFuncs template.FuncMap
 
 func init() {
@@ -544,6 +573,12 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 		},
 	}
 
+	if f.options.AuthProvider != nil {
+		if username, ok := f.options.AuthProvider.UsernameFromContext(ctx); ok {
+			requestedSchematic.Owner = username
+		}
+	}
+
 	if params.Bootloader != "" && params.Bootloader != "auto" {
 		bootloader, err := imageropts.BootloaderKindString(params.Bootloader)
 		if err != nil {
@@ -581,6 +616,18 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 		}
 	}
 
+	// Build PXE base URL with credential placeholder when auth is active,
+	// so the displayed URL shows the user they need to embed credentials for iPXE.
+	pxeBaseURL := newPlaceholderURL(f.options.ExternalPXEURL.JoinPath("pxe", schematicID, version), "")
+	if f.options.AuthProvider != nil {
+		if username, ok := f.options.AuthProvider.UsernameFromContext(ctx); ok {
+			pxeBaseURL = newPlaceholderURL(
+				f.options.ExternalPXEURL.JoinPath("pxe", schematicID, version),
+				username+":<password>@",
+			)
+		}
+	}
+
 	return "wizard-final",
 		struct {
 			WizardParams
@@ -589,7 +636,7 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 			Marshaled string
 
 			ImageBaseURL             *url.URL
-			PXEBaseURL               *url.URL
+			PXEBaseURL               *placeholderURL
 			TalosctlBaseURL          *url.URL
 			SPDXBaseURL              *url.URL
 			ChecksumBaseURL          *url.URL
@@ -610,7 +657,7 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 			Marshaled: string(marshaled),
 
 			ImageBaseURL:    f.options.ExternalURL.JoinPath("image", schematicID, version),
-			PXEBaseURL:      f.options.ExternalPXEURL.JoinPath("pxe", schematicID, version),
+			PXEBaseURL:      pxeBaseURL,
 			TalosctlBaseURL: f.options.ExternalURL.JoinPath("talosctl", version),
 
 			InstallerImage:           installerImage,

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -1,0 +1,470 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/pkg/client"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+// testAuthFrontend runs all auth sub-tests. Enforcement, public endpoint, and
+// ownership tests use the provided factory; reload spins up its own instance
+// because it needs direct control over the htpasswd file path.
+// Skipped entirely when enterprise features are disabled.
+func testAuthFrontend(ctx context.Context, t *testing.T, baseURL string) {
+	if !enterprise.Enabled() {
+		t.Skip("enterprise features are disabled")
+	}
+
+	t.Run("Enforcement", func(t *testing.T) {
+		t.Parallel()
+
+		testAuthEnforcement(ctx, t, baseURL)
+	})
+
+	t.Run("PublicEndpoints", func(t *testing.T) {
+		t.Parallel()
+
+		testPublicEndpoints(ctx, t, baseURL)
+	})
+
+	t.Run("Ownership", func(t *testing.T) {
+		t.Parallel()
+
+		testOwnership(ctx, t, baseURL)
+	})
+
+	t.Run("Reload", testAuthReload)
+}
+
+func testAuthEnforcement(ctx context.Context, t *testing.T, baseURL string) {
+	// Protected endpoints: registry /v2/*, schematics, and UI wizard.
+	// /healthz, /versions, and meta endpoints are public.
+	protectedEndpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/v2/"},
+		{http.MethodHead, "/v2/"},
+		{http.MethodGet, "/v2"},
+		{http.MethodHead, "/v2"},
+		{http.MethodPost, "/schematics"},
+		{http.MethodGet, "/schematics/" + nonexistentSchematicID},
+		{http.MethodGet, "/"},
+		{http.MethodHead, "/"},
+	}
+
+	t.Run("NoCredentials", func(t *testing.T) {
+		t.Parallel()
+
+		for _, ep := range protectedEndpoints {
+			t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequestWithContext(ctx, ep.method, baseURL+ep.path, bytes.NewReader([]byte("customization: {}")))
+				require.NoError(t, err)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+
+				t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+				assertRequiresAuth(t, resp)
+			})
+		}
+	})
+
+	t.Run("IncorrectCredentials", func(t *testing.T) {
+		t.Parallel()
+
+		username, password := authCredentials()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		req.SetBasicAuth(username, password+"wrong")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("CorrectCredentials", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		addTestAuth(req)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("HealthzIsPublic", func(t *testing.T) {
+		t.Parallel()
+
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			t.Run(method, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequestWithContext(ctx, method, baseURL+"/healthz", nil)
+				require.NoError(t, err)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+
+				t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+				assert.Equal(t, http.StatusOK, resp.StatusCode,
+					"/healthz must always be reachable without credentials")
+			})
+		}
+	})
+
+	t.Run("V2AuthChallenge", func(t *testing.T) {
+		t.Parallel()
+
+		// OCI Distribution Spec: unauthenticated GET /v2/ → 401 with WWW-Authenticate
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+
+		// Authenticated /v2/ must return 200
+		req2, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		addTestAuth(req2)
+
+		resp2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp2.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp2.StatusCode)
+	})
+}
+
+// testPublicEndpoints verifies that health, meta, and informational endpoints are
+// reachable without credentials even when auth is active.
+func testPublicEndpoints(ctx context.Context, t *testing.T, baseURL string) {
+	publicEndpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/healthz"},
+		{http.MethodGet, "/versions"},
+		{http.MethodGet, "/secureboot/signing-cert.pem"},
+		{http.MethodGet, "/oci/cosign/signing-key.pub"},
+	}
+
+	for _, ep := range publicEndpoints {
+		t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequestWithContext(ctx, ep.method, baseURL+ep.path, nil)
+			require.NoError(t, err)
+
+			// deliberately NO auth
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+			assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode,
+				"%s %s must be reachable without credentials", ep.method, ep.path)
+		})
+	}
+}
+
+// testAuthReload verifies that the provider hot-reloads the htpasswd file.
+// It adds a new user and removes an existing one, then polls until the change
+// propagates (up to 10 s - fsnotify usually fires within milliseconds).
+func testAuthReload(t *testing.T) {
+	t.Parallel()
+
+	options := cmd.DefaultOptions
+	options.Cache.OCI = cacheRepository.OCIRepositoryOptions
+	options.Metrics.Namespace = "test_auth_reload"
+
+	// Write the initial htpasswd to a path we control.
+	configDir := t.TempDir()
+	htpasswdPath := filepath.Join(configDir, "htpasswd")
+
+	require.NoError(t, os.WriteFile(htpasswdPath, htpasswdFile, 0o600))
+
+	// Pre-configure auth so setupEnterprise won't overwrite our path.
+	options.Authentication.Enabled = true
+	options.Authentication.HTPasswdPath = htpasswdPath
+
+	ctx, listenAddr, _ := setupFactory(t, options)
+	baseURL := "http://" + listenAddr
+
+	checkStatus := func(username, password string) int {
+		// Use /v2/ (registry discovery) - auth-protected endpoint that requires no body.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		req.SetBasicAuth(username, password)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		defer resp.Body.Close() //nolint:errcheck
+
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+		return resp.StatusCode
+	}
+
+	// Verify initial state.
+	require.Equal(t, http.StatusOK, checkStatus("alice", "alicetopsecret"),
+		"alice must authenticate before reload")
+	require.Equal(t, http.StatusUnauthorized, checkStatus("carol", "carolsecret"),
+		"carol must not exist before reload")
+
+	// Generate a fresh bcrypt hash for carol's password.
+	carolHash, err := bcrypt.GenerateFromPassword([]byte("carolsecret"), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	// New htpasswd: add carol, remove alice entirely.
+	newContent := fmt.Sprintf("carol:%s\n", carolHash)
+
+	require.NoError(t, os.WriteFile(htpasswdPath, []byte(newContent), 0o600))
+
+	// Poll for up to 10 s - fsnotify normally reacts within a few milliseconds.
+	deadline := time.Now().Add(10 * time.Second)
+	carolAuthed := false
+
+	for time.Now().Before(deadline) {
+		if checkStatus("carol", "carolsecret") == http.StatusOK {
+			carolAuthed = true
+
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.True(t, carolAuthed, "carol should authenticate within 10 s of htpasswd update")
+	require.Equal(t, http.StatusUnauthorized, checkStatus("alice", "alicetopsecret"),
+		"alice must be rejected after removal from htpasswd")
+}
+
+// testOwnership verifies that owned schematics are only accessible to their creator.
+// A schematic created by alice (via authenticated POST /schematics) should:
+//   - be inaccessible to unauthenticated requests (401)
+//   - be inaccessible to other authenticated users (403)
+//   - be accessible to alice (200)
+func testOwnership(ctx context.Context, t *testing.T, baseURL string) {
+	// Create a schematic as alice.
+	var ownedSchematicID string
+
+	{
+		c, err := client.New(baseURL, clientAuthCredentials()...)
+		require.NoError(t, err)
+
+		ownedSchematicID, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		require.NoError(t, err)
+	}
+
+	schematicURL := baseURL + "/schematics/" + ownedSchematicID
+
+	t.Run("GetSchematic_NoCredentials_401", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("GetSchematic_WrongOwner_403", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		req.SetBasicAuth("bob", "bobsecret")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("GetSchematic_Owner_200", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		addTestAuth(req)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// testAuthS3NoRedirect asserts that the factory serves assets directly (no
+// HTTP 302) when both S3 caching and authentication are active.
+// S3 credentials must already be set in the environment by the caller.
+func testAuthS3NoRedirect(t *testing.T, pool *dockertest.Pool) {
+	options := cmd.DefaultOptions
+	options.Cache.OCI = signingCacheRepository.OCIRepositoryOptions
+	options.Metrics.Namespace = "test_auth_s3_no_redirect"
+
+	options.Cache.S3.Enabled = true
+	options.Cache.S3.Bucket = "test-auth-s3"
+	options.Cache.S3.Insecure = true
+	options.Cache.S3.Endpoint = setupS3(t, pool, options.Cache.S3.Bucket)
+
+	ctx, listenAddr, _ := setupFactory(t, options)
+	baseURL := "http://" + listenAddr
+
+	// Ensure schematic exists.
+	{
+		c, err := client.New(baseURL, clientAuthCredentials()...)
+		require.NoError(t, err)
+
+		_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		require.NoError(t, err)
+	}
+
+	// First download - builds and caches the asset in S3.
+	resp := downloadAsset(ctx, t, baseURL, emptySchematicID, "v1.9.4", "kernel-amd64")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	// Second download - asset is in S3, but auth is active: must NOT redirect.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		baseURL+"/image/"+emptySchematicID+"/v1.9.4/kernel-amd64", nil)
+	require.NoError(t, err)
+
+	addTestAuth(req)
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return fmt.Errorf("unexpected S3 redirect to %s - auth active, factory must serve directly", req.URL)
+		},
+	}
+
+	resp2, err := noRedirectClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { resp2.Body.Close() }) //nolint:errcheck
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// testAuthCDNNoRedirect asserts that the factory never redirects to CDN URLs
+// when authentication is active. CDN URLs are fully public (no auth) so they
+// must never be issued from an auth-gated factory.
+// S3 credentials must already be set in the environment by the caller.
+func testAuthCDNNoRedirect(t *testing.T, pool *dockertest.Pool) {
+	options := cmd.DefaultOptions
+	options.Cache.OCI = signingCacheRepository.OCIRepositoryOptions
+	options.Metrics.Namespace = "test_auth_cdn_no_redirect"
+
+	options.Cache.S3.Enabled = true
+	options.Cache.S3.Bucket = "test-auth-cdn"
+	options.Cache.S3.Insecure = true
+	options.Cache.S3.Endpoint = setupS3(t, pool, options.Cache.S3.Bucket)
+
+	options.Cache.CDN.Enabled = true
+	options.Cache.CDN.TrimPrefix = fmt.Sprintf("/%s", options.Cache.S3.Bucket)
+	options.Cache.CDN.Host = setupMockCDN(t, pool, options.Cache.S3.Endpoint, options.Cache.S3.Bucket)
+
+	ctx, listenAddr, _ := setupFactory(t, options)
+	baseURL := "http://" + listenAddr
+
+	{
+		c, err := client.New(baseURL, clientAuthCredentials()...)
+		require.NoError(t, err)
+
+		_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		require.NoError(t, err)
+	}
+
+	// Build and cache the asset.
+	resp := downloadAsset(ctx, t, baseURL, emptySchematicID, "v1.9.4", "kernel-amd64")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	// Cached asset available via CDN, but auth active - must NOT redirect.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		baseURL+"/image/"+emptySchematicID+"/v1.9.4/kernel-amd64", nil)
+	require.NoError(t, err)
+
+	addTestAuth(req)
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return fmt.Errorf("unexpected CDN redirect to %s - auth active, factory must never redirect to CDN", req.URL)
+		},
+	}
+
+	resp2, err := noRedirectClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { resp2.Body.Close() }) //nolint:errcheck
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// assertRequiresAuth checks that the response is 401 with WWW-Authenticate set,
+// as required by RFC 7235 and the OCI Distribution Spec.
+func assertRequiresAuth(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.NotEmpty(t, resp.Header.Get("WWW-Authenticate"),
+		"401 response must include WWW-Authenticate header")
+}

--- a/internal/integration/checksum_test.go
+++ b/internal/integration/checksum_test.go
@@ -32,6 +32,8 @@ func downloadChecksum(ctx context.Context, t *testing.T, baseURL, schematicID, v
 	req, err := http.NewRequestWithContext(ctx, method, baseURL+"/image/"+schematicID+"/"+version+"/"+path+suffix, nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 

--- a/internal/integration/download_test.go
+++ b/internal/integration/download_test.go
@@ -39,6 +39,8 @@ func downloadAsset(ctx context.Context, t *testing.T, baseURL string, schematicI
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/image/"+schematicID+"/"+talosVersion+"/"+path, nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
@@ -61,6 +63,8 @@ func downloadAssetWithFilename(ctx context.Context, t *testing.T, baseURL string
 
 	req.URL.RawQuery = query.Encode()
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
@@ -76,6 +80,8 @@ func downloadNoRedirect(ctx context.Context, t *testing.T, url string) *http.Res
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err, url)
+
+	addTestAuth(req)
 
 	noRedirectClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -177,6 +183,8 @@ func checkCors(ctx context.Context, t *testing.T, baseURL, schematicID, talosVer
 		}
 
 		req.Header.Set("Origin", "https://foo.com")
+
+		addTestAuth(req)
 
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -387,9 +395,7 @@ func schematicExtraInfo(t *testing.T, schematicID string, talosVersion string) s
 		return ""
 	}
 
-	schematic := must.Value(testSchematics[schematicID].Marshal())(t)
-
-	return string(schematic)
+	return string(must.Value(testSchematics[schematicID].Marshal())(t))
 }
 
 func sizePicker(talosVersion string, v ...any) int64 {
@@ -872,7 +878,7 @@ func testDownloadFrontend(ctx context.Context, t *testing.T, baseURL string) {
 				initramfsSpec{
 					schematicID:        rpiGenericOverlaySchematicID,
 					skipMlxfw:          true,
-					schematicExtraInfo: string(must.Value(testSchematics[rpiGenericOverlaySchematicID].Marshal())(t)),
+					schematicExtraInfo: schematicExtraInfo(t, rpiGenericOverlaySchematicID, talosVersion),
 				},
 			)
 		})

--- a/internal/integration/frontend_test.go
+++ b/internal/integration/frontend_test.go
@@ -11,31 +11,81 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/image-factory/pkg/enterprise"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
-func testFrontend(ctx context.Context, t *testing.T, baseURL string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, baseURL+"/", nil)
-	require.NoError(t, err)
+func testFrontend(ctx context.Context, baseURL string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+		t.Run("Server Header", func(t *testing.T) {
+			t.Parallel()
 
-	t.Cleanup(func() {
-		require.NoError(t, resp.Body.Close())
-	})
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, baseURL+"/", nil)
+			require.NoError(t, err)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+			addTestAuth(req)
 
-	server := resp.Header.Get("Server")
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
 
-	if enterprise.Enabled() {
-		assert.Contains(t, server, "Image Factory Enterprise")
-	} else {
-		assert.Contains(t, server, "Image Factory")
-		assert.NotContains(t, server, "Enterprise")
+			t.Cleanup(func() {
+				require.NoError(t, resp.Body.Close())
+			})
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			server := resp.Header.Get("Server")
+
+			if enterprise.Enabled() {
+				assert.Contains(t, server, "Image Factory Enterprise")
+			} else {
+				assert.Contains(t, server, "Image Factory")
+				assert.NotContains(t, server, "Enterprise")
+			}
+		})
+
+		t.Run("Auth", testFrontendAuth(ctx, baseURL))
+	}
+}
+
+func testFrontendAuth(ctx context.Context, baseURL string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		if !enterprise.Enabled() {
+			t.Skip("enterprise features are disabled")
+		}
+
+		t.Run("Correct Credentials", func(t *testing.T) {
+			t.Parallel()
+
+			// POST /schematics requires auth; verify correct credentials allow access.
+			c, err := client.New(baseURL, clientAuthCredentials()...)
+			require.NoError(t, err)
+
+			_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+			require.NoError(t, err)
+		})
+
+		t.Run("Incorrect Credentials", func(t *testing.T) {
+			t.Parallel()
+
+			username, password := authCredentials()
+			password += "x"
+
+			// /versions is now public; use SchematicCreate (POST /schematics) which requires auth.
+			c, err := client.New(baseURL, client.WithBasicAuth(username, password))
+			require.NoError(t, err)
+
+			_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+			require.Error(t, err)
+			require.ErrorContains(t, err, "HTTP 401: authentication required")
+		})
 	}
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
+	"github.com/siderolabs/image-factory/pkg/client"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 )
 
 func setupFactory(t *testing.T, options cmd.Options) (context.Context, string, string) {
@@ -48,6 +50,10 @@ func setupFactory(t *testing.T, options cmd.Options) (context.Context, string, s
 	options.HTTP.ListenAddr = net.JoinHostPort(host, port)
 	options.HTTP.ExternalURL = "http://" + defaultAddr + "/"
 	options.HTTP.ExternalPXEURL = "http://" + pxeAddr + "/"
+
+	_, metricsPort := findListenAddr(t, "127.0.0.1")
+	options.Metrics.Addr = net.JoinHostPort("127.0.0.1", metricsPort)
+
 	options.Artifacts.Core.Registry = imageRegistryFlag
 	options.Artifacts.Schematic = schematicFactoryRepositoryFlag.OCIRepositoryOptions
 	options.Artifacts.Installer.External = installerExternalRepository.OCIRepositoryOptions
@@ -56,6 +62,7 @@ func setupFactory(t *testing.T, options cmd.Options) (context.Context, string, s
 
 	setupSecureBoot(t, &options)
 	setupCacheSigningKey(t, &options)
+	setupEnterprise(t, &options)
 
 	t.Cleanup(remotewrap.ShutdownTransport)
 
@@ -234,6 +241,58 @@ func setupSecureBoot(t *testing.T, options *cmd.Options) {
 	}
 }
 
+//go:embed "testdata/htpasswd"
+var htpasswdFile []byte
+
+func setupEnterprise(t *testing.T, options *cmd.Options) {
+	t.Helper()
+
+	if !enterprise.Enabled() {
+		return
+	}
+
+	// Skip if the caller already configured auth (e.g. reload tests that need
+	// explicit control over the htpasswd file path).
+	if options.Authentication.Enabled && options.Authentication.HTPasswdPath != "" {
+		return
+	}
+
+	configDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "htpasswd"), htpasswdFile, 0o600))
+
+	options.Authentication.Enabled = true
+	options.Authentication.HTPasswdPath = filepath.Join(configDir, "htpasswd")
+}
+
+func authCredentials() (string, string) {
+	if !enterprise.Enabled() {
+		return "", ""
+	}
+
+	return "alice", "alicetopsecret"
+}
+
+// addTestAuth sets BasicAuth on req when enterprise auth is active.
+func addTestAuth(req *http.Request) {
+	username, password := authCredentials()
+	if username != "" {
+		req.SetBasicAuth(username, password)
+	}
+}
+
+func clientAuthCredentials() []client.Option {
+	username, password := authCredentials()
+
+	if username != "" && password != "" {
+		return []client.Option{
+			client.WithBasicAuth(username, password),
+		}
+	}
+
+	return nil
+}
+
 func findListenAddr(t *testing.T, host string) (string, string) {
 	t.Helper()
 
@@ -255,11 +314,7 @@ func commonTest(t *testing.T, options cmd.Options) {
 	baseURL := "http://" + listenAddr
 	pxeURL := "http://" + pxeAddr
 
-	t.Run("TestFrontend", func(t *testing.T) {
-		t.Parallel()
-
-		testFrontend(ctx, t, baseURL)
-	})
+	t.Run("TestFrontend", testFrontend(ctx, baseURL))
 
 	t.Run("TestSchematic", func(t *testing.T) {
 		// schematic should be created first, thus no t.Parallel
@@ -312,6 +367,12 @@ func commonTest(t *testing.T, options cmd.Options) {
 		t.Parallel()
 
 		testChecksumFrontend(ctx, t, baseURL)
+	})
+
+	t.Run("TestAuthFrontend", func(t *testing.T) {
+		t.Parallel()
+
+		testAuthFrontend(ctx, t, baseURL)
 	})
 }
 

--- a/internal/integration/main_cdn_test.go
+++ b/internal/integration/main_cdn_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 )
 
 func TestIntegrationCDN(t *testing.T) {
@@ -37,4 +38,10 @@ func TestIntegrationCDN(t *testing.T) {
 
 		commonTest(t, options)
 	})
+
+	if enterprise.Enabled() {
+		t.Run("AuthCDNNoRedirect", func(t *testing.T) {
+			testAuthCDNNoRedirect(t, pool)
+		})
+	}
 }

--- a/internal/integration/main_s3_test.go
+++ b/internal/integration/main_s3_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 )
 
 func TestIntegrationS3(t *testing.T) {
@@ -32,4 +33,10 @@ func TestIntegrationS3(t *testing.T) {
 
 		commonTest(t, options)
 	})
+
+	if enterprise.Enabled() {
+		t.Run("AuthS3NoRedirect", func(t *testing.T) {
+			testAuthS3NoRedirect(t, pool)
+		})
+	}
 }

--- a/internal/integration/meta_test.go
+++ b/internal/integration/meta_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func testMetaFrontend(ctx context.Context, t *testing.T, baseURL string) {
-	c, err := client.New(baseURL)
+	c, err := client.New(baseURL, clientAuthCredentials()...)
 	require.NoError(t, err)
 
 	t.Run("versions", func(t *testing.T) {

--- a/internal/integration/pxe_test.go
+++ b/internal/integration/pxe_test.go
@@ -11,12 +11,15 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 )
 
 func downloadPXE(ctx context.Context, t *testing.T, baseURL string, schematicID, talosVersion, path string) string {
@@ -24,6 +27,8 @@ func downloadPXE(ctx context.Context, t *testing.T, baseURL string, schematicID,
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/pxe/"+schematicID+"/"+talosVersion+"/"+path, nil)
 	require.NoError(t, err)
+
+	addTestAuth(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -94,6 +99,19 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) 
 		securebootExpected      = "#!ipxe\n\nimgfree\nkernel ENDPOINT/image/CONFIG/VERSION/metal-amd64-secureboot-uki.efi talos.platform=metal console=ttyS0 console=tty0 init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on ima_template=ima-ng ima_appraise=fix ima_hash=sha512 lockdown=confidentiality\nboot\n"
 	)
 
+	// When enterprise auth is active the PXE handler embeds credentials into
+	// image asset URLs so iPXE can authenticate when fetching kernel/initramfs.
+	expectedPXEURL := pxeURL
+	if enterprise.Enabled() {
+		username, password := authCredentials()
+		if username != "" {
+			if u, err := url.Parse(pxeURL); err == nil {
+				u.User = url.UserPassword(username, password)
+				expectedPXEURL = u.String()
+			}
+		}
+	}
+
 	for _, talosVersion := range talosVersions {
 		t.Run(talosVersion, func(t *testing.T) {
 			t.Parallel()
@@ -106,7 +124,7 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) 
 				assert.Equal(t,
 					strings.ReplaceAll(
 						strings.ReplaceAll(
-							strings.ReplaceAll(fixupCmdline(metalInsecureExpected, talosVersion), "ENDPOINT", pxeURL),
+							strings.ReplaceAll(fixupCmdline(metalInsecureExpected, talosVersion), "ENDPOINT", expectedPXEURL),
 							"CONFIG", emptySchematicID,
 						),
 						"VERSION", talosVersion,
@@ -125,7 +143,7 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) 
 				assert.Equal(t,
 					strings.ReplaceAll(
 						strings.ReplaceAll(
-							strings.ReplaceAll(fixupCmdline(metalInsecureExpected, talosVersion), "ENDPOINT", pxeURL),
+							strings.ReplaceAll(fixupCmdline(metalInsecureExpected, talosVersion), "ENDPOINT", expectedPXEURL),
 							"CONFIG", emptySchematicID,
 						),
 						"VERSION", talosVersion,
@@ -144,7 +162,7 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) 
 				assert.Equal(t,
 					strings.ReplaceAll(
 						strings.ReplaceAll(
-							strings.ReplaceAll(fixupCmdline(equinixInsecureExpected, talosVersion), "ENDPOINT", pxeURL),
+							strings.ReplaceAll(fixupCmdline(equinixInsecureExpected, talosVersion), "ENDPOINT", expectedPXEURL),
 							"CONFIG", emptySchematicID,
 						),
 						"VERSION", talosVersion,
@@ -163,7 +181,7 @@ func testPXEFrontend(ctx context.Context, t *testing.T, baseURL, pxeURL string) 
 				assert.Equal(t,
 					strings.ReplaceAll(
 						strings.ReplaceAll(
-							strings.ReplaceAll(fixupCmdline(securebootExpected, talosVersion), "ENDPOINT", pxeURL),
+							strings.ReplaceAll(fixupCmdline(securebootExpected, talosVersion), "ENDPOINT", expectedPXEURL),
 							"CONFIG", emptySchematicID,
 						),
 						"VERSION", talosVersion,

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -27,6 +28,7 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +38,20 @@ import (
 	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
+
+func ociRemoteAuthOpts() []remote.Option {
+	username, password := authCredentials()
+	if username == "" {
+		return nil
+	}
+
+	return []remote.Option{
+		remote.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: username,
+			Password: password,
+		})),
+	}
+}
 
 func testInstallerImage(ctx context.Context, t *testing.T, registry name.Registry, talosVersion, schematic string, secureboot bool, platform v1.Platform, baseURL string, overlay bool) {
 	imageName := "installer"
@@ -47,10 +63,10 @@ func testInstallerImage(ctx context.Context, t *testing.T, registry name.Registr
 
 	q := quirks.New(talosVersion)
 
-	_, err := remote.Head(ref)
+	_, err := remote.Head(ref, ociRemoteAuthOpts()...)
 	require.NoError(t, err)
 
-	descriptor, err := remote.Get(ref, remote.WithPlatform(platform))
+	descriptor, err := remote.Get(ref, append(ociRemoteAuthOpts(), remote.WithPlatform(platform))...)
 	require.NoError(t, err)
 
 	index, err := descriptor.ImageIndex()
@@ -117,7 +133,7 @@ func testInstallerImage(ctx context.Context, t *testing.T, registry name.Registr
 	// try to get the image once again, it should be fast now, as the image got cached & signed
 	start := time.Now()
 
-	_, err = remote.Get(ref, remote.WithPlatform(platform))
+	_, err = remote.Get(ref, append(ociRemoteAuthOpts(), remote.WithPlatform(platform))...)
 	require.NoError(t, err)
 
 	assert.Less(t, time.Since(start), 1*time.Second)
@@ -172,6 +188,8 @@ func assertImageSignature(ctx context.Context, t *testing.T, ref name.Reference,
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/oci/cosign/signing-key.pub", nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
@@ -190,11 +208,17 @@ func assertImageSignature(ctx context.Context, t *testing.T, ref name.Reference,
 	verifier, err := signature.LoadVerifier(pubKey, crypto.SHA256)
 	require.NoError(t, err)
 
+	var registryClientOpts []ociremote.Option
+	if opts := ociRemoteAuthOpts(); len(opts) > 0 {
+		registryClientOpts = append(registryClientOpts, ociremote.WithRemoteOptions(opts...))
+	}
+
 	checkOpts := &cosign.CheckOpts{
-		SigVerifier: verifier,
-		IgnoreSCT:   true,
-		IgnoreTlog:  true,
-		Offline:     true,
+		SigVerifier:        verifier,
+		IgnoreSCT:          true,
+		IgnoreTlog:         true,
+		Offline:            true,
+		RegistryClientOpts: registryClientOpts,
 	}
 
 	_, _, err = cosign.VerifyImageSignatures(ctx, ref, checkOpts)
@@ -213,7 +237,7 @@ func testRegistryFrontend(ctx context.Context, t *testing.T, registryAddr string
 	registry, err := name.NewRegistry(registryAddr)
 	require.NoError(t, err)
 
-	c, err := client.New("http://" + registryAddr)
+	c, err := client.New("http://"+registryAddr, clientAuthCredentials()...)
 	require.NoError(t, err)
 
 	// create a new random schematic, so that we can make sure new installer is generated

--- a/internal/integration/schematic_test.go
+++ b/internal/integration/schematic_test.go
@@ -23,70 +23,69 @@ import (
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
-// well known schematic IDs, they will be created with the test run
-const (
-	emptySchematicID                    = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
-	nonexistentSchematicID              = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	extraArgsSchematicID                = "e0fb1129bbbdfb5d002e94af4cdce712a8370e850950a33a242d4c3f178c532d"
-	systemExtensionsSchematicID         = "51ff3e49313773332729a5c04e57af0dbe2e6d3f65ff638e6d4c3a05065fefff"
-	metaSchematicID                     = "fe866116408a5a13dab7d5003eb57a00954ea81ebeec3fbbcd1a6d4462a00036"
-	rpiGenericOverlaySchematicID        = "ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9"
-	securebootWellKnownSchematicID      = "fa8e05f142a851d3ee568eb0a8e5841eaf6b0ebc8df9a63df16ac5ed2c04f3e6"
-	grubBootloaderOverrideSchematicID   = "39d496b2cbdb6265d3b714514c5334bf010f1b4d31b23b9e38c80fb2f3ad7ecb"
-	sdBootBootloaderOverrideSchematicID = "9ed5fecdacb36b5c5427b87d409f1065cfb2df69b0f71c58b868d9d466d8dab3"
+// nonexistentSchematicID is a fixed ID that will never be created.
+const nonexistentSchematicID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+// Schematic IDs are computed at init time because in enterprise builds the owner
+// is embedded in the schematic YAML before hashing, changing the resulting ID.
+var (
+	emptySchematicID                    string
+	extraArgsSchematicID                string
+	systemExtensionsSchematicID         string
+	metaSchematicID                     string
+	rpiGenericOverlaySchematicID        string
+	securebootWellKnownSchematicID      string
+	grubBootloaderOverrideSchematicID   string
+	sdBootBootloaderOverrideSchematicID string
+
+	testSchematics map[string]*schematic.Schematic
 )
 
-var testSchematics = map[string]*schematic.Schematic{
-	emptySchematicID: {},
-	extraArgsSchematicID: {
-		Customization: schematic.Customization{
-			ExtraKernelArgs: []string{"nolapic", "nomodeset"},
-		},
-	},
-	systemExtensionsSchematicID: {
-		Customization: schematic.Customization{
-			SystemExtensions: schematic.SystemExtensions{
-				OfficialExtensions: []string{
-					"siderolabs/amd-ucode",
-					"siderolabs/gvisor",
-					"siderolabs/gasket-driver",
-				},
-			},
-		},
-	},
-	metaSchematicID: {
-		Customization: schematic.Customization{
-			Meta: []schematic.MetaValue{
-				{
-					Key:   0xa,
-					Value: `{"externalIPs":["1.2.3.4"]}`,
-				},
-			},
-		},
-	},
-	rpiGenericOverlaySchematicID: {
-		Overlay: schematic.Overlay{
-			Name:  "rpi_generic",
-			Image: "siderolabs/sbc-raspberrypi",
-		},
-	},
-	securebootWellKnownSchematicID: {
-		Customization: schematic.Customization{
-			SecureBoot: schematic.SecureBootCustomization{
-				IncludeWellKnownCertificates: true,
-			},
-		},
-	},
-	grubBootloaderOverrideSchematicID: {
-		Customization: schematic.Customization{
-			Bootloader: profile.BootLoaderKindGrub,
-		},
-	},
-	sdBootBootloaderOverrideSchematicID: {
-		Customization: schematic.Customization{
-			Bootloader: profile.BootLoaderKindSDBoot,
-		},
-	},
+func mustSchematicID(s *schematic.Schematic) string {
+	id, err := s.ID()
+	if err != nil {
+		panic("computing schematic ID: " + err.Error())
+	}
+
+	return id
+}
+
+func init() {
+	// In enterprise builds, schematics created via the authenticated API include the
+	// owner in their YAML, which changes the SHA-256 ID. Pre-set the owner here so
+	// the IDs computed in tests match what the server will return.
+	owner, _ := authCredentials()
+
+	raw := []*schematic.Schematic{
+		{Owner: owner},
+		{Owner: owner, Customization: schematic.Customization{ExtraKernelArgs: []string{"nolapic", "nomodeset"}}},
+		{Owner: owner, Customization: schematic.Customization{SystemExtensions: schematic.SystemExtensions{OfficialExtensions: []string{"siderolabs/amd-ucode", "siderolabs/gvisor", "siderolabs/gasket-driver"}}}},
+		{Owner: owner, Customization: schematic.Customization{Meta: []schematic.MetaValue{{Key: 0xa, Value: `{"externalIPs":["1.2.3.4"]}`}}}},
+		{Owner: owner, Overlay: schematic.Overlay{Name: "rpi_generic", Image: "siderolabs/sbc-raspberrypi"}},
+		{Owner: owner, Customization: schematic.Customization{SecureBoot: schematic.SecureBootCustomization{IncludeWellKnownCertificates: true}}},
+		{Owner: owner, Customization: schematic.Customization{Bootloader: profile.BootLoaderKindGrub}},
+		{Owner: owner, Customization: schematic.Customization{Bootloader: profile.BootLoaderKindSDBoot}},
+	}
+
+	testSchematics = make(map[string]*schematic.Schematic, len(raw))
+
+	emptySchematicID = mustSchematicID(raw[0])
+	extraArgsSchematicID = mustSchematicID(raw[1])
+	systemExtensionsSchematicID = mustSchematicID(raw[2])
+	metaSchematicID = mustSchematicID(raw[3])
+	rpiGenericOverlaySchematicID = mustSchematicID(raw[4])
+	securebootWellKnownSchematicID = mustSchematicID(raw[5])
+	grubBootloaderOverrideSchematicID = mustSchematicID(raw[6])
+	sdBootBootloaderOverrideSchematicID = mustSchematicID(raw[7])
+
+	testSchematics[emptySchematicID] = raw[0]
+	testSchematics[extraArgsSchematicID] = raw[1]
+	testSchematics[systemExtensionsSchematicID] = raw[2]
+	testSchematics[metaSchematicID] = raw[3]
+	testSchematics[rpiGenericOverlaySchematicID] = raw[4]
+	testSchematics[securebootWellKnownSchematicID] = raw[5]
+	testSchematics[grubBootloaderOverrideSchematicID] = raw[6]
+	testSchematics[sdBootBootloaderOverrideSchematicID] = raw[7]
 }
 
 func createSchematicGetID(ctx context.Context, t *testing.T, c *client.Client, schematic schematic.Schematic) string {
@@ -95,9 +94,10 @@ func createSchematicGetID(ctx context.Context, t *testing.T, c *client.Client, s
 	id, err := c.SchematicCreate(ctx, schematic)
 	require.NoError(t, err)
 
-	// get the shematic back and compare
+	// get the schematic back and compare
 	retrieved, err := c.SchematicGet(ctx, id)
 	require.NoError(t, err)
+	schematic.Owner, _ = authCredentials()
 	assert.Equal(t, &schematic, retrieved)
 
 	return id
@@ -109,6 +109,8 @@ func createSchematicInvalid(ctx context.Context, t *testing.T, baseURL string, m
 
 	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/schematics", bytes.NewReader(marshalled))
 	require.NoError(t, err)
+
+	addTestAuth(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -124,7 +126,7 @@ func createSchematicInvalid(ctx context.Context, t *testing.T, baseURL string, m
 }
 
 func testSchematic(ctx context.Context, t *testing.T, baseURL string) {
-	c, err := client.New(baseURL)
+	c, err := client.New(baseURL, clientAuthCredentials()...)
 	require.NoError(t, err)
 
 	t.Run("empty", func(t *testing.T) {

--- a/internal/integration/secureboot_test.go
+++ b/internal/integration/secureboot_test.go
@@ -22,6 +22,8 @@ func getSecureBootCert(ctx context.Context, t *testing.T, baseURL string) []byte
 	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/secureboot/signing-cert.pem", nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 

--- a/internal/integration/spdx_test.go
+++ b/internal/integration/spdx_test.go
@@ -30,6 +30,8 @@ func downloadSPDX(ctx context.Context, t *testing.T, baseURL, schematicID, versi
 	req, err := http.NewRequestWithContext(ctx, method, baseURL+"/spdx/"+schematicID+"/"+version+"/"+arch, nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 

--- a/internal/integration/talosctl_test.go
+++ b/internal/integration/talosctl_test.go
@@ -36,6 +36,8 @@ func downloadTalosctl(ctx context.Context, t *testing.T, baseURL string, talosVe
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/talosctl/"+talosVersion+"/"+path, nil)
 	require.NoError(t, err)
 
+	addTestAuth(req)
+
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 

--- a/internal/integration/testdata/htpasswd
+++ b/internal/integration/testdata/htpasswd
@@ -1,0 +1,6 @@
+# Fixture for authentication configuration in the integration tests.
+# alice has two passwords: alicesecret and alicetopsecret
+alice:$2a$10$IncF6ZgOKkwL5YrZQZWbb.cxyVnhYj0PZLoTADMmZ9dRNBE0G5XwW
+alice:$2a$10$4BZEQoTTUw0a/OXXjTcZMOcfI1Vd33YifMbqhJTurunWXgCuzdIxm
+# bob has one password: bobsecret
+bob:$2a$10$U9nvzVw56UlJKsnkREoDzessssxqkN0Cck4IecOOZMD.LzaRvNVbG

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -36,8 +37,9 @@ type OverlayInfo struct {
 
 // Client is the Image Factory HTTP API client.
 type Client struct {
-	baseURL *url.URL
-	client  http.Client
+	baseURL      *url.URL
+	extraHeaders http.Header
+	client       http.Client
 }
 
 // New creates a new Image Factory API client.
@@ -50,8 +52,9 @@ func New(baseURL string, options ...Option) (*Client, error) {
 	}
 
 	c := &Client{
-		baseURL: bURL,
-		client:  opts.Client,
+		baseURL:      bURL,
+		client:       opts.Client,
+		extraHeaders: opts.ExtraHeaders,
 	}
 
 	return c, nil
@@ -140,6 +143,8 @@ func (c *Client) do(ctx context.Context, method, uri string, requestData []byte,
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
+
+	maps.Copy(req.Header, c.extraHeaders)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -4,10 +4,15 @@
 
 package client
 
-import "net/http"
+import (
+	"encoding/base64"
+	"net/http"
+)
 
 // Options defines client options.
 type Options struct {
+	// ExtraHeaders represents extra headers to be added to each request.
+	ExtraHeaders http.Header
 	// Client is the http client.
 	Client http.Client
 }
@@ -19,6 +24,19 @@ type Option func(*Options)
 func WithClient(client http.Client) Option {
 	return func(o *Options) {
 		o.Client = client
+	}
+}
+
+// WithBasicAuth adds basic authentication to each request.
+func WithBasicAuth(username, password string) Option {
+	return func(o *Options) {
+		if o.ExtraHeaders == nil {
+			o.ExtraHeaders = http.Header{}
+		}
+
+		auth := username + ":" + password
+
+		o.ExtraHeaders.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 	}
 }
 

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -33,6 +33,7 @@ type SPDXOptions struct {
 	SchematicFactory        *schematic.Factory
 	ArtifactsManager        *artifacts.Manager
 	AssetBuilder            *asset.Builder
+	AuthProvider            AuthProvider
 	CacheRepository         string
 	RemoteOptions           []remote.Option
 	RegistryRefreshInterval time.Duration
@@ -52,4 +53,22 @@ type ErrNotEnabledTag struct{}
 // ".sha256", ".md5") and determines both the algorithm and the output filename.
 type Checksummer interface {
 	WriteChecksum(ctx context.Context, w http.ResponseWriter, r *http.Request, reader io.ReadCloser, size int64, filename, suffix string) error
+}
+
+// Handler is the type of HTTP handlers used by the enterprise frontend.
+type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error
+
+// AuthProvider defines an authentication provider.
+type AuthProvider interface {
+	// Run starts the background reload loop and blocks until ctx is canceled.
+	Run(ctx context.Context) error
+
+	// Middleware returns an HTTP middleware that enforces authentication on the provided handler.
+	Middleware(Handler) Handler
+
+	// VerifyCredentials checks if the username/password pair is valid.
+	VerifyCredentials(username, password string) bool
+
+	// UsernameFromContext retrieves the authenticated username stored by the middleware.
+	UsernameFromContext(ctx context.Context) (string, bool)
 }

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -26,3 +26,8 @@ func NewSpdxFrontend(_ *zap.Logger, _ SPDXOptions) (FrontendPlugin, error) {
 func NewChecksummer() Checksummer {
 	return nil
 }
+
+// NewAuthProvider creates a new authentication provider.
+func NewAuthProvider(_ *zap.Logger, _ string) (AuthProvider, error) {
+	return nil, errors.New("authentication is not supported in the non-enterprise version")
+}

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -8,55 +8,20 @@ package enterprise
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/image-factory/enterprise/auth"
 	"github.com/siderolabs/image-factory/enterprise/checksum"
 	"github.com/siderolabs/image-factory/enterprise/spdx"
 	"github.com/siderolabs/image-factory/enterprise/spdx/builder"
 	"github.com/siderolabs/image-factory/enterprise/spdx/storage/registry"
-	"github.com/siderolabs/image-factory/internal/image/signer"
 )
 
 // Enabled indicates whether Enterprise features are enabled.
 func Enabled() bool {
 	return true
-}
-
-// NewSpdxStorage initializes and returns a new SPDX storage instance.
-func NewSpdxStorage(
-	logger *zap.Logger,
-	cacheImageSigner signer.Signer,
-	insecure bool,
-	repository string,
-	refreshInterval time.Duration,
-	remoteOptions func() []remote.Option,
-) (*registry.Storage, error) {
-	var repoOpts []name.Option
-
-	if insecure {
-		repoOpts = append(repoOpts, name.Insecure)
-	}
-
-	cacheRepository, err := name.NewRepository(repository, repoOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cache repository: %w", err)
-	}
-
-	spdxStorage, err := registry.NewStorage(logger, registry.Options{
-		CacheRepository:         cacheRepository,
-		CacheImageSigner:        cacheImageSigner,
-		RemoteOptions:           remoteOptions(),
-		RegistryRefreshInterval: refreshInterval,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize SPDX storage: %w", err)
-	}
-
-	return spdxStorage, nil
 }
 
 // NewSpdxFrontend returns a new Spdx FrontendPlugin.
@@ -89,10 +54,15 @@ func NewSpdxFrontend(logger *zap.Logger, opts SPDXOptions) (FrontendPlugin, erro
 		AssetBuilder:     opts.AssetBuilder,
 	})
 
-	return spdx.NewFrontend(opts.SchematicFactory, builder), nil
+	return spdx.NewFrontend(opts.SchematicFactory, builder, opts.AuthProvider), nil
 }
 
 // NewChecksummer returns an enterprise Checksummer implementation.
 func NewChecksummer() Checksummer {
 	return checksum.NewChecksummer()
+}
+
+// NewAuthProvider creates a new authentication provider.
+func NewAuthProvider(logger *zap.Logger, configPath string) (AuthProvider, error) {
+	return auth.NewProvider(configPath, logger)
 }

--- a/pkg/schematic/schematic.go
+++ b/pkg/schematic/schematic.go
@@ -17,6 +17,13 @@ import (
 
 // Schematic represents the requested image customization.
 type Schematic struct {
+	// Owner is the name (username) of the schematic owner.
+	//
+	// If owner is set, the schematic is only accessible to the owner and
+	// requires authentication to access.
+	//
+	// Note: this field is only supported in Enterprise edition.
+	Owner string `yaml:"owner,omitempty"`
 	// Overlay represents the overlay options for image generation.
 	Overlay Overlay `yaml:"overlay,omitempty"`
 	// Customization represents the Talos image customization.
@@ -68,6 +75,12 @@ type SecureBootCustomization struct {
 
 // InvalidErrorTag is a tag for invalid schematic errors.
 type InvalidErrorTag struct{}
+
+// RequiresAuthenticationTag is a tag for schematics that require authentication to access.
+type RequiresAuthenticationTag struct{}
+
+// ForbiddenTag is a tag for access denied errors (authenticated but not the owner).
+type ForbiddenTag struct{}
 
 // Unmarshal the schematic from text representation.
 func Unmarshal(data []byte) (*Schematic, error) {


### PR DESCRIPTION
This feature is Enterprise only (requires BUSL).

Any access to the schematic requires the user to be authenticated
before access.

Moreover, any schematic stores the owner in the schematic, so each
schematic becomes private (owned by the user which created it).

Authentication is configured using a set of usernames and keys
associates with each user (API key).

<img width="2016" height="1081" alt="Screenshot 2026-04-20 at 10 59 22" src="https://github.com/user-attachments/assets/d48f180b-40b2-40a6-8cb8-d0fd9ee769cc" />
<img width="1007" height="414" alt="Screenshot 2026-04-20 at 13 49 21" src="https://github.com/user-attachments/assets/9d3b2bfe-6cff-4363-a6e3-5b1072f8ca5d" />
<img width="2016" height="1081" alt="Screenshot 2026-04-20 at 13 49 31" src="https://github.com/user-attachments/assets/daae7f6e-94a8-418c-b55d-4743e754bf6a" />

Closes https://github.com/siderolabs/image-factory/issues/285
Closes https://github.com/siderolabs/image-factory/pull/346

Co-authored-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
