### PR TITLE
feat: add enterprise features with Helm chart support

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -127,6 +127,8 @@ spec:
       toplevel: true
     - name: push-talos-vex-data
       toplevel: true
+    - name: update-local-path-provisioner
+      toplevel: true
 ---
 kind: custom.Step
 name: imager-base
@@ -865,6 +867,23 @@ spec:
       - |
         @tar -C $(PWD)/internal/integration/testdata/vex-data -cvf $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar .
         @crane append -f $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar -t $(TALOS_VEX_DATA_IMAGE_REF)
+---
+kind: custom.Step
+name: update-local-path-provisioner
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    variables:
+      - name: LOCAL_PATH_PROVISIONER_VERSION
+        defaultValue: v0.0.35
+      - name: LOCAL_PATH_PROVISIONER_URL
+        defaultValue: "https://raw.githubusercontent.com/rancher/local-path-provisioner/$(LOCAL_PATH_PROVISIONER_VERSION)/deploy/local-path-storage.yaml"
+    script:
+      - |
+        @curl -sSL $(LOCAL_PATH_PROVISIONER_URL) -o ./deploy/helm/e2e/_manifests/local-path-storage.yaml
+        @yq -i 'with(select(.kind == "StorageClass"); .metadata.annotations."storageclass.kubernetes.io/is-default-class" = "true")' ./deploy/helm/e2e/_manifests/local-path-storage.yaml
+        @yq -i 'with(select(.kind == "Namespace"); .metadata.labels."pod-security.kubernetes.io/enforce" = "privileged")' ./deploy/helm/e2e/_manifests/local-path-storage.yaml
 ---
 kind: golang.UnitTests
 spec:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-05-05T13:49:12Z by kres 1762ab2.
+# Generated on 2026-05-07T13:45:16Z by kres 1762ab2.
 
 # common variables
 
@@ -103,6 +103,8 @@ K8S_VERSION ?= v1.35.0
 CHART_VERSION ?= 0.0.0-alpha.0
 GO_TOOLS_RELEASE ?= v0.3.1
 TALOS_VEX_DATA_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/image-factory/test-vex-data:latest
+LOCAL_PATH_PROVISIONER_VERSION ?= v0.0.35
+LOCAL_PATH_PROVISIONER_URL ?= https://raw.githubusercontent.com/rancher/local-path-provisioner/$(LOCAL_PATH_PROVISIONER_VERSION)/deploy/local-path-storage.yaml
 
 # help menu
 
@@ -455,6 +457,12 @@ sign-images: $(ARTIFACTS)/image-signer
 push-talos-vex-data:
 	@tar -C $(PWD)/internal/integration/testdata/vex-data -cvf $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar .
 	@crane append -f $(PWD)/$(ARTIFACTS)/test-vulnerability-data.tar -t $(TALOS_VEX_DATA_IMAGE_REF)
+
+.PHONY: update-local-path-provisioner
+update-local-path-provisioner:
+	@curl -sSL $(LOCAL_PATH_PROVISIONER_URL) -o ./deploy/helm/e2e/_manifests/local-path-storage.yaml
+	@yq -i 'with(select(.kind == "StorageClass"); .metadata.annotations."storageclass.kubernetes.io/is-default-class" = "true")' ./deploy/helm/e2e/_manifests/local-path-storage.yaml
+	@yq -i 'with(select(.kind == "Namespace"); .metadata.labels."pod-security.kubernetes.io/enforce" = "privileged")' ./deploy/helm/e2e/_manifests/local-path-storage.yaml
 
 .PHONY: rekres
 rekres:

--- a/deploy/helm/e2e/_manifests/local-path-storage.yaml
+++ b/deploy/helm/e2e/_manifests/local-path-storage.yaml
@@ -1,0 +1,157 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.35
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: busybox
+        imagePullPolicy: IfNotPresent

--- a/deploy/helm/e2e/testdata/htpasswd
+++ b/deploy/helm/e2e/testdata/htpasswd
@@ -1,0 +1,1 @@
+e2euser:$2y$05$x5uBLbOhVWS3h6rMVVb0meBIff5.KpvG3NgtKXOGImpfYcvL/c9xW

--- a/deploy/helm/e2e/tests/04-enterprise/00-namespace.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: image-factory-e2e
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/deploy/helm/e2e/tests/04-enterprise/01-install.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/01-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-image-factory-enterprise
+commands:
+  - command: >-
+      helm install image-factory ../../../image-factory
+        --wait --timeout=600s
+        --set config.authentication.enabled=true
+        --set-file auth.htpasswd=../../testdata/htpasswd
+        --set grypeDB.type=emptyDir
+        --set-file cacheSigningKey.key=../../testdata/signing-key.key
+    namespaced: true

--- a/deploy/helm/e2e/tests/04-enterprise/02-assert.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/02-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-factory
+status:
+  replicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-factory-htpasswd
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-factory-cache-signing-key
+type: Opaque
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-factory

--- a/deploy/helm/e2e/tests/04-enterprise/11-upgrade.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/11-upgrade.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: upgrade-grypeDB-pvc
+commands:
+  - command: >-
+      helm upgrade --install image-factory ../../../image-factory
+        --wait --timeout=600s --reuse-values
+        --set grypeDB.type=pvc
+        --set grypeDB.pvc.size=1Gi
+    namespaced: true

--- a/deploy/helm/e2e/tests/04-enterprise/12-assert.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/12-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-factory
+status:
+  replicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: image-factory-grype-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+status:
+  phase: Bound

--- a/deploy/helm/e2e/tests/04-enterprise/98-delete.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/98-delete.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: uninstall-image-factory
+commands:
+  - command: helm uninstall image-factory --wait --timeout=120s
+    namespaced: true

--- a/deploy/helm/e2e/tests/04-enterprise/99-error.yaml
+++ b/deploy/helm/e2e/tests/04-enterprise/99-error.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-factory
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: image-factory
+      app.kubernetes.io/instance: image-factory
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: image-factory
+        app.kubernetes.io/instance: image-factory
+    spec:
+      serviceAccountName: image-factory
+      containers:
+        - name: image-factory
+          image: ghcr.io/siderolabs/image-factory

--- a/deploy/helm/image-factory/README.md
+++ b/deploy/helm/image-factory/README.md
@@ -320,10 +320,13 @@ extraVolumeMounts:
 | affinity | object | `{}` |  |
 | args[0] | string | `"--config=/config.yaml"` | Path to the configuration file (mounted via ConfigMap). Do not remove this unless you are using args only. |
 | args[1] | string | `"--log-level=info"` | Log level [debug info warn error dpanic panic fatal] (default info) |
+| auth | object | `{"existingSecret":"","htpasswd":""}` | Enterprise Authentication (htpasswd) Requires the Enterprise image-factory build. The chart cannot verify image identity; enabling this on a non-Enterprise image causes the app to ignore the configuration. |
+| auth.existingSecret | string | `""` | Name of an existing Secret containing an "htpasswd" data key (bcrypt hashes only). Example: kubectl create secret generic my-htpasswd --from-file=htpasswd=./users.htpasswd |
+| auth.htpasswd | string | `""` | If 'existingSecret' is empty and config.authentication.enabled=true, a Secret is created from this content. Multiline htpasswd content. Bcrypt hashes only ($2y$/$2a$/$2b$). Generate using: htpasswd -bnB user password >> users.htpasswd |
 | cacheSigningKey | object | `{"existingSecret":"","key":""}` | Image Cache Signing Key Configuration # This secret contains the ECDSA private key used to sign cached Talos image artifacts. # This ensures that nodes can verify the integrity of images served by the Image Factory. # If you are running a self-hosted Image Factory, this key is required. |
 | cacheSigningKey.existingSecret | string | `""` | Name of an existing Secret containing the ECDSA private key. IMPORTANT: The existing secret MUST contain a data key named exactly "cache-signing.key". If your secret uses a different key, Image Factory will not find the file. Example creation: kubectl create secret generic image-factory-cache-signing-key --from-file=cache-signing.key=./signing-key.key |
 | cacheSigningKey.key | string | `""` | If 'existingSecret' is empty, a new Secret will be created. The ECDSA private key content (multiline string). Generate using: openssl ecparam -name prime256v1 -genkey -noout -out cache-signing.key |
-| config | object | `{"artifacts":{"schematic":{"insecure":false,"namespace":"siderolabs/image-factory","registry":"registry.example.com","repository":"schematics"}},"cache":{"signingKeyPath":"/etc/image-factory/keys/cache-signing.key"}}` | Sidero Image-Factory Configuration |
+| config | object | `{"artifacts":{"schematic":{"insecure":false,"namespace":"siderolabs/image-factory","registry":"registry.example.com","repository":"schematics"}},"authentication":{"enabled":false,"htpasswdPath":"/etc/image-factory/auth/htpasswd"},"cache":{"signingKeyPath":"/etc/image-factory/keys/cache-signing.key"}}` | Sidero Image-Factory Configuration |
 | env | list | `[]` | Environment variables to pass to Image Factory |
 | envFrom | list | `[]` | envFrom to pass to Image Factory |
 | extraObjects | list | `[]` |  |
@@ -339,6 +342,16 @@ extraVolumeMounts:
 | gatewayApi.ui.hostnames | list | `["factory.example.com"]` | Image Factory UI hostname |
 | gatewayApi.ui.labels | object | `{}` | Additional Labels |
 | gatewayApi.ui.parentRefs | list | `[]` | The Gateway(s) to attach this route to. You MUST define at least one parentRef for the route to be active. |
+| grypeDB | object | `{"emptyDir":{"sizeLimit":""},"pvc":{"accessModes":["ReadWriteOnce"],"annotations":{},"labels":{},"size":"10Gi","storageClassName":""},"type":"emptyDir"}` | Grype Vulnerability DB Volume (Enterprise scanner) This block lets you choose how that volume is provided. |
+| grypeDB.emptyDir | object | `{"sizeLimit":""}` | emptyDir options (used when type=emptyDir). Disk-backed by design (no Memory medium). |
+| grypeDB.emptyDir.sizeLimit | string | `""` | Optional sizeLimit for the emptyDir volume. |
+| grypeDB.pvc | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"labels":{},"size":"10Gi","storageClassName":""}` | PVC options (used when type=pvc). The chart creates a PersistentVolumeClaim. |
+| grypeDB.pvc.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC. |
+| grypeDB.pvc.annotations | object | `{}` | Additional annotations for the PVC. |
+| grypeDB.pvc.labels | object | `{}` | Additional labels for the PVC. |
+| grypeDB.pvc.size | string | `"10Gi"` | Requested storage size for the PVC. |
+| grypeDB.pvc.storageClassName | string | `""` | StorageClassName for the PVC. |
+| grypeDB.type | string | `"emptyDir"` | Volume backing type: emptyDir | pvc |
 | hostUsers | bool | `true` | Controls whether the pod uses the host's user namespace. When true (default), the pod uses the host user namespace. When false, the pod uses a separate user namespace for enhanced security isolation. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Image Factory |
 | image.repository | string | `"ghcr.io/siderolabs/image-factory"` | Repository to use for Image Factory |

--- a/deploy/helm/image-factory/templates/_helpers.tpl
+++ b/deploy/helm/image-factory/templates/_helpers.tpl
@@ -81,3 +81,23 @@ Otherwise, use the chart's fullname with a '-cache-signing-key' suffix.
     {{- include "image-factory.fullname" . -}}-cache-signing-key
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the name of the htpasswd Secret to use.
+If 'auth.existingSecret' is set, use it.
+Otherwise, use the chart's fullname with a '-htpasswd' suffix.
+*/}}
+{{- define "image-factory.htpasswdSecret" -}}
+{{- if .Values.auth.existingSecret -}}
+    {{- .Values.auth.existingSecret -}}
+{{- else -}}
+    {{- include "image-factory.fullname" . -}}-htpasswd
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the Grype DB PersistentVolumeClaim to use.
+*/}}
+{{- define "image-factory.grypeDBClaim" -}}
+    {{- include "image-factory.fullname" . -}}-grype-db
+{{- end -}}

--- a/deploy/helm/image-factory/templates/deployment.yaml
+++ b/deploy/helm/image-factory/templates/deployment.yaml
@@ -101,6 +101,13 @@ spec:
             - name: cache-signing-key
               mountPath: /etc/image-factory/keys
               readOnly: true
+            - name: grype-db
+              mountPath: /var/lib/grype
+            {{- if .Values.config.authentication.enabled }}
+            - name: htpasswd
+              mountPath: {{ dir .Values.config.authentication.htpasswdPath }}
+              readOnly: true
+            {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -116,6 +123,24 @@ spec:
             items:
               - key: cache-signing.key
                 path: cache-signing.key
+        - name: grype-db
+          {{- if eq .Values.grypeDB.type "emptyDir" }}
+          emptyDir:
+          {{- if .Values.grypeDB.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.grypeDB.emptyDir.sizeLimit }}
+          {{- end }}
+          {{- else if eq .Values.grypeDB.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ include "image-factory.grypeDBClaim" . }}
+          {{- end }}
+        {{- if .Values.config.authentication.enabled }}
+        - name: htpasswd
+          secret:
+            secretName: {{ include "image-factory.htpasswdSecret" . }}
+            items:
+              - key: htpasswd
+                path: {{ base .Values.config.authentication.htpasswdPath }}
+        {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/image-factory/templates/pvc-grype-db.yaml
+++ b/deploy/helm/image-factory/templates/pvc-grype-db.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.grypeDB.type "pvc" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "image-factory.grypeDBClaim" . }}
+  namespace: {{ include "image-factory.namespace" . }}
+  labels:
+    {{- include "image-factory.labels" . | nindent 4 }}
+    {{- with .Values.grypeDB.pvc.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.grypeDB.pvc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.grypeDB.pvc.accessModes | nindent 4 }}
+  {{- with .Values.grypeDB.pvc.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.grypeDB.pvc.size | quote }}
+{{- end }}

--- a/deploy/helm/image-factory/templates/secret-htpasswd.yaml
+++ b/deploy/helm/image-factory/templates/secret-htpasswd.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.config.authentication.enabled (not .Values.auth.existingSecret) }}
+{{- $htpasswd := .Values.auth.htpasswd | required ".Values.auth.htpasswd is required when config.authentication.enabled=true and config.authentication.existingSecret is empty." -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "image-factory.fullname" . }}-htpasswd
+  namespace: {{ include "image-factory.namespace" . }}
+  labels:
+    {{- include "image-factory.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  htpasswd: |
+    {{- $htpasswd | nindent 4 }}
+{{- end }}

--- a/deploy/helm/image-factory/tests/configmap_test.yaml
+++ b/deploy/helm/image-factory/tests/configmap_test.yaml
@@ -68,3 +68,59 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  # ========================================
+  # Enterprise Auth Injection Tests
+  # ========================================
+  - it: Should not enable authentication by default
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "enabled: true"
+
+  - it: Should inject authentication block when config.authentication.enabled
+    template: configmap.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+          htpasswdPath: /etc/image-factory/auth/htpasswd
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "authentication:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enabled: true"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "htpasswdPath: /etc/image-factory/auth/htpasswd"
+
+  - it: Should honor custom htpasswdPath in injected config
+    template: configmap.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+          htpasswdPath: /custom/dir/creds
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "htpasswdPath: /custom/dir/creds"
+
+  - it: Should pass enterprise.scanner config through unchanged
+    template: configmap.yaml
+    set:
+      config:
+        enterprise:
+          scanner:
+            databaseURL: https://mirror.example.com/grype
+            cacheTTL: 30m
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "databaseURL: https://mirror.example.com/grype"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "cacheTTL: 30m"

--- a/deploy/helm/image-factory/tests/deployment_test.yaml
+++ b/deploy/helm/image-factory/tests/deployment_test.yaml
@@ -522,3 +522,133 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  # ========================================
+  # Enterprise Auth + Grype DB Volume Tests
+  # ========================================
+  - it: Should not mount htpasswd volume by default
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: htpasswd
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: htpasswd
+
+  - it: Should mount htpasswd Secret at parent directory when config.authentication.enabled
+    template: deployment.yaml
+    set:
+      config:
+        authentication:
+           enabled: true
+      auth:
+        htpasswd: "u:$2y$05$x"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: htpasswd
+            secret:
+              secretName: RELEASE-NAME-image-factory-htpasswd
+              items:
+                - key: htpasswd
+                  path: htpasswd
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: htpasswd
+            mountPath: /etc/image-factory/auth
+            readOnly: true
+
+  - it: Should use existing Secret for htpasswd when set
+    template: deployment.yaml
+    set:
+      config:
+        authentication:
+           enabled: true
+      auth:
+        existingSecret: my-htpasswd-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: htpasswd
+            secret:
+              secretName: my-htpasswd-secret
+              items:
+                - key: htpasswd
+                  path: htpasswd
+
+  - it: Should derive mountPath and item path from custom htpasswdPath
+    template: deployment.yaml
+    set:
+      config:
+        authentication:
+           enabled: true
+           htpasswdPath: /var/run/auth/creds
+      auth:
+        htpasswd: "u:$2y$05$x"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: htpasswd
+            mountPath: /var/run/auth
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: htpasswd
+            secret:
+              secretName: RELEASE-NAME-image-factory-htpasswd
+              items:
+                - key: htpasswd
+                  path: creds
+
+  - it: Should mount grype-db emptyDir by default when grypeDB.enabled
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: grype-db
+            emptyDir: null
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: grype-db
+            mountPath: /var/lib/grype
+
+  - it: Should set sizeLimit on grype-db emptyDir when provided
+    template: deployment.yaml
+    set:
+      grypeDB:
+        enabled: true
+        emptyDir:
+          sizeLimit: 5Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: grype-db
+            emptyDir:
+              sizeLimit: 5Gi
+
+  - it: Should mount chart-managed PVC when grypeDB.type=pvc
+    template: deployment.yaml
+    set:
+      grypeDB:
+        enabled: true
+        type: pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: grype-db
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-image-factory-grype-db

--- a/deploy/helm/image-factory/tests/pvc_test.yaml
+++ b/deploy/helm/image-factory/tests/pvc_test.yaml
@@ -1,0 +1,151 @@
+suite: Grype DB PVC Logic
+templates:
+  - pvc-grype-db.yaml
+
+tests:
+  # ========================================
+  # Gating Tests
+  # ========================================
+  - it: Should not render when grypeDB.enabled is false
+    template: pvc-grype-db.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not render when type is emptyDir
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: emptyDir
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render PVC when type is pvc
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-image-factory-grype-db
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  # ========================================
+  # Configuration Pass-through Tests
+  # ========================================
+  - it: Should honor storageClassName when set
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+        pvc:
+          storageClassName: fast-ssd
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+
+  - it: Should omit storageClassName when empty
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+    asserts:
+      - isNull:
+          path: spec.storageClassName
+
+  - it: Should pass custom accessModes through
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+        pvc:
+          storageClassName: ""
+          accessModes:
+            - ReadWriteMany
+          size: 10Gi
+    asserts:
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany
+
+  - it: Should pass custom size through
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+        pvc:
+          storageClassName: ""
+          accessModes:
+            - ReadWriteOnce
+          size: 50Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+
+  - it: Should pass annotations and labels through
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+        pvc:
+          storageClassName: ""
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+          annotations:
+            volume.kubernetes.io/foo: bar
+          labels:
+            tier: storage
+    asserts:
+      - equal:
+          path: metadata.annotations["volume.kubernetes.io/foo"]
+          value: bar
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+
+  # ========================================
+  # Metadata Tests
+  # ========================================
+  - it: Should include standard Helm labels
+    template: pvc-grype-db.yaml
+    set:
+      grypeDB:
+        type: pvc
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: image-factory
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: Should be created in correct namespace
+    template: pvc-grype-db.yaml
+    release:
+      namespace: custom-namespace
+    set:
+      grypeDB:
+        type: pvc
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/deploy/helm/image-factory/tests/secret_htpasswd_test.yaml
+++ b/deploy/helm/image-factory/tests/secret_htpasswd_test.yaml
@@ -1,0 +1,133 @@
+suite: htpasswd Secret Logic
+templates:
+  - secret-htpasswd.yaml
+
+tests:
+  # ========================================
+  # Gating Tests
+  # ========================================
+  - it: Should not render when config.authentication.enabled is false
+    template: secret-htpasswd.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not render when existingSecret is set
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        existingSecret: my-pre-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should fail when config.authentication.enabled and htpasswd is empty
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: ".Values.auth.htpasswd is required when config.authentication.enabled=true and config.authentication.existingSecret is empty."
+
+  - it: Should render Secret when config.authentication.enabled and htpasswd provided
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        htpasswd: |-
+          e2euser:$2y$05$abcdefghijklmnopqrstuv
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-image-factory-htpasswd
+      - equal:
+          path: type
+          value: Opaque
+
+  # ========================================
+  # Content Tests
+  # ========================================
+  - it: Should store htpasswd under correct stringData key
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        htpasswd: |-
+          alice:$2y$05$abcdefghijklmnopqrstuv
+    asserts:
+      - isNotNull:
+          path: stringData.htpasswd
+      - matchRegex:
+          path: stringData.htpasswd
+          pattern: "\\$2[ayb]\\$"
+
+  - it: Should preserve multiline htpasswd content
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        htpasswd: |-
+          alice:$2y$05$abcdefghijklmnopqrstuv
+          bob:$2a$05$zyxwvutsrqponmlkjihgfe
+          carol:$2b$05$0123456789abcdef0123456
+    asserts:
+      - matchRegex:
+          path: stringData.htpasswd
+          pattern: "alice:"
+      - matchRegex:
+          path: stringData.htpasswd
+          pattern: "bob:"
+      - matchRegex:
+          path: stringData.htpasswd
+          pattern: "carol:"
+
+  # ========================================
+  # Metadata Tests
+  # ========================================
+  - it: Should include standard Helm labels
+    template: secret-htpasswd.yaml
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        htpasswd: "u:$2y$05$x"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: image-factory
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: Should be created in correct namespace
+    template: secret-htpasswd.yaml
+    release:
+      namespace: custom-namespace
+    set:
+      config:
+        authentication:
+          enabled: true
+      auth:
+        htpasswd: "u:$2y$05$x"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/deploy/helm/image-factory/values.schema.json
+++ b/deploy/helm/image-factory/values.schema.json
@@ -11,6 +11,20 @@
         "type": "string"
       }
     },
+    "auth": {
+      "description": "Enterprise Authentication (htpasswd) Requires the Enterprise image-factory build. The chart cannot verify image identity; enabling this on a non-Enterprise image causes the app to ignore the configuration.",
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "description": "Name of an existing Secret containing an \"htpasswd\" data key (bcrypt hashes only).",
+          "type": "string"
+        },
+        "htpasswd": {
+          "description": "If 'existingSecret' is empty and config.authentication.enabled=true, a Secret is created from this content. Multiline htpasswd content. Bcrypt hashes only ($2y$/$2a$/$2b$). Generate using: htpasswd -bnB user password \u003e\u003e users.htpasswd",
+          "type": "string"
+        }
+      }
+    },
     "cacheSigningKey": {
       "description": "Image Cache Signing Key Configuration # This secret contains the ECDSA private key used to sign cached Talos image artifacts. # This ensures that nodes can verify the integrity of images served by the Image Factory. # If you are running a self-hosted Image Factory, this key is required.",
       "type": "object",
@@ -51,6 +65,17 @@
                   "type": "string"
                 }
               }
+            }
+          }
+        },
+        "authentication": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "htpasswdPath": {
+              "type": "string"
             }
           }
         },
@@ -148,6 +173,59 @@
               ]
             }
           }
+        }
+      }
+    },
+    "grypeDB": {
+      "description": "Grype Vulnerability DB Volume (Enterprise scanner) This block lets you choose how that volume is provided.",
+      "type": "object",
+      "properties": {
+        "emptyDir": {
+          "description": "emptyDir options (used when type=emptyDir). Disk-backed by design (no Memory medium).",
+          "type": "object",
+          "properties": {
+            "sizeLimit": {
+              "description": "Optional sizeLimit for the emptyDir volume.",
+              "type": "string"
+            }
+          }
+        },
+        "pvc": {
+          "description": "PVC options (used when type=pvc). The chart creates a PersistentVolumeClaim.",
+          "type": "object",
+          "properties": {
+            "accessModes": {
+              "description": "Access modes for the PVC.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "annotations": {
+              "description": "Additional annotations for the PVC.",
+              "type": "object"
+            },
+            "labels": {
+              "description": "Additional labels for the PVC.",
+              "type": "object"
+            },
+            "size": {
+              "description": "Requested storage size for the PVC.",
+              "type": "string"
+            },
+            "storageClassName": {
+              "description": "StorageClassName for the PVC.",
+              "type": "string"
+            }
+          }
+        },
+        "type": {
+          "description": "Volume backing type: emptyDir | pvc",
+          "type": "string",
+          "enum": [
+            "emptyDir",
+            "pvc"
+          ]
         }
       }
     },

--- a/deploy/helm/image-factory/values.yaml
+++ b/deploy/helm/image-factory/values.yaml
@@ -199,6 +199,44 @@ config:
       ## Path to the private key used for signing boot assets
       # signingKeyPath: ""
 
+  ## Configuration for Enterprise Authentication (htpasswd)
+  authentication:
+    ## Enable Enterprise Authentication
+    enabled: false
+    ## Path to the htpasswd file containing user credentials (bcrypt hashes only)
+    htpasswdPath: /etc/image-factory/auth/htpasswd
+
+  ## Enterprise features configuration
+  # enterprise:
+    ## Scanner configuration for vulnerability scanning of base images and built artifacts
+    # scanner:
+      ## Cache configuration for the scan results
+      # cache:
+        ## Capacity of the scanner cache (number of entries)
+        # capacity: 4096
+        ## Time-to-live for cache entries
+        # ttl: 15m0s
+      ## URL of the vulnerability database to use for scanning
+      # databaseURL: https://grype.anchore.io/databases
+    ## Vulnerability Exploitability eXchange (VEX) configuration
+    # vex:
+      ## Cache configuration for VEX data
+      # cache:
+        ## Capacity of the VEX cache (number of entries)
+        # capacity: 65536
+        ## Time-to-live for VEX cache entries
+        # ttl: 15m0s
+      ## Data source configuration for VEX data
+      # data:
+        ## Allow insecure connections to the VEX data source
+        # insecure: false
+        ## Namespace for VEX data repository
+        # namespace: siderolabs/talos-vex
+        ## Registry for VEX data
+        # registry: ghcr.io
+        ## Repository name for VEX data
+        # repository: talos-vex-data
+
 # -- Environment variables to pass to Image Factory
 env: []
 
@@ -224,6 +262,45 @@ cacheSigningKey:
   # The ECDSA private key content (multiline string).
   # Generate using: openssl ecparam -name prime256v1 -genkey -noout -out cache-signing.key
   key: |-
+
+# -- Enterprise Authentication (htpasswd)
+# Requires the Enterprise image-factory build. The chart cannot verify image identity;
+# enabling this on a non-Enterprise image causes the app to ignore the configuration.
+auth:
+  # -- Name of an existing Secret containing an "htpasswd" data key (bcrypt hashes only).
+  # Example: kubectl create secret generic my-htpasswd --from-file=htpasswd=./users.htpasswd
+  existingSecret: ""
+  # @schema type:string
+  # -- If 'existingSecret' is empty and config.authentication.enabled=true, a Secret is created from this content.
+  # Multiline htpasswd content. Bcrypt hashes only ($2y$/$2a$/$2b$).
+  # Generate using: htpasswd -bnB user password >> users.htpasswd
+  htpasswd: |-
+
+# -- Grype Vulnerability DB Volume (Enterprise scanner)
+# This block lets you choose how that volume is provided.
+grypeDB:
+  # @schema enum:[emptyDir, pvc]
+  # -- Volume backing type: emptyDir | pvc
+  type: emptyDir
+  # -- emptyDir options (used when type=emptyDir). Disk-backed by design (no Memory medium).
+  emptyDir:
+    # @schema type:string
+    # -- Optional sizeLimit for the emptyDir volume.
+    sizeLimit: ""
+  # -- PVC options (used when type=pvc). The chart creates a PersistentVolumeClaim.
+  pvc:
+    # @schema type:string
+    # -- StorageClassName for the PVC.
+    storageClassName: ""
+    # -- Access modes for the PVC.
+    accessModes:
+      - ReadWriteOnce
+    # -- Requested storage size for the PVC.
+    size: 10Gi
+    # -- Additional annotations for the PVC.
+    annotations: {}
+    # -- Additional labels for the PVC.
+    labels: {}
 
 # -- Ingress Configuration
 # This section configures standard Kubernetes Ingress resources.


### PR DESCRIPTION
This enables running image-factory Enterprise Edition via Helm while
supporting CVE vulnerability scanning with grype integration and VEX
and SBOM document generation.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
