### PR TITLE
feat: return normalized schematic on creation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,11 +58,17 @@ overlay: # optional
     data: "mydata"
 ```
 
-Output is a JSON-encoded schematic ID:
+Output is a JSON object containing the schematic ID and the canonical schematic body as YAML:
 
 ```json
-{"id":"2a63b6e7dab90ec9d44f213339b9545bd39c6499b22a14cf575c1ca4b6e39ff8"}
+{
+  "id": "2a63b6e7dab90ec9d44f213339b9545bd39c6499b22a14cf575c1ca4b6e39ff8",
+  "schematic": "customization:\n    extraKernelArgs:\n        - vga=791\n"
+}
 ```
+
+The `schematic` field is the canonical representation used to compute the ID.
+Callers should treat it as authoritative, since the factory may modify or add fields to the submitted schematic, for example setting `owner` for authenticated requests.
 
 This ID can be used to download images with this schematic.
 
@@ -72,6 +78,8 @@ Well-known schematic IDs:
 
 The schematic in Enterprise edition may contain an `owner` field, which restricts access to the schematic to the specified owner only.
 This requires authentication to be enabled.
+When authentication is enabled, the factory sets `owner` to the authenticated user.
+If the request body specifies an `owner` that does not match the authenticated user, the request is rejected.
 
 ### `GET /schematics/:schematic`
 

--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -7,6 +7,7 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -35,6 +36,10 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 
 	if f.options.AuthProvider != nil {
 		if username, ok := f.options.AuthProvider.UsernameFromContext(ctx); ok {
+			if schematic.Owner != "" && schematic.Owner != username {
+				return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("schematic owner does not match authenticated user"))
+			}
+
 			schematic.Owner = username
 		}
 	}
@@ -44,13 +49,20 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
+	normalized, err := schematic.Marshal()
+	if err != nil {
+		return err
+	}
+
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
 	resp := struct {
-		ID string `json:"id"`
+		ID        string `json:"id"`
+		Schematic string `json:"schematic"`
 	}{
-		ID: id,
+		ID:        id,
+		Schematic: string(normalized),
 	}
 
 	return json.NewEncoder(w).Encode(resp)

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -298,7 +298,7 @@ func testOwnership(ctx context.Context, t *testing.T, baseURL string) {
 		c, err := client.New(baseURL, clientAuthCredentials()...)
 		require.NoError(t, err)
 
-		ownedSchematicID, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		ownedSchematicID, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
 		require.NoError(t, err)
 	}
 
@@ -349,6 +349,17 @@ func testOwnership(ctx context.Context, t *testing.T, baseURL string) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
+
+	t.Run("PostSchematic_OwnerMismatch_403", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := client.New(baseURL, clientAuthCredentials()...)
+		require.NoError(t, err)
+
+		_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{Owner: "bob"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 403")
+	})
 }
 
 // testAuthS3NoRedirect asserts that the factory serves assets directly (no
@@ -372,7 +383,7 @@ func testAuthS3NoRedirect(t *testing.T, pool *dockertest.Pool) {
 		c, err := client.New(baseURL, clientAuthCredentials()...)
 		require.NoError(t, err)
 
-		_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
 		require.NoError(t, err)
 	}
 
@@ -428,7 +439,7 @@ func testAuthCDNNoRedirect(t *testing.T, pool *dockertest.Pool) {
 		c, err := client.New(baseURL, clientAuthCredentials()...)
 		require.NoError(t, err)
 
-		_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
 		require.NoError(t, err)
 	}
 

--- a/internal/integration/frontend_test.go
+++ b/internal/integration/frontend_test.go
@@ -69,7 +69,7 @@ func testFrontendAuth(ctx context.Context, baseURL string) func(t *testing.T) {
 			c, err := client.New(baseURL, clientAuthCredentials()...)
 			require.NoError(t, err)
 
-			_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+			_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
 			require.NoError(t, err)
 		})
 
@@ -83,7 +83,7 @@ func testFrontendAuth(ctx context.Context, baseURL string) func(t *testing.T) {
 			c, err := client.New(baseURL, client.WithBasicAuth(username, password))
 			require.NoError(t, err)
 
-			_, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+			_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
 			require.Error(t, err)
 			require.ErrorContains(t, err, "HTTP 401: authentication required")
 		})

--- a/internal/integration/schematic_test.go
+++ b/internal/integration/schematic_test.go
@@ -91,13 +91,15 @@ func init() {
 func createSchematicGetID(ctx context.Context, t *testing.T, c *client.Client, schematic schematic.Schematic) string {
 	t.Helper()
 
-	id, err := c.SchematicCreate(ctx, schematic)
+	id, normalized, err := c.SchematicCreate(ctx, schematic)
 	require.NoError(t, err)
+
+	schematic.Owner, _ = authCredentials()
+	assert.Equal(t, &schematic, normalized)
 
 	// get the schematic back and compare
 	retrieved, err := c.SchematicGet(ctx, id)
 	require.NoError(t, err)
-	schematic.Owner, _ = authCredentials()
 	assert.Equal(t, &schematic, retrieved)
 
 	return id

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -66,23 +66,43 @@ func (c *Client) BaseURL() string {
 }
 
 // SchematicCreate generates new schematic from the configuration.
-func (c *Client) SchematicCreate(ctx context.Context, schematic schematic.Schematic) (string, error) {
-	data, err := schematic.Marshal()
+//
+// It returns the schematic ID and the normalized schematic as returned by the factory.
+// The normalized schematic should be considered authoritative as it may differ from the
+// input (for example, the factory may set the owner field for authenticated requests).
+func (c *Client) SchematicCreate(ctx context.Context, sc schematic.Schematic) (string, *schematic.Schematic, error) {
+	data, err := sc.Marshal()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	var response struct {
-		ID string `json:"id"`
+		ID        string `json:"id"`
+		Schematic string `json:"schematic"`
 	}
 
 	if err = c.do(ctx, http.MethodPost, "/schematics", data, &response, map[string]string{
 		"Content-Type": "application/yaml",
 	}); err != nil {
-		return "", err
+		return "", nil, err
 	}
 
-	return response.ID, nil
+	if response.Schematic == "" {
+		// Older factories don't return the schematic in the create response, fetch it separately.
+		normalized, getErr := c.SchematicGet(ctx, response.ID)
+		if getErr != nil {
+			return "", nil, getErr
+		}
+
+		return response.ID, normalized, nil
+	}
+
+	normalized, err := schematic.Unmarshal([]byte(response.Schematic))
+	if err != nil {
+		return "", nil, err
+	}
+
+	return response.ID, normalized, nil
 }
 
 func (c *Client) SchematicGet(ctx context.Context, schematicID string) (*schematic.Schematic, error) {


### PR DESCRIPTION
The schematic creation response now includes the canonical schematic body alongside the ID. Callers should adopt both as authoritative, since the factory may normalize formatting, reorder fields, or set the owner for authenticated requests, and the caller cannot reproduce all of these locally. The Go client returns the parsed normalized schematic alongside the ID.

Also, fix the authenticated submission path to reject explicitly when a non-empty owner is provided that does not match the authenticated user, instead of silently overwriting it.

Part of siderolabs/omni#2797.