### PR TITLE
feat(enterprise): implement VEX endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T20:13:43Z by kres 8299790.
+# Generated on 2026-05-05T11:14:47Z by kres 1762ab2.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -174,7 +174,7 @@ jobs:
           make release-notes
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # version: v3.0.0
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"
@@ -349,7 +349,7 @@ jobs:
           REGISTRY: registry.dev.siderolabs.io
           RUN_TESTS_ENTERPRISE: TestIntegrationDirect
           TAG_SUFFIX: -enterprise
-          TEST_FLAGS: -test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache -test.signing-cache-repository=127.0.0.1:5100/image-factory/signing-cache
+          TEST_FLAGS: -test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache -test.signing-cache-repository=127.0.0.1:5100/image-factory/signing-cache -test.vex-data-repository=ghcr.io/siderolabs/image-factory/test-vex-data
         run: |
           make integration-enterprise
       - name: coverage

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T20:13:43Z by kres 8299790.
+# Generated on 2026-05-04T15:24:07Z by kres 1762ab2.
 
 "on":
   workflow_run:
@@ -18,7 +18,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T20:13:43Z by kres 8299790.
+# Generated on 2026-05-04T15:24:07Z by kres 1762ab2.
 
 "on":
   workflow_run:
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo pull_request_number=$(gh pr view -R ${{ github.repository }} ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} --json number --jq .number) >> $GITHUB_OUTPUT
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -121,6 +121,12 @@ spec:
       toplevel: true
     - name: chart-version
       toplevel: true
+    - name: $(ARTIFACTS)/image-signer
+      toplevel: true
+    - name: sign-images
+      toplevel: true
+    - name: push-talos-vex-data
+      toplevel: true
 ---
 kind: custom.Step
 name: imager-base
@@ -563,7 +569,7 @@ spec:
     environment:
       REGISTRY: registry.dev.siderolabs.io
       RUN_TESTS_ENTERPRISE: TestIntegrationDirect
-      TEST_FLAGS: "-test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache -test.signing-cache-repository=127.0.0.1:5100/image-factory/signing-cache"
+      TEST_FLAGS: "-test.schematic-service-repository=127.0.0.1:5100/image-factory/schematic -test.installer-internal-repository=127.0.0.1:5100/siderolabs -test.cache-repository=127.0.0.1:5100/image-factory/cache -test.signing-cache-repository=127.0.0.1:5100/image-factory/signing-cache -test.vex-data-repository=ghcr.io/siderolabs/image-factory/test-vex-data"
       TAG_SUFFIX: "-enterprise"
 ---
 kind: custom.Step
@@ -816,6 +822,49 @@ spec:
       runnerGroup: large
     environment:
       REGISTRY: registry.dev.siderolabs.io
+---
+kind: custom.Step
+name: $(ARTIFACTS)/image-signer
+spec:
+  makefile:
+    variables:
+      - name: GO_TOOLS_RELEASE
+        defaultValue: v0.3.1
+    enabled: true
+    phony: true
+    depends:
+      - $(ARTIFACTS)
+    script:
+      - |
+        @curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(GO_TOOLS_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+        @chmod +x $(ARTIFACTS)/image-signer
+---
+kind: custom.Step
+name: sign-images
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - $(ARTIFACTS)/image-signer
+    script:
+      - |
+        @$(ARTIFACTS)/image-signer sign --timeout=15m \
+          $(TALOS_VEX_DATA_IMAGE_REF)@$$(crane digest $(TALOS_VEX_DATA_IMAGE_REF))
+---
+kind: custom.Step
+name: push-talos-vex-data
+spec:
+  makefile:
+    variables:
+      - name: TALOS_VEX_DATA_IMAGE_REF
+        defaultValue: $(REGISTRY_AND_USERNAME)/image-factory/test-vex-data:latest
+    enabled: true
+    phony: true
+    script:
+      - |
+        @tar -C $(PWD)/internal/integration/testdata/vex-data -cvf $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar .
+        @crane append -f $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar -t $(TALOS_VEX_DATA_IMAGE_REF)
 ---
 kind: golang.UnitTests
 spec:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T20:13:43Z by kres 8299790.
+# Generated on 2026-05-04T15:24:07Z by kres 1762ab2.
 
 ARG TOOLCHAIN=scratch
 ARG PKGS_PREFIX=scratch
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=image-factory/root/.cache
 	&& mv /go/bin/helm-docs /bin/helm-docs
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.3.11-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.3.13-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.48.0 sentences-per-line@0.5.2
 COPY .markdownlint.json .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T20:13:43Z by kres 8299790.
+# Generated on 2026-05-05T13:49:12Z by kres 1762ab2.
 
 # common variables
 
@@ -21,15 +21,15 @@ USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 PROTOBUF_GO_VERSION ?= 1.36.11
 GRPC_GO_VERSION ?= 1.6.1
-GRPC_GATEWAY_VERSION ?= 2.28.0
+GRPC_GATEWAY_VERSION ?= 2.29.0
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.43.0
+GOIMPORTS_VERSION ?= 0.44.0
 GOMOCK_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.8
 GOLANGCILINT_VERSION ?= v2.11.4
 GOFUMPT_VERSION ?= v0.9.2
 GO_VERSION ?= 1.26.2
-DIS_VULNCHECK_VERSION ?= v0.0.0-20260408104044-a7a2dc044240
+DIS_VULNCHECK_VERSION ?= v0.0.0-20260409114749-05440f84fe69
 GO_BUILDFLAGS ?=
 GO_BUILDTAGS ?= ,
 GO_LDFLAGS ?=
@@ -101,6 +101,8 @@ GOOS ?= $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOS_VERSION ?= 1.12.2
 K8S_VERSION ?= v1.35.0
 CHART_VERSION ?= 0.0.0-alpha.0
+GO_TOOLS_RELEASE ?= v0.3.1
+TALOS_VEX_DATA_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/image-factory/test-vex-data:latest
 
 # help menu
 
@@ -438,6 +440,21 @@ chart-version:
 	yq -i '.version = strenv(CHART_VERSION)' deploy/helm/image-factory/Chart.yaml
 	yq -i '.appVersion = strenv(TAG)' deploy/helm/image-factory/Chart.yaml
 	sed -i '/# -- Repository to use for Image Factory/{n; s|repository:.*|repository: '"$(REGISTRY)/$(USERNAME)/image-factory"'|}' deploy/helm/image-factory/values.yaml
+
+.PHONY: $(ARTIFACTS)/image-signer
+$(ARTIFACTS)/image-signer: $(ARTIFACTS)
+	@curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(GO_TOOLS_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+	@chmod +x $(ARTIFACTS)/image-signer
+
+.PHONY: sign-images
+sign-images: $(ARTIFACTS)/image-signer
+	@$(ARTIFACTS)/image-signer sign --timeout=15m \
+	  $(TALOS_VEX_DATA_IMAGE_REF)@$$(crane digest $(TALOS_VEX_DATA_IMAGE_REF))
+
+.PHONY: push-talos-vex-data
+push-talos-vex-data:
+	@tar -C $(PWD)/internal/integration/testdata/vex-data -cvf $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar .
+	@crane append -f $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar -t $(TALOS_VEX_DATA_IMAGE_REF)
 
 .PHONY: rekres
 rekres:

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -36,6 +36,9 @@ type Options struct { //nolint:govet // keeping order for semantic clarity
 	//
 	// Note: only available in the Enterprise edition.
 	Authentication AuthenticationOptions `koanf:"authentication"`
+
+	// Enterprise contains configuration for enterprise-specific features.
+	Enterprise EnterpriseOptions `koanf:"enterprise"`
 }
 
 // AssetBuilderOptions contains settings for building assets.
@@ -417,6 +420,21 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	HTPasswdPath string `koanf:"htpasswdPath"`
 }
 
+// EnterpriseOptions contains configuration for enterprise-specific features.
+type EnterpriseOptions struct {
+	// VEX contains configuration for VEX data fetching.
+	VEX VEXOptions `koanf:"vex"`
+}
+
+// VEXOptions configures VEX data caching.
+type VEXOptions struct {
+	// Data specifies the OCI repository where VEX documents are stored.
+	Data OCIRepositoryOptions `koanf:"data"`
+
+	// CacheTTL is the duration for caching generated VEX documents.
+	CacheTTL time.Duration `koanf:"cacheTTL"`
+}
+
 // DefaultOptions are the default options.
 var DefaultOptions = Options{
 	HTTP: HTTPOptions{
@@ -484,6 +502,17 @@ var DefaultOptions = Options{
 				OverlayManifest:   "siderolabs/overlays",
 				Talosctl:          "siderolabs/talosctl-all",
 			},
+		},
+	},
+
+	Enterprise: EnterpriseOptions{
+		VEX: VEXOptions{
+			Data: OCIRepositoryOptions{
+				Registry:   "ghcr.io",
+				Namespace:  "siderolabs/talos-vex",
+				Repository: "talos-vex-data",
+			},
+			CacheTTL: 15 * time.Minute,
 		},
 	},
 }

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -207,7 +207,24 @@ func buildEnterprisePlugins(
 		return nil, fmt.Errorf("failed to initialize SPDX frontend: %w", err)
 	}
 
-	return []enterprise.FrontendPlugin{spdxFrontend}, nil
+	imageVerifyOptions, err := buildImageVerifyOptions(logger, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	vexFrontend, err := enterprise.NewVEXFrontend(logger, enterprise.VEXOptions{
+		Data:            opts.Enterprise.VEX.Data.String(),
+		DataInsecure:    opts.Enterprise.VEX.Data.Insecure,
+		CacheTTL:        opts.Enterprise.VEX.CacheTTL,
+		RefreshInterval: opts.Artifacts.RefreshInterval,
+		RemoteOptions:   remoteOptions(),
+		VerifyOptions:   imageVerifyOptions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize VEX frontend: %w", err)
+	}
+
+	return []enterprise.FrontendPlugin{spdxFrontend, vexFrontend}, nil
 }
 
 func buildFrontendOptions(cacheImageSigner signer.Signer, authProvider enterprise.AuthProvider, opts Options) (frontendhttp.Options, error) {
@@ -342,7 +359,7 @@ func runMetricsServer(ctx context.Context, logger *zap.Logger, eg *errgroup.Grou
 	})
 }
 
-func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager, error) {
+func buildImageVerifyOptions(logger *zap.Logger, opts Options) (artifacts.ImageVerifyOptions, error) {
 	var checkOpts []cosign.CheckOpts
 
 	if opts.ContainerSignature.Disabled {
@@ -351,7 +368,7 @@ func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager
 		if len(strings.TrimSpace(opts.ContainerSignature.PublicKeyFile)) > 0 {
 			keyVerifier, err := getPublicKeyVerifier(opts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get signature verifier for key %s: %w", opts.ContainerSignature.PublicKeyFile, err)
+				return artifacts.ImageVerifyOptions{}, fmt.Errorf("failed to get signature verifier for key %s: %w", opts.ContainerSignature.PublicKeyFile, err)
 			}
 
 			checkOpts = append(checkOpts, cosign.CheckOpts{
@@ -364,7 +381,7 @@ func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager
 		if opts.ContainerSignature.SubjectRegExp != "" {
 			trustedRoot, err := cosign.TrustedRoot()
 			if err != nil {
-				return nil, fmt.Errorf("failed to get cosign trusted root: %w", err)
+				return artifacts.ImageVerifyOptions{}, fmt.Errorf("failed to get cosign trusted root: %w", err)
 			}
 
 			// Prefer opts.ContainerSignatureIssuerRegExp if set as this is more flexible
@@ -387,9 +404,16 @@ func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager
 		}
 	}
 
-	imageVerifyOptions := artifacts.ImageVerifyOptions{
+	return artifacts.ImageVerifyOptions{
 		CheckOpts: checkOpts,
 		Disabled:  opts.ContainerSignature.Disabled,
+	}, nil
+}
+
+func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager, error) {
+	imageVerifyOptions, err := buildImageVerifyOptions(logger, opts)
+	if err != nil {
+		return nil, err
 	}
 
 	minVersion, err := semver.Parse(opts.Build.MinTalosVersion)

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,18 @@ grype sbom:response.spdx.json
 
 SPDX bundles are available for Talos versions **v1.11.0** and later.
 
+### `GET /vex/:version/vex.json`
+
+> [!NOTE]
+> Enterprise feature: requires Talos Enterprise Image Factory.
+
+Returns a VEX JSON document containing vulnerability information for all packages in the Talos Linux release.
+The response is a JSON-encoded VEX document which can be consumed directly by vulnerability scanners such as grype:
+
+```shell
+grype sbom:talos.spdx.json --vex response.vex.json
+```
+
 ## HTTP Frontend API
 
 ### `POST /schematics`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -360,21 +360,21 @@ Insecure allows connecting to S3 without TLS or with invalid certificates.
 
 ---
 
-### `cache.s3.presignedURLTTL`
-
-- **Type:** `time.Duration`
-- **Env:** `CACHE_S3_PRESIGNEDURLTTL`
-
-PresignedURLTTL is the duration for which presigned URLs are valid.
-
----
-
 ### `cache.s3.enabled`
 
 - **Type:** `bool`
 - **Env:** `CACHE_S3_ENABLED`
 
 Enabled enables S3 cache.
+
+---
+
+### `cache.s3.presignedURLTTL`
+
+- **Type:** `time.Duration`
+- **Env:** `CACHE_S3_PRESIGNEDURLTTL`
+
+PresignedURLTTL is the duration for which presigned URLs are valid.
 
 ---
 
@@ -837,6 +837,72 @@ It is required if authentication is enabled.
 
 ---
 
+### `enterprise`
+
+Enterprise contains configuration for enterprise-specific features.
+
+---
+
+### `enterprise.vex`
+
+VEX contains configuration for VEX data fetching.
+
+---
+
+### `enterprise.vex.data`
+
+Data specifies the OCI repository where VEX documents are stored.
+
+---
+
+### `enterprise.vex.data.registry`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_VEX_DATA_REGISTRY`
+
+Registry is the hostname of the container registry, e.g., `ghcr.io`.
+This is where images are stored.
+
+---
+
+### `enterprise.vex.data.namespace`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_VEX_DATA_NAMESPACE`
+
+Namespace is the repository namespace or organization within the registry, e.g., `sidero-labs`.
+Some registries allow repositories without a namespace.
+
+---
+
+### `enterprise.vex.data.repository`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_VEX_DATA_REPOSITORY`
+
+Repository is the name of the repository inside the namespace, e.g., `talos`.
+Combined with Registry and Namespace, it forms the fully qualified repository path.
+
+---
+
+### `enterprise.vex.data.insecure`
+
+- **Type:** `bool`
+- **Env:** `ENTERPRISE_VEX_DATA_INSECURE`
+
+Insecure allows connections to registries over HTTP or with invalid TLS certificates.
+
+---
+
+### `enterprise.vex.cacheTTL`
+
+- **Type:** `time.Duration`
+- **Env:** `ENTERPRISE_VEX_CACHETTL`
+
+CacheTTL is the duration for caching generated VEX documents.
+
+---
+
 ## Default Configuration
 
 ### YAML
@@ -910,6 +976,14 @@ containerSignature:
     publicKeyFile: ""
     publicKeyHashAlgo: sha256
     subjectRegExp: (@siderolabs\.com$|^releasemgr-svc@talos-production\.iam\.gserviceaccount\.com$)
+enterprise:
+    vex:
+        cacheTTL: 15m0s
+        data:
+            insecure: false
+            namespace: siderolabs/talos-vex
+            registry: ghcr.io
+            repository: talos-vex-data
 http:
     allowedOrigins:
         - '*'
@@ -993,6 +1067,11 @@ IF_CONTAINERSIGNATURE_ISSUERREGEXP=
 IF_CONTAINERSIGNATURE_PUBLICKEYFILE=
 IF_CONTAINERSIGNATURE_PUBLICKEYHASHALGO=sha256
 IF_CONTAINERSIGNATURE_SUBJECTREGEXP=(@siderolabs\.com$|^releasemgr-svc@talos-production\.iam\.gserviceaccount\.com$)
+IF_ENTERPRISE_VEX_CACHETTL=15m0s
+IF_ENTERPRISE_VEX_DATA_INSECURE=false
+IF_ENTERPRISE_VEX_DATA_NAMESPACE=siderolabs/talos-vex
+IF_ENTERPRISE_VEX_DATA_REGISTRY=ghcr.io
+IF_ENTERPRISE_VEX_DATA_REPOSITORY=talos-vex-data
 IF_HTTP_ALLOWEDORIGINS=[*]
 IF_HTTP_CERTFILE=
 IF_HTTP_EXTERNALPXEURL=

--- a/enterprise/vex/builder/builder.go
+++ b/enterprise/vex/builder/builder.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package builder produces VEX documents from a signed OCI VEX data image.
+package builder
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/siderolabs/go-vex/pkg/types/v1alpha1"
+	"github.com/siderolabs/go-vex/pkg/vexgen"
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/siderolabs/image-factory/internal/image/verify"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
+)
+
+// FetchTimeout caps an OCI fetch + signature verification.
+const FetchTimeout = 5 * time.Minute
+
+// DefaultDataTag is the OCI tag pulled when no override is configured.
+const DefaultDataTag = "latest"
+
+// Builder produces VEX documents for a Talos version, with TTL caching and singleflight.
+type Builder struct {
+	puller        remotewrap.Puller
+	sf            singleflight.Group
+	logger        *zap.Logger
+	cache         map[string]cachedDoc
+	registry      string
+	dataTag       string
+	verifyOptions verify.VerifyOptions
+	cacheTTL      time.Duration
+	mu            sync.RWMutex
+	insecure      bool
+}
+
+// Options configures Builder.
+type Options struct {
+	Registry        string
+	DataTag         string
+	RemoteOptions   []remote.Option
+	VerifyOptions   verify.VerifyOptions
+	RefreshInterval time.Duration
+	CacheTTL        time.Duration
+	Insecure        bool
+}
+
+type cachedDoc struct {
+	expiresAt time.Time
+	data      []byte
+}
+
+// NewBuilder constructs a Builder.
+func NewBuilder(logger *zap.Logger, opts Options) (*Builder, error) {
+	puller, err := remotewrap.NewPuller(opts.RefreshInterval, opts.RemoteOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating puller: %w", err)
+	}
+
+	dataTag := opts.DataTag
+	if dataTag == "" {
+		dataTag = DefaultDataTag
+	}
+
+	return &Builder{
+		puller:        puller,
+		registry:      opts.Registry,
+		dataTag:       dataTag,
+		insecure:      opts.Insecure,
+		verifyOptions: opts.VerifyOptions,
+		cacheTTL:      opts.CacheTTL,
+		cache:         make(map[string]cachedDoc),
+		logger:        logger.With(zap.String("component", "vex-builder")),
+	}, nil
+}
+
+// Build returns a serialized VEX JSON document for the given Talos version tag.
+//
+// Cached per versionTag with TTL. Concurrent calls for the same tag share one OCI fetch
+// via singleflight. The fetch runs under a detached context so request cancellations
+// don't poison the shared work.
+func (b *Builder) Build(ctx context.Context, versionTag string) ([]byte, error) {
+	if data, ok := b.getCached(versionTag); ok {
+		return data, nil
+	}
+
+	resultCh := b.sf.DoChan(versionTag, func() (any, error) { //nolint:contextcheck
+		return b.buildAndCache(versionTag)
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-resultCh:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+
+		data, ok := res.Val.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("unexpected result type: %T", res.Val)
+		}
+
+		return data, nil
+	}
+}
+
+func (b *Builder) getCached(versionTag string) ([]byte, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	item, ok := b.cache[versionTag]
+	if !ok {
+		return nil, false
+	}
+
+	if time.Now().After(item.expiresAt) {
+		return nil, false
+	}
+
+	return item.data, true
+}
+
+func (b *Builder) setCached(versionTag string, data []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.cache[versionTag] = cachedDoc{
+		data:      data,
+		expiresAt: time.Now().Add(b.cacheTTL),
+	}
+}
+
+// buildAndCache runs under singleflight with a detached context.
+func (b *Builder) buildAndCache(versionTag string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+	defer cancel()
+
+	expData, err := b.fetchExploitabilityData(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching VEX data: %w", err)
+	}
+
+	now := time.Now()
+
+	doc, err := vexgen.Populate(expData, versionTag, &now, "image-factory")
+	if err != nil {
+		return nil, fmt.Errorf("error generating VEX document: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err = vexgen.Serialize(doc, &buf); err != nil {
+		return nil, fmt.Errorf("error serializing VEX document: %w", err)
+	}
+
+	data := buf.Bytes()
+	b.setCached(versionTag, data)
+
+	return data, nil
+}
+
+// fetchExploitabilityData heads the configured OCI tag, verifies the signature on the resolved digest,
+// pulls the image, and extracts the first regular file from the first layer.
+func (b *Builder) fetchExploitabilityData(ctx context.Context) (*v1alpha1.ExploitabilityData, error) {
+	var nameOpts []name.Option
+
+	if b.insecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	tagRef, err := name.NewTag(fmt.Sprintf("%s:%s", b.registry, b.dataTag), nameOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing reference: %w", err)
+	}
+
+	descriptor, err := b.puller.Head(ctx, tagRef)
+	if err != nil {
+		return nil, fmt.Errorf("error heading VEX image: %w", err)
+	}
+
+	digestRef := tagRef.Digest(descriptor.Digest.String())
+
+	logger := b.logger.With(zap.Stringer("image", digestRef))
+
+	logger.Debug("verifying VEX image signature")
+
+	verifyResult, err := verify.VerifySignatures(ctx, digestRef, b.verifyOptions, nameOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify VEX image signature for %s: %w", digestRef.Name(), err)
+	}
+
+	logger.Info("VEX image signature verified",
+		zap.String("verification_method", verifyResult.Method),
+		zap.Bool("bundle_verified", verifyResult.Verified))
+
+	imgDesc, err := b.puller.Get(ctx, digestRef)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching VEX image: %w", err)
+	}
+
+	img, err := imgDesc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("error reading VEX image: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("error getting VEX layers: %w", err)
+	}
+
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("no layers found in VEX data image")
+	}
+
+	reader, err := layers[0].Uncompressed()
+	if err != nil {
+		return nil, fmt.Errorf("error getting layer content: %w", err)
+	}
+	defer reader.Close() //nolint:errcheck
+
+	tarReader := tar.NewReader(reader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error reading VEX data archive: %w", err)
+		}
+
+		if header.Typeflag == tar.TypeReg {
+			return v1alpha1.LoadExploitabilityData(tarReader)
+		}
+	}
+
+	return nil, fmt.Errorf("no data file found in VEX data image")
+}

--- a/enterprise/vex/frontend.go
+++ b/enterprise/vex/frontend.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package vex provides an HTTP handler for downloading Vulnerability Exploitability eXchange (VEX) documents.
+package vex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+
+	"github.com/siderolabs/image-factory/enterprise/vex/builder"
+	"github.com/siderolabs/image-factory/internal/profile"
+)
+
+const vexJSONMediaType = "application/json"
+
+const routePath = "/vex/:version/vex.json"
+
+var availableFrom = semver.MustParse("1.13.0")
+
+// Frontend serves VEX documents over HTTP. It delegates document generation and caching to a Builder.
+type Frontend struct {
+	builder *builder.Builder
+}
+
+// NewFrontend wires a Frontend around a Builder.
+func NewFrontend(b *builder.Builder) *Frontend {
+	return &Frontend{builder: b}
+}
+
+// Path implements enterprise.FrontendExtension.
+func (f *Frontend) Path() string {
+	return routePath
+}
+
+// Methods implements enterprise.FrontendExtension.
+func (f *Frontend) Methods() []string {
+	return []string{http.MethodGet, http.MethodHead}
+}
+
+// Handle implements enterprise.FrontendExtension.
+// It handles VEX document download requests for a specific Talos version.
+//
+// The document can be consumed directly by vulnerability scanners such as grype:
+//
+//	grype sbom:talos.spdx.json --vex v1.13.0.vex.json
+func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	versionTag := p.ByName("version")
+	if !strings.HasPrefix(versionTag, "v") {
+		versionTag = "v" + versionTag
+	}
+
+	// Validate version format
+	talosVersion, err := semver.Parse(versionTag[1:])
+	if err != nil {
+		return xerrors.NewTaggedf[profile.InvalidErrorTag]("invalid version format: %q", versionTag)
+	}
+
+	if talosVersion.LT(availableFrom) {
+		return xerrors.NewTaggedf[profile.InvalidErrorTag]("VEX documents are only available for Talos versions %s and later", availableFrom)
+	}
+
+	data, err := f.builder.Build(ctx, versionTag)
+	if err != nil {
+		return fmt.Errorf("error building VEX document: %w", err)
+	}
+
+	w.Header().Set("Content-Type", vexJSONMediaType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.vex.json"`, versionTag))
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.WriteHeader(http.StatusOK)
+
+	if r.Method == http.MethodHead {
+		return nil
+	}
+
+	_, err = w.Write(data)
+
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/siderolabs/go-blockdevice/v2 v2.0.28
 	github.com/siderolabs/go-debug v0.6.2
 	github.com/siderolabs/go-pointer v1.0.1
+	github.com/siderolabs/go-vex v0.0.0-20260430094145-fd0fd5ea1e79
 	github.com/siderolabs/talos v1.13.0
 	github.com/siderolabs/talos/pkg/machinery v1.13.0
 	github.com/sigstore/cosign/v3 v3.0.6
@@ -216,6 +217,8 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runc v1.3.0 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
+	github.com/openvex/go-vex v0.2.7 // indirect
+	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,12 @@ github.com/opencontainers/runc v1.3.0 h1:cvP7xbEvD0QQAs0nZKLzkVog2OPZhI/V2w3WmTm
 github.com/opencontainers/runc v1.3.0/go.mod h1:9wbWt42gV+KRxKRVVugNP6D5+PQciRbenB4fLVsqGPs=
 github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/openvex/go-vex v0.2.7 h1:/pN3bqvS4QOc6WkkL0hbKzJuAtsUD9vmvk9IZkzD3Zc=
+github.com/openvex/go-vex v0.2.7/go.mod h1:ZyQC3NXl9jjS53JOpBG3LAUXySkW8IlJ/GIhsnf5D54=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
+github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
+github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/petermattis/goid v0.0.0-20260226131333-17d1149c6ac6 h1:rh2lKw/P/EqHa724vYH2+VVQ1YnW4u6EOXl0PMAovZE=
@@ -597,6 +601,8 @@ github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/siderolabs/go-smbios v0.3.3 h1:rM3UKHQ8in1mqNRkpV75Ls3Wnk6rAhQJVYKUsKkQS20=
 github.com/siderolabs/go-smbios v0.3.3/go.mod h1:kScnr0XSyzLfkRo/ChjITgI0rPRQnIi6PdgbxVCwA9U=
+github.com/siderolabs/go-vex v0.0.0-20260430094145-fd0fd5ea1e79 h1:b8DPo7GYH/JLP9GEvU6ljgKgm4OUHQQW7lVZYzZVFnc=
+github.com/siderolabs/go-vex v0.0.0-20260430094145-fd0fd5ea1e79/go.mod h1:FRL9K46oYiSVHfH5XtZ5eex+qlca7L1SlP+9jI23zQY=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
 github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIGsr8Q=

--- a/hack/dev/compose.yaml
+++ b/hack/dev/compose.yaml
@@ -17,6 +17,8 @@ services:
       - OTEL_TRACES_EXPORTER=none
       - REGISTRY_LOG_LEVEL=info
       - REGISTRY_STORAGE_DELETE_ENABLED=true
+    ports:
+      - "5100:5000"
     restart: unless-stopped
   registry.ghcr.io:
     image: ghcr.io/distribution/distribution:edge

--- a/hack/dev/config.yaml
+++ b/hack/dev/config.yaml
@@ -32,3 +32,10 @@ http:
 # authentication:
 #   enabled: true
 #   htpasswdPath: /etc/image-factory/htpasswd
+
+enterprise:
+  vex:
+    data:
+      namespace: siderolabs/image-factory
+      repository: test-vex-data
+    cacheTTL: 15s

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -5,38 +5,18 @@ project_name = "image-factory"
 github_repo = "siderolabs/image-factory"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
-previous = "v1.1.0"
+previous = "v1.2.0"
 pre_release = false
 
 [notes]
 
-    [notes.authentication]
-        title = "Authentication Support (Enterprise)"
+    [notes.vex]
+        title = "VEX Support"
         description = """\
-Image Factory Enterprise now supports API key-based authentication.
-When enabled, all schematic access requires the caller to be authenticated.
-Each schematic records its owner at creation time, making schematics private to the user who created them.
-Authentication is configured via a set of usernames and associated API keys.
+Image Factory now supports VEX (Vulnerability Exploitability eXchange) documents, allowing users to associate vulnerability information with their schematics.
+This feature enables better tracking and management of vulnerabilities in the images created with Image Factory.
 
 **Note:** This feature is enterprise-only and is subject to the BUSL-1.1 license.
-"""
-
-    [notes.talosctl_endpoint]
-        title = "New /talosctl/:version Endpoint"
-        description = """\
-A new `/talosctl/:version` endpoint has been added that lists all downloadable talosctl binaries for a given Talos version.
-"""
-
-    [notes.french_locale]
-        title = "French Locale"
-        description = """\
-The Image Factory frontend now includes a French (fr) locale, adding translations for the web interface.
-"""
-
-    [notes.latest_tag]
-        title = "Stable Resolution for 'latest' Tag"
-        description = """\
-The `latest` tag in the registry frontend now resolves to the latest non-prerelease (stable) version instead of being passed through to the upstream registry.
 """
 
 [make_deps]

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
-	"github.com/siderolabs/image-factory/internal/artifacts/internal/image"
+	"github.com/siderolabs/image-factory/internal/image/verify"
 )
 
 // Options are the options for the artifacts manager.
@@ -46,7 +46,7 @@ type Options struct { //nolint:govet
 }
 
 // ImageVerifyOptions are the options for verifying the image signature.
-type ImageVerifyOptions = image.VerifyOptions
+type ImageVerifyOptions = verify.VerifyOptions
 
 // Kind is the artifact kind.
 type Kind string

--- a/internal/artifacts/fetch.go
+++ b/internal/artifacts/fetch.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/siderolabs/image-factory/internal/artifacts/internal/image"
+	"github.com/siderolabs/image-factory/internal/image/verify"
 )
 
 type imageHandler func(ctx context.Context, logger *zap.Logger, img v1.Image) error
@@ -122,7 +122,7 @@ func (m *Manager) fetchImageByDigest(digestRef name.Digest, architecture Arch, i
 		nameOptions = append(nameOptions, name.Insecure)
 	}
 
-	verifyResult, err := image.VerifySignatures(ctx, digestRef, m.options.ImageVerifyOptions, nameOptions...)
+	verifyResult, err := verify.VerifySignatures(ctx, digestRef, m.options.ImageVerifyOptions, nameOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to verify image signature for %s: %w", digestRef.Name(), err)
 	}

--- a/internal/frontend/http/locales/active.en.yaml
+++ b/internal/frontend/http/locales/active.en.yaml
@@ -298,6 +298,12 @@
 - id: final.extra.spdx_enterprise_feature
   translation: "SBOM (SPDX) bundle is only available through the Talos Linux Image Factory Enterprise."
 
+- id: final.extra.vex
+  translation: "VEX (Vulnerability Exploitability eXchange)"
+
+- id: final.extra.vex_enterprise_feature
+  translation: "VEX document is only available through the Talos Linux Image Factory Enterprise."
+
 - id: final.extra.checksum_enterprise_feature
   translation: "Checksums are only available through the Talos Linux Enterprise Image Factory."
 

--- a/internal/frontend/http/locales/active.fr.yaml
+++ b/internal/frontend/http/locales/active.fr.yaml
@@ -298,6 +298,12 @@
 - id: final.extra.spdx_enterprise_feature
   translation: "Le bundle SBOM (SPDX) est uniquement disponible via la Talos Linux Image Factory Enterprise."
 
+- id: final.extra.vex
+  translation: "VEX (Vulnerability Exploitability eXchange)"
+
+- id: final.extra.vex_enterprise_feature
+  translation: "Le document VEX est uniquement disponible via la Talos Linux Image Factory Enterprise."
+
 - id: final.extra.checksum_enterprise_feature
   translation: "Les sommes de contrôle sont uniquement disponibles via la Talos Linux Enterprise Image Factory."
 

--- a/internal/frontend/http/locales/active.pl.yaml
+++ b/internal/frontend/http/locales/active.pl.yaml
@@ -298,6 +298,12 @@
 - id: final.extra.spdx_enterprise_feature
   translation: "Pakiet SBOM (SPDX) jest dostępny wyłącznie za pośrednictwem Talos Linux Image Factory Enterprise."
 
+- id: final.extra.vex
+  translation: "VEX (Vulnerability Exploitability eXchange)"
+
+- id: final.extra.vex_enterprise_feature
+  translation: "Dokument VEX jest dostępny wyłącznie za pośrednictwem Talos Linux Image Factory Enterprise."
+
 - id: final.extra.checksum_enterprise_feature
   translation: "Sumy kontrolne są dostępne wyłącznie za pośrednictwem Talos Linux Enterprise Image Factory."
 

--- a/internal/frontend/http/locales/active.ru.yaml
+++ b/internal/frontend/http/locales/active.ru.yaml
@@ -295,6 +295,12 @@
 - id: final.extra.spdx_enterprise_feature
   translation: "Пакет SBOM (SPDX) доступен только через Talos Linux Enterprise Image Factory."
 
+- id: final.extra.vex
+  translation: "VEX (Vulnerability Exploitability eXchange)"
+
+- id: final.extra.vex_enterprise_feature
+  translation: "Документ VEX доступен только через Talos Linux Enterprise Image Factory."
+
 - id: final.extra.checksum_enterprise_feature
   translation: "Контрольные суммы доступны только через Talos Linux Enterprise Image Factory."
 

--- a/internal/frontend/http/templates/wizard-final.html
+++ b/internal/frontend/http/templates/wizard-final.html
@@ -141,6 +141,19 @@
         </dl>
         {{ end }}
         {{ end }}
+
+        {{ if .VEXAvailable }}
+        <h2>{{ t .Localizer "final.extra.vex" }}</h2>
+        {{ if .Enterprise }}
+        <dl>
+                <dd><a target="_blank" href="{{ .VEXBaseURL }}">{{ .VEXBaseURL }}</a></dd>
+        </dl>
+        {{ else }}
+        <dl>
+                <dd>{{ t .Localizer "final.extra.vex_enterprise_feature" }}</dd>
+        </dl>
+        {{ end }}
+        {{ end }}
 </div>
 
 <div class="flex gap-4">

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -714,6 +714,7 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 			PXEBaseURL               *placeholderURL
 			TalosctlBaseURL          *url.URL
 			SPDXBaseURL              *url.URL
+			VEXBaseURL               *url.URL
 			ChecksumBaseURL          *url.URL
 			InstallerImage           string
 			SecureBootInstallerImage string
@@ -724,6 +725,7 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 			ProductionGuideAvailable      bool
 			TalosctlAvailable             bool
 			SBOMAvailable                 bool
+			VEXAvailable                  bool
 			Enterprise                    bool
 		}{
 			WizardParams: params,
@@ -744,9 +746,11 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 			ProductionGuideAvailable:      talosVersion.GTE(semver.MustParse("1.5.0")),
 			TalosctlAvailable:             quirks.New(params.Version).SupportsFactoryTalosctlDownload(),
 			SBOMAvailable:                 talosVersion.GTE(semver.MustParse("1.11.0")),
+			VEXAvailable:                  talosVersion.GTE(semver.MustParse("1.13.0")),
 
 			Enterprise:      enterprise.Enabled(),
 			SPDXBaseURL:     f.options.ExternalURL.JoinPath("spdx", schematicID, version, params.Arch),
+			VEXBaseURL:      f.options.ExternalURL.JoinPath("vex", version, "vex.json"),
 			ChecksumBaseURL: f.options.ExternalURL.JoinPath("image", schematicID, version),
 		},
 		urlValues,

--- a/internal/image/verify/image.go
+++ b/internal/image/verify/image.go
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package image provides utilities for working with container image signatures.
-package image
+// Package verify provides utilities for verifying container image signatures.
+package verify
 
 import "github.com/sigstore/cosign/v3/pkg/cosign"
 

--- a/internal/image/verify/verify.go
+++ b/internal/image/verify/verify.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package image
+package verify
 
 import (
 	"context"

--- a/internal/image/verify/verify_test.go
+++ b/internal/image/verify/verify_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package image_test
+package verify_test
 
 import (
 	"testing"
@@ -12,16 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/siderolabs/image-factory/internal/artifacts/internal/image"
+	"github.com/siderolabs/image-factory/internal/image/verify"
 )
 
-func siderolabsVerifyOptions(t *testing.T) image.VerifyOptions {
+func siderolabsVerifyOptions(t *testing.T) verify.VerifyOptions {
 	t.Helper()
 
 	trustedRoot, err := cosign.TrustedRoot()
 	require.NoError(t, err)
 
-	return image.VerifyOptions{
+	return verify.VerifyOptions{
 		CheckOpts: []cosign.CheckOpts{
 			{
 				TrustedMaterial: trustedRoot,
@@ -40,7 +40,7 @@ func siderolabsVerifyOptions(t *testing.T) image.VerifyOptions {
 func TestVerifyLegacy(t *testing.T) {
 	t.Parallel()
 
-	result, err := image.VerifySignatures(
+	result, err := verify.VerifySignatures(
 		t.Context(),
 		name.MustParseReference("ghcr.io/siderolabs/talos:v1.11.0"),
 		siderolabsVerifyOptions(t),
@@ -54,7 +54,7 @@ func TestVerifyLegacy(t *testing.T) {
 func TestVerifyBundledSuccess(t *testing.T) {
 	t.Parallel()
 
-	result, err := image.VerifySignatures(
+	result, err := verify.VerifySignatures(
 		t.Context(),
 		name.MustParseReference("ghcr.io/siderolabs/talos:v1.11.5"),
 		siderolabsVerifyOptions(t),
@@ -68,7 +68,7 @@ func TestVerifyBundledSuccess(t *testing.T) {
 func TestVerifyFailure(t *testing.T) {
 	t.Parallel()
 
-	_, err := image.VerifySignatures(
+	_, err := verify.VerifySignatures(
 		t.Context(),
 		name.MustParseReference("ghcr.io/siderolabs/talos:v0.8.0"),
 		siderolabsVerifyOptions(t),

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -251,6 +251,8 @@ func setupEnterprise(t *testing.T, options *cmd.Options) {
 		return
 	}
 
+	options.Enterprise.VEX.Data = vexDataRepositoryFlag.OCIRepositoryOptions
+
 	// Skip if the caller already configured auth (e.g. reload tests that need
 	// explicit control over the htpasswd file path).
 	if options.Authentication.Enabled && options.Authentication.HTPasswdPath != "" {
@@ -380,6 +382,12 @@ func commonTest(t *testing.T, options cmd.Options) {
 
 		testAuthFrontend(ctx, t, baseURL)
 	})
+
+	t.Run("TestVEXFrontend", func(t *testing.T) {
+		t.Parallel()
+
+		testVEXFrontend(ctx, t, baseURL)
+	})
 }
 
 type ociRepositoryFalg struct {
@@ -407,6 +415,7 @@ var (
 	installerInternalRepository    = mustNewDefaultOCIRepository(cmd.DefaultOptions.Artifacts.Installer.Internal.String())
 	cacheRepository                = mustNewDefaultOCIRepository(cmd.DefaultOptions.Cache.OCI.String())
 	signingCacheRepository         = mustNewDefaultOCIRepository(cmd.DefaultOptions.Cache.OCI.String() + "sign")
+	vexDataRepositoryFlag          = mustNewDefaultOCIRepository(cmd.DefaultOptions.Enterprise.VEX.Data.String())
 )
 
 func init() {
@@ -416,4 +425,5 @@ func init() {
 	flag.Var(&installerInternalRepository, "test.installer-internal-repository", "image repository for the installer (internal)")
 	flag.Var(&cacheRepository, "test.cache-repository", "image repository for cached boot assets")
 	flag.Var(&signingCacheRepository, "test.signing-cache-repository", "image repository for signatures of cached boot assets (used for S3+CDN tests)")
+	flag.Var(&vexDataRepositoryFlag, "test.vex-data-repository", "OCI repository for VEX data")
 }

--- a/internal/integration/testdata/vex-data/talos.yaml
+++ b/internal/integration/testdata/vex-data/talos.yaml
@@ -1,0 +1,133 @@
+author: "Sidero Labs (https://siderolabs.com/)"
+ids:
+  purl: pkg:generic/talos
+statements:
+  - created: 2025-07-19T12:40:16Z
+    name: CVE-1999-0524
+    status: affected
+    action: |
+      This is a very common CVE of Low severity, however if it is a concern you need to configure your firewall
+      to reject ICMP timestamp requests. However, this does not have high impact on security in most cases.
+  - created: 2025-09-10T11:55:00Z
+    name: CVE-1999-0656
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2006-2932
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2007-2764
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-09-10T10:55:00Z
+    name: CVE-2007-4998
+    status: not_affected
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Talos Linux doesn't ship coreutils/busybox.
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2008-2544
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2008-4609
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2010-4563
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2014-8171
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2016-0774
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2016-3695
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2016-3699
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2017-6264
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-10840
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-10876
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-10882
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-10902
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-14625
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2018-6559
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2019-14899
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2019-3016
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2019-3819
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T20:34:39Z
+    name: CVE-2019-3887
+    status: fixed
+    statusNotes: |
+      CVE from long before Linux 6.12, considered fixed by the time of disclosure
+  - created: 2025-07-18T11:54:44Z
+    name: CVE-2017-1000377
+    status: not_affected
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      This vulnerability concerns PAX Linux, a patch set that is not applied to Talos Linux.
+  - created: 2025-07-18T20:02:23Z
+    name: CVE-2017-1000255
+    status: not_affected
+    justification: vulnerable_code_not_present
+    statusNotes: |
+      Talos does not target PowerPC architecture, so the affected code is not being built.

--- a/internal/integration/testdata/vex/v1.13.0.vex.json
+++ b/internal/integration/testdata/vex/v1.13.0.vex.json
@@ -1,0 +1,389 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-626e3bf1d299a4df3a418b2b8286b1cebf4f3270cf273d1b8521a714cfe230ce",
+  "author": "Sidero Labs (https://siderolabs.com/)",
+  "version": 1,
+  "tooling": "image-factory",
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-1999-0524"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "affected",
+      "action_statement": "This is a very common CVE of Low severity, however if it is a concern you need to configure your firewall\nto reject ICMP timestamp requests. However, this does not have high impact on security in most cases.\n",
+      "timestamp": "2025-07-19T12:40:16Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-1999-0656"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-09-10T11:55:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2006-2932"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2007-2764"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2007-4998"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Talos Linux doesn't ship coreutils/busybox.\n",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-09-10T10:55:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2008-2544"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2008-4609"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2010-4563"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2014-8171"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2016-0774"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2016-3695"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2016-3699"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2017-1000255"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Talos does not target PowerPC architecture, so the affected code is not being built.\n",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-07-18T20:02:23Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2017-1000377"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "This vulnerability concerns PAX Linux, a patch set that is not applied to Talos Linux.\n",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-07-18T11:54:44Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2017-6264"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-10840"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-10876"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-10882"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-10902"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-14625"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2018-6559"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-14899"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-3016"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-3819"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2019-3887"
+      },
+      "products": [
+        {
+          "identifiers": {
+            "purl": "pkg:generic/talos@v1.13.0"
+          }
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "CVE from long before Linux 6.12, considered fixed by the time of disclosure\n",
+      "timestamp": "2025-07-18T20:34:39Z"
+    }
+  ],
+  "timestamp": "2026-05-05T13:52:39Z"
+}
+

--- a/internal/integration/vex_test.go
+++ b/internal/integration/vex_test.go
@@ -1,0 +1,179 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+)
+
+//go:embed "testdata/vex/v1.13.0.vex.json"
+var vexFile []byte
+
+const vexTestTalosVersion = "v1.13.0"
+
+func downloadVEX(ctx context.Context, t *testing.T, baseURL, version, method string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+"/vex/"+version+"/vex.json", nil)
+	require.NoError(t, err)
+
+	addTestAuth(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		resp.Body.Close()
+	})
+
+	return resp
+}
+
+func testVEXFrontend(ctx context.Context, t *testing.T, baseURL string) {
+	if !enterprise.Enabled() {
+		t.Run("endpoint not registered", func(t *testing.T) {
+			t.Parallel()
+
+			resp := downloadVEX(ctx, t, baseURL, vexTestTalosVersion, http.MethodGet)
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		})
+
+		return
+	}
+
+	t.Run("GET valid version", func(t *testing.T) {
+		t.Parallel()
+
+		resp := downloadVEX(ctx, t, baseURL, vexTestTalosVersion, http.MethodGet)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		assert.Equal(t,
+			`attachment; filename="`+vexTestTalosVersion+`.vex.json"`,
+			resp.Header.Get("Content-Disposition"),
+		)
+
+		contentLength := resp.Header.Get("Content-Length")
+		require.NotEmpty(t, contentLength)
+
+		clValue, err := strconv.ParseInt(contentLength, 10, 64)
+		require.NoError(t, err)
+		assert.Greater(t, clValue, int64(0))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.True(t, json.Valid(body))
+
+		assert.Equal(t, decodeVEX(t, body), decodeVEX(t, vexFile))
+	})
+
+	t.Run("HEAD valid version", func(t *testing.T) {
+		t.Parallel()
+
+		resp := downloadVEX(ctx, t, baseURL, vexTestTalosVersion, http.MethodHead)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		assert.Equal(t,
+			`attachment; filename="`+vexTestTalosVersion+`.vex.json"`,
+			resp.Header.Get("Content-Disposition"),
+		)
+
+		contentLength := resp.Header.Get("Content-Length")
+		require.NotEmpty(t, contentLength)
+
+		clValue, err := strconv.ParseInt(contentLength, 10, 64)
+		require.NoError(t, err)
+		assert.Greater(t, clValue, int64(0))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Empty(t, body)
+	})
+
+	t.Run("version without v prefix", func(t *testing.T) {
+		t.Parallel()
+
+		resp := downloadVEX(ctx, t, baseURL, "1.13.0", http.MethodGet)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// handler adds the v prefix
+		assert.Equal(t,
+			`attachment; filename="v1.13.0.vex.json"`,
+			resp.Header.Get("Content-Disposition"),
+		)
+	})
+
+	t.Run("invalid version", func(t *testing.T) {
+		t.Parallel()
+
+		for _, version := range []string{
+			"not-a-version",
+			"v1.12.0", // below availableFrom (1.13.0)
+		} {
+			t.Run(version, func(t *testing.T) {
+				t.Parallel()
+
+				resp := downloadVEX(ctx, t, baseURL, version, http.MethodGet)
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			})
+		}
+	})
+
+	t.Run("cached response", func(t *testing.T) {
+		t.Parallel()
+
+		// first request: fetch from OCI registry (may be slow)
+		resp1 := downloadVEX(ctx, t, baseURL, vexTestTalosVersion, http.MethodGet)
+		require.Equal(t, http.StatusOK, resp1.StatusCode)
+
+		firstSize, err := io.Copy(io.Discard, resp1.Body)
+		require.NoError(t, err)
+
+		// second request: served from in-memory cache
+		start := time.Now()
+
+		resp2 := downloadVEX(ctx, t, baseURL, vexTestTalosVersion, http.MethodGet)
+		require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+		secondSize, err := io.Copy(io.Discard, resp2.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, firstSize, secondSize)
+		assert.Less(t, time.Since(start), 5*time.Second)
+	})
+}
+
+func decodeVEX(t *testing.T, data []byte) any {
+	t.Helper()
+
+	var value any
+	require.NoError(t, json.Unmarshal(data, &value))
+
+	if valueMap, ok := value.(map[string]any); ok {
+		for _, key := range []string{"timestamp", "@id"} {
+			valueMap[key] = nil
+		}
+
+		value = valueMap
+	}
+
+	return value
+}

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset"
 	"github.com/siderolabs/image-factory/internal/image/signer"
+	"github.com/siderolabs/image-factory/internal/image/verify"
 	"github.com/siderolabs/image-factory/internal/schematic"
 )
 
@@ -39,6 +40,16 @@ type SPDXOptions struct {
 	RemoteOptions           []remote.Option
 	RegistryRefreshInterval time.Duration
 	CacheInsecure           bool
+}
+
+// VEXOptions holds configuration options for the VEX frontend.
+type VEXOptions struct {
+	Data            string
+	RemoteOptions   []remote.Option
+	VerifyOptions   verify.VerifyOptions
+	RefreshInterval time.Duration
+	CacheTTL        time.Duration
+	DataInsecure    bool
 }
 
 // ErrNotEnabledTag tags errors that occur when an enterprise feature is

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -17,6 +17,11 @@ func Enabled() bool {
 	return false
 }
 
+// NewVEXFrontend returns a new VEX FrontendPlugin.
+func NewVEXFrontend(_ *zap.Logger, _ VEXOptions) (FrontendPlugin, error) {
+	return nil, errors.New("VEX is not supported in the non-enterprise version")
+}
+
 // NewSpdxFrontend returns a new Spdx FrontendPlugin.
 func NewSpdxFrontend(_ *zap.Logger, _ SPDXOptions) (FrontendPlugin, error) {
 	return nil, errors.New("SPDX is not supported in the non-enterprise version")

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -17,6 +17,8 @@ import (
 	"github.com/siderolabs/image-factory/enterprise/spdx"
 	"github.com/siderolabs/image-factory/enterprise/spdx/builder"
 	"github.com/siderolabs/image-factory/enterprise/spdx/storage/registry"
+	"github.com/siderolabs/image-factory/enterprise/vex"
+	vexbuilder "github.com/siderolabs/image-factory/enterprise/vex/builder"
 )
 
 // Enabled indicates whether Enterprise features are enabled.
@@ -24,7 +26,24 @@ func Enabled() bool {
 	return true
 }
 
-// NewSpdxFrontend returns a new Spdx FrontendPlugin.
+// NewVEXFrontend returns a new VEX FrontendPlugin.
+func NewVEXFrontend(logger *zap.Logger, config VEXOptions) (FrontendPlugin, error) {
+	b, err := vexbuilder.NewBuilder(logger, vexbuilder.Options{
+		Registry:        config.Data,
+		Insecure:        config.DataInsecure,
+		RefreshInterval: config.RefreshInterval,
+		RemoteOptions:   config.RemoteOptions,
+		VerifyOptions:   config.VerifyOptions,
+		CacheTTL:        config.CacheTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating VEX builder: %w", err)
+	}
+
+	return vex.NewFrontend(b), nil
+}
+
+// NewSpdxFrontend returns a new SPDX FrontendPlugin.
 func NewSpdxFrontend(logger *zap.Logger, opts SPDXOptions) (FrontendPlugin, error) {
 	var repoOpts []name.Option
 


### PR DESCRIPTION
This feature is Enterprise only (requires BUSL).

Serves GET/HEAD /vex/:version/vex.json for Talos ≥ 1.13.0.
Pulls exploitability data from an OCI registry, generates a VEX
document via go-vex, and caches it in-memory with configurable TTL.

<img width="507" height="950" alt="image" src="https://github.com/user-attachments/assets/9a9f4ae7-2649-4351-b41b-202cc4ff83f1" />

Closes #427

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
