### PR TITLE
fix: centralize schematic ownership enforcement

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -5,11 +5,8 @@
 package cmd
 
 import (
-	"errors"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // Options configures the behavior of the image factory.
@@ -418,20 +415,6 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	//
 	// It is required if authentication is enabled.
 	HTPasswdPath string `koanf:"htpasswdPath"`
-}
-
-// Validate checks for invalid or conflicting configuration.
-func (o *Options) Validate() error {
-	var err error
-
-	if o.Authentication.Enabled && o.Cache.CDN.Enabled {
-		err = multierror.Append(err,
-			errors.New("CDN cache cannot be enabled when authentication is enabled: "+
-				"CDN would serve assets without authentication, effectively leaking secrets",
-			))
-	}
-
-	return err
 }
 
 // DefaultOptions are the default options.

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -12,50 +12,6 @@ import (
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
 )
 
-func TestValidate(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name        string
-		opts        cmd.Options
-		expectedErr string
-	}{
-		{
-			name: "default options",
-			opts: cmd.DefaultOptions,
-		},
-		{
-			name: "empty options",
-			opts: cmd.Options{},
-		},
-		{
-			name: "CDN cache enabled with authentication",
-			opts: cmd.Options{
-				Cache: cmd.CacheOptions{
-					CDN: cmd.CDNCacheOptions{
-						Enabled: true,
-					},
-				},
-				Authentication: cmd.AuthenticationOptions{
-					Enabled: true,
-				},
-			},
-			expectedErr: "CDN cache cannot be enabled when authentication is enabled",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := tc.opts.Validate()
-			if tc.expectedErr == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.ErrorContains(t, err, tc.expectedErr)
-			}
-		})
-	}
-}
-
 func TestOCIRepositoryOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/image-factory/flags.go
+++ b/cmd/image-factory/flags.go
@@ -57,9 +57,5 @@ func initConfig() (cmd.Options, error) {
 		return opts, err
 	}
 
-	if err := opts.Validate(); err != nil {
-		return opts, fmt.Errorf("invalid configuration: %w", err)
-	}
-
 	return opts, nil
 }

--- a/enterprise/spdx/builder/builder.go
+++ b/enterprise/spdx/builder/builder.go
@@ -33,6 +33,12 @@ import (
 	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
+// AuthProvider is a subset of enterprise.AuthProvider used for ownership checks.
+// Defined locally to avoid an import cycle with pkg/enterprise.
+type AuthProvider interface {
+	UsernameFromContext(ctx context.Context) (string, bool)
+}
+
 // Builder orchestrates SPDX extraction and caching.
 type Builder struct {
 	storage          storage.Storage
@@ -41,6 +47,7 @@ type Builder struct {
 	schematicFactory *schematic.Factory
 	logger           *zap.Logger
 	sf               singleflight.Group
+	authProvider     AuthProvider
 }
 
 // Options defines the dependencies for the SPDX builder.
@@ -49,6 +56,7 @@ type Options struct {
 	ArtifactsManager *artifacts.Manager
 	SchematicFactory *schematic.Factory
 	AssetBuilder     *asset.Builder
+	AuthProvider     AuthProvider
 }
 
 // NewBuilder creates a new SPDX bundle builder.
@@ -61,6 +69,7 @@ func NewBuilder(
 		artifactsManager: opts.ArtifactsManager,
 		schematicFactory: opts.SchematicFactory,
 		assetBuilder:     opts.AssetBuilder,
+		authProvider:     opts.AuthProvider,
 		logger:           logger.With(zap.String("component", "spdx-builder")),
 	}
 }
@@ -84,11 +93,19 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 		return b.storage.Get(ctx, schematicID, versionTag, string(arch))
 	}
 
+	// Verify access and fetch schematic data before entering singleflight.
+	// buildBundle runs with context.Background() (request context may be canceled),
+	// so ownership enforcement must happen here with the live request context.
+	sc, err := b.schematicFactory.Get(ctx, schematicID, b.authProvider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schematic: %w", err)
+	}
+
 	// Build the bundle using singleflight to prevent duplicate work
 	cacheKey := CacheTag(schematicID, versionTag, string(arch))
 
 	resultCh := b.sf.DoChan(cacheKey, func() (any, error) { //nolint:contextcheck
-		return nil, b.buildBundle(schematicID, versionTag, arch)
+		return nil, b.buildBundle(sc, schematicID, versionTag, arch)
 	})
 
 	select {
@@ -105,19 +122,15 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 }
 
 // buildBundle creates and stores an SPDX bundle for a single architecture.
-func (b *Builder) buildBundle(schematicID, versionTag string, arch artifacts.Arch) error {
+// sc must be pre-fetched by the caller (Build) using the live request context,
+// since this function runs inside singleflight with context.Background().
+func (b *Builder) buildBundle(sc *schematicpkg.Schematic, schematicID, versionTag string, arch artifacts.Arch) error {
 	// Use a fresh context since we're in singleflight
 	ctx := context.Background()
 
 	logger := b.logger.With(zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
 
 	logger.Info("building SPDX bundle")
-
-	// Get the schematic to find extensions
-	schematicData, err := b.schematicFactory.Get(ctx, schematicID)
-	if err != nil {
-		return fmt.Errorf("failed to get schematic: %w", err)
-	}
 
 	bundle := &Bundle{
 		SchematicID:  schematicID,
@@ -132,16 +145,17 @@ func (b *Builder) buildBundle(schematicID, versionTag string, arch artifacts.Arc
 		zap.String("arch", string(arch)))
 
 	// Extract SPDX from Talos
+	var err error
 	if err = b.extractTalosSPDX(ctx, bundle, versionTag, arch); err != nil {
 		return fmt.Errorf("failed to extract SPDX from Talos: %w", err)
 	}
 
 	logger.Debug("building SPDX bundle from extensions",
-		zap.Int("extensions", len(schematicData.Customization.SystemExtensions.OfficialExtensions)))
+		zap.Int("extensions", len(sc.Customization.SystemExtensions.OfficialExtensions)))
 
 	// Extract SPDX from extensions
-	if len(schematicData.Customization.SystemExtensions.OfficialExtensions) > 0 {
-		if err = b.extractExtensionsSPDX(ctx, bundle, schematicData, versionTag, arch); err != nil {
+	if len(sc.Customization.SystemExtensions.OfficialExtensions) > 0 {
+		if err = b.extractExtensionsSPDX(ctx, bundle, sc, versionTag, arch); err != nil {
 			logger.Warn("failed to extract SPDX from some extensions", zap.Error(err))
 		}
 	}

--- a/enterprise/spdx/frontend.go
+++ b/enterprise/spdx/frontend.go
@@ -10,7 +10,6 @@ package spdx
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,12 +24,11 @@ import (
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/schematic"
-	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
-// authProvider is a subset of enterprise.AuthProvider used for ownership checks.
+// AuthProvider is a subset of enterprise.AuthProvider used for ownership checks.
 // Defined locally to avoid an import cycle with pkg/enterprise.
-type authProvider interface {
+type AuthProvider interface {
 	UsernameFromContext(ctx context.Context) (string, bool)
 }
 
@@ -47,11 +45,11 @@ var availableFrom = semver.MustParse("1.11.0")
 type Frontend struct {
 	schematicFactory *schematic.Factory
 	spdxBuilder      *builder.Builder
-	authProvider     authProvider
+	authProvider     AuthProvider
 }
 
 // NewFrontend creates a new Frontend instance.
-func NewFrontend(schematicFactory *schematic.Factory, spdxBuilder *builder.Builder, auth authProvider) *Frontend {
+func NewFrontend(schematicFactory *schematic.Factory, spdxBuilder *builder.Builder, auth AuthProvider) *Frontend {
 	return &Frontend{
 		schematicFactory: schematicFactory,
 		spdxBuilder:      spdxBuilder,
@@ -69,29 +67,6 @@ func (f *Frontend) Methods() []string {
 	return []string{http.MethodGet, http.MethodHead}
 }
 
-// checkOwnership verifies the context user owns the schematic.
-// Returns nil if schematic has no owner or the authenticated user matches the owner.
-func (f *Frontend) checkOwnership(ctx context.Context, s *schematicpkg.Schematic) error {
-	if s.Owner == "" {
-		return nil
-	}
-
-	if f.authProvider == nil {
-		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
-	}
-
-	username, ok := f.authProvider.UsernameFromContext(ctx)
-	if !ok {
-		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
-	}
-
-	if username != s.Owner {
-		return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("access denied"))
-	}
-
-	return nil
-}
-
 // Handle implements enterprise.FrontendExtension.
 // It handles SPDX bundle download requests.
 //
@@ -103,13 +78,7 @@ func (f *Frontend) checkOwnership(ctx context.Context, s *schematicpkg.Schematic
 func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
-	// Validate schematic exists and check ownership.
-	schematic, err := f.schematicFactory.Get(ctx, schematicID)
-	if err != nil {
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, schematic); err != nil {
+	if _, err := f.schematicFactory.Get(ctx, schematicID, f.authProvider); err != nil {
 		return err
 	}
 

--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -60,7 +60,7 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 func (f *Frontend) handleSchematicGet(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
-	schematic, err := f.schematicFactory.Get(ctx, schematicID)
+	schematic, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
 	if err != nil {
 		if xerrors.TagIs[storage.ErrNotFoundTag](err) {
 			http.Error(w, "schematic not found", http.StatusNotFound)
@@ -68,10 +68,6 @@ func (f *Frontend) handleSchematicGet(ctx context.Context, w http.ResponseWriter
 			return nil
 		}
 
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -303,29 +303,6 @@ func MatchError(err error, callback func(message string, code int)) (zapcore.Lev
 	return level, status
 }
 
-// checkOwnership verifies the context user owns the schematic (for auth-protected routes).
-// Returns nil if schematic has no owner or the authenticated user matches the owner.
-func (f *Frontend) checkOwnership(ctx context.Context, s *schematicpkg.Schematic) error {
-	if s.Owner == "" {
-		return nil
-	}
-
-	if f.options.AuthProvider == nil {
-		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
-	}
-
-	username, ok := f.options.AuthProvider.UsernameFromContext(ctx)
-	if !ok {
-		return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
-	}
-
-	if username != s.Owner {
-		return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("access denied"))
-	}
-
-	return nil
-}
-
 // Use several ways to detect language.
 func (f *Frontend) getLocalizer(r *http.Request) *i18n.Localizer {
 	lang := r.URL.Query().Get("lang")

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -61,12 +61,8 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		return xerrors.NewTaggedf[enterprise.ErrNotEnabledTag]("enterprise not enabled: checksum endpoint is not available")
 	}
 
-	schematic, err := f.schematicFactory.Get(ctx, schematicID)
+	schematic, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
 	if err != nil {
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 
@@ -113,11 +109,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		return f.checksummer.WriteChecksum(ctx, w, r, reader, asset.Size(), filename, checksumSuffix)
 	}
 
-	// When auth is active, never redirect to S3/CDN - bytes must flow through the
-	// factory so the auth boundary is maintained. S3/CDN URLs carry no user identity.
-	authActive := f.options.AuthProvider != nil
-
-	if asset, ok := asset.(cache.RedirectableAsset); ok && !disableRedirect && r.Method != http.MethodHead && !authActive {
+	if asset, ok := asset.(cache.RedirectableAsset); ok && !disableRedirect && r.Method != http.MethodHead {
 		var url string
 
 		url, err = asset.Redirect(ctx, filename)

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -31,12 +31,8 @@ var securebootIPXE string
 func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
-	schematic, err := f.schematicFactory.Get(ctx, schematicID)
+	schematic, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
 	if err != nil {
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 
@@ -83,10 +79,12 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, r *http
 
 	// Embed credentials in image asset URLs so iPXE can authenticate when fetching kernel/initramfs.
 	imageBaseURL := f.options.ExternalPXEURL
-	if username, password, ok := r.BasicAuth(); ok {
-		u := *f.options.ExternalPXEURL
-		u.User = url.UserPassword(username, password)
-		imageBaseURL = &u
+	if f.options.AuthProvider != nil {
+		if username, password, ok := r.BasicAuth(); ok {
+			u := *f.options.ExternalPXEURL
+			u.User = url.UserPassword(username, password)
+			imageBaseURL = &u
+		}
 	}
 
 	if prof.SecureBootEnabled() {

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -88,12 +88,8 @@ func (f *Frontend) handleBlob(ctx context.Context, w http.ResponseWriter, req *h
 	// verify that schematic exists
 	schematicID := p.ByName("schematic")
 
-	sc, err := f.schematicFactory.Get(ctx, schematicID)
+	_, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
 	if err != nil {
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, sc); err != nil {
 		return err
 	}
 
@@ -121,7 +117,8 @@ func (f *Frontend) handleExternalRegistry(w http.ResponseWriter, req *http.Reque
 
 	location := redirectURL.JoinPath("v2", repo.RepositoryStr(), imageName, schematicID, manifestsOrBlobs, tagOrDigest)
 
-	if f.options.ProxyInstallerInternalRepository {
+	// When auth is active, always proxy - redirecting to the backing registry would bypass the auth boundary.
+	if f.options.ProxyInstallerInternalRepository || f.options.AuthProvider != nil {
 		f.logger.Info("proxying manifest/blob", zap.Stringer("location", location))
 
 		proxy := &httputil.ReverseProxy{
@@ -156,12 +153,8 @@ func (f *Frontend) handleExternalRegistry(w http.ResponseWriter, req *http.Reque
 func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, req *http.Request, p httprouter.Params) error {
 	schematicID := p.ByName("schematic")
 
-	schematic, err := f.schematicFactory.Get(ctx, schematicID)
+	schematic, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
 	if err != nil {
-		return err
-	}
-
-	if err = f.checkOwnership(ctx, schematic); err != nil {
 		return err
 	}
 

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -7,13 +7,20 @@ package schematic
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/image-factory/internal/schematic/storage"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
+
+// OwnershipChecker resolves the authenticated user from a context.
+type OwnershipChecker interface {
+	UsernameFromContext(ctx context.Context) (string, bool)
+}
 
 // Factory is the schematic factory.
 type Factory struct {
@@ -88,7 +95,7 @@ func (s *Factory) Put(ctx context.Context, cfg *schematic.Schematic) (string, er
 }
 
 // Get retrieves the stored schematic.
-func (s *Factory) Get(ctx context.Context, id string) (*schematic.Schematic, error) {
+func (s *Factory) get(ctx context.Context, id string) (*schematic.Schematic, error) {
 	data, err := s.storage.Get(ctx, id)
 	if err != nil {
 		return nil, err
@@ -97,6 +104,42 @@ func (s *Factory) Get(ctx context.Context, id string) (*schematic.Schematic, err
 	s.metricGet.Inc()
 
 	return schematic.Unmarshal(data)
+}
+
+// Get retrieves the stored schematic and enforces ownership.
+//
+// If auth is non-nil and the caller is unauthenticated, RequiresAuthenticationTag is returned
+// even when the schematic is not found, to avoid leaking schematic existence to anonymous callers.
+func (s *Factory) Get(ctx context.Context, id string, auth OwnershipChecker) (*schematic.Schematic, error) {
+	sc, err := s.get(ctx, id)
+	if err != nil {
+		if auth != nil {
+			if _, ok := auth.UsernameFromContext(ctx); !ok {
+				return nil, xerrors.NewTagged[schematic.RequiresAuthenticationTag](err)
+			}
+		}
+
+		return nil, err
+	}
+
+	if sc.Owner == "" && auth == nil {
+		return sc, nil
+	}
+
+	if auth == nil {
+		return nil, xerrors.NewTagged[schematic.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	username, ok := auth.UsernameFromContext(ctx)
+	if !ok {
+		return nil, xerrors.NewTagged[schematic.RequiresAuthenticationTag](errors.New("authentication required"))
+	}
+
+	if username != sc.Owner {
+		return nil, xerrors.NewTagged[schematic.ForbiddenTag](errors.New("access denied"))
+	}
+
+	return sc, nil
 }
 
 // Describe implements prom.Collector interface.

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -52,6 +52,7 @@ func NewSpdxFrontend(logger *zap.Logger, opts SPDXOptions) (FrontendPlugin, erro
 		ArtifactsManager: opts.ArtifactsManager,
 		SchematicFactory: opts.SchematicFactory,
 		AssetBuilder:     opts.AssetBuilder,
+		AuthProvider:     opts.AuthProvider,
 	})
 
 	return spdx.NewFrontend(opts.SchematicFactory, builder, opts.AuthProvider), nil


### PR DESCRIPTION
  Move ownership/auth checks from scattered frontend handlers into
  schematic.Factory.Get, which now accepts an OwnershipChecker. This
  eliminates duplicated checkOwnership methods across http and spdx
  frontends and ensures anonymous callers cannot probe schematic
  existence when auth is enabled.

  Also guard PXE credential embedding behind AuthProvider != nil so
  credentials are never propagated when auth is disabled.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
