### PR TITLE
feat(registry): resolve latest tag to stable version

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -244,6 +244,14 @@ Examples:
 Pulls the Talos Linux `installer` image with the specified schematic and Talos Linux version.
 The image platform (architecture) will be determined by the architecture of the Talos Linux Linux machine.
 
+#### `latest` Tag Resolution
+
+The `latest` tag automatically resolves to the latest stable (non-prerelease) Talos Linux version available:
+
+* `docker pull factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:latest`
+
+This is equivalent to pulling with an explicit stable version, ensuring that prerelease versions (e.g. `v1.5.0-alpha.1`) are not used.
+
 ### `GET /oci/cosign/signing-key.pub`
 
 Returns PEM-encoded public key used to sign the Talos Linux `installer` images.

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -165,6 +166,14 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 		return err
 	}
 
+	// if the tag is "latest", replace it with latest known stable version to the factory.
+	if versionTag == "latest" {
+		versionTag, err = f.resolveLatest(ctx, schematicID)
+		if err != nil {
+			return fmt.Errorf("error resolving latest version: %w", err)
+		}
+	}
+
 	// if the tag is the digest, or it doesn't look like the version, we just redirect to the external registry
 	if strings.HasPrefix(versionTag, "sha256:") || !strings.HasPrefix(versionTag, "v") {
 		return f.handleExternalRegistry(w, req, img.Name(), schematicID, "manifests", versionTag)
@@ -250,6 +259,30 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 
 	// now we can redirect to the external registry
 	return f.handleExternalRegistry(w, req, img.Name(), schematicID, "manifests", manifestHash.String())
+}
+
+func (f *Frontend) resolveLatest(ctx context.Context, schematicID string) (string, error) {
+	ver, err := f.artifactsManager.GetTalosVersions(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	semver.Sort(ver)
+	slices.Reverse(ver)
+
+	var versionTag string
+
+	for _, v := range ver {
+		if len(v.Pre) == 0 {
+			versionTag = "v" + v.String()
+
+			break
+		}
+	}
+
+	f.logger.Info("resolving latest tag to version", zap.String("schematic", schematicID), zap.String("version", versionTag))
+
+	return versionTag, nil
 }
 
 func (f *Frontend) buildInstallImage(ctx context.Context, img requestedImage, schematic *schematic.Schematic, version semver.Version, schematicID, versionTag string) (v1.Hash, error) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -345,6 +345,12 @@ func commonTest(t *testing.T, options cmd.Options) {
 		testRegistryFrontend(ctx, t, listenAddr, baseURL)
 	})
 
+	t.Run("TestLatestTagResolution", func(t *testing.T) {
+		t.Parallel()
+
+		testLatestTagResolution(ctx, t, listenAddr, baseURL)
+	})
+
 	t.Run("TestMetaFrontend", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -225,6 +225,32 @@ func assertImageSignature(ctx context.Context, t *testing.T, ref name.Reference,
 	assert.NoError(t, err)
 }
 
+func testLatestTagResolution(ctx context.Context, t *testing.T, registryAddr string, baseURL string) {
+	registry, err := name.NewRegistry(registryAddr)
+	require.NoError(t, err)
+
+	// pull installer with 'latest' tag
+	ref := registry.Repo("installer", emptySchematicID).Tag("latest")
+
+	_, err = remote.Head(ref, ociRemoteAuthOpts()...)
+	require.NoError(t, err, "failed to pull latest tag")
+
+	// verify the image exists and is valid
+	descriptor, err := remote.Get(ref, append(ociRemoteAuthOpts(), remote.WithPlatform(v1.Platform{
+		Architecture: "amd64",
+		OS:           "linux",
+	}))...)
+	require.NoError(t, err)
+
+	img, err := descriptor.Image()
+	require.NoError(t, err)
+
+	layers, err := img.Layers()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, layers, "latest tag should resolve to a valid installer image with layers")
+}
+
 func testRegistryFrontend(ctx context.Context, t *testing.T, registryAddr string, baseURL string) {
 	talosVersions := []string{
 		"v1.3.7",


### PR DESCRIPTION
"latest" now maps to latest non-prerelease version instead of external pass-through.

Part of https://github.com/siderolabs/talos/issues/13138

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
