### PR TITLE
fix: build profile with version

### DIFF
--- a/enterprise/spdx/builder/builder.go
+++ b/enterprise/spdx/builder/builder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siderolabs/image-factory/internal/asset"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/schematic"
+	ifconstants "github.com/siderolabs/image-factory/pkg/constants"
 	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -143,10 +144,7 @@ func (b *Builder) buildBundle(sc *schematicpkg.Schematic, schematicID, versionTa
 		Files:        []File{},
 	}
 
-	logger.Debug("extracting SPDX from Talos",
-		zap.String("schematic", schematicID),
-		zap.String("version", versionTag),
-		zap.String("arch", string(arch)))
+	logger.Debug("extracting SPDX from Talos")
 
 	// Extract SPDX from Talos
 	var err error
@@ -194,6 +192,14 @@ func (b *Builder) extractTalosSPDX(ctx context.Context, bundle *Bundle, versionT
 	if err != nil {
 		return fmt.Errorf("invalid version: %w", err)
 	}
+
+	// We are manually setting the profile version and name here because after enhancing the profile
+	// the produced initramfs' magic number does not match what's expected by the decompression
+	// library, causing it to fail to decompress and preventing us from extracting the embedded SPDX files.
+	// That's why we are getting SBOM from each extension individually instead of relying on the
+	// one embedded in the initramfs.
+	prof.Version = talosVersion.String()
+	prof.Name = ifconstants.TalosName
 
 	asset, err := b.assetBuilder.Build(ctx, prof, talosVersion.String(), path, path)
 	if err != nil {

--- a/hack/dev/config.yaml
+++ b/hack/dev/config.yaml
@@ -36,6 +36,8 @@ authentication:
 enterprise:
   vex:
     data:
+      registry: registry.ghcr.io:5000
       namespace: siderolabs/image-factory
       repository: test-vex-data
+      insecure: true
     cacheTTL: 15s

--- a/internal/integration/spdx_test.go
+++ b/internal/integration/spdx_test.go
@@ -24,6 +24,15 @@ import (
 
 const spdxTestTalosVersion = "v1.12.4"
 
+// Two patch releases used to assert that the SPDX bundle reflects the
+// requested Talos version. A previous bug cached the initramfs by a profile
+// hash that did not include the version, so different versions returned the
+// same package set.
+const (
+	spdxRegressionVersionA = "v1.13.0"
+	spdxRegressionVersionB = "v1.13.2"
+)
+
 func downloadSPDX(ctx context.Context, t *testing.T, baseURL, schematicID, version, arch, method string) *http.Response {
 	t.Helper()
 
@@ -156,6 +165,65 @@ func testSPDXFrontend(ctx context.Context, t *testing.T, baseURL string) {
 
 		resp := downloadSPDX(ctx, t, baseURL, emptySchematicID, spdxTestTalosVersion, "invalid-arch", http.MethodGet)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("differs across talos versions", func(t *testing.T) {
+		t.Parallel()
+
+		fetchPackages := func(version string) []*spdx.Package {
+			resp := downloadSPDX(ctx, t, baseURL, emptySchematicID, version, "amd64", http.MethodGet)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			doc, err := spdxjson.Read(resp.Body)
+			require.NoError(t, err)
+
+			return doc.Packages
+		}
+
+		pkgsA := fetchPackages(spdxRegressionVersionA)
+		pkgsB := fetchPackages(spdxRegressionVersionB)
+
+		require.NotEmpty(t, pkgsA, "no packages extracted for %s", spdxRegressionVersionA)
+		require.NotEmpty(t, pkgsB, "no packages extracted for %s", spdxRegressionVersionB)
+
+		type pkgKey struct {
+			name    string
+			version string
+		}
+
+		toSet := func(pkgs []*spdx.Package) map[pkgKey]struct{} {
+			out := make(map[pkgKey]struct{}, len(pkgs))
+			for _, p := range pkgs {
+				out[pkgKey{name: p.PackageName, version: p.PackageVersion}] = struct{}{}
+			}
+
+			return out
+		}
+
+		setA := toSet(pkgsA)
+		setB := toSet(pkgsB)
+
+		diff := 0
+
+		for k := range setA {
+			if _, ok := setB[k]; !ok {
+				diff++
+			}
+		}
+
+		for k := range setB {
+			if _, ok := setA[k]; !ok {
+				diff++
+			}
+		}
+
+		// Regression guard: the prior bug caused both versions to extract SPDX
+		// from the same cached initramfs, so the (name, version) sets were
+		// identical (diff == 0). Two adjacent patch releases must yield several
+		// differing entries (kernel/userspace package bumps).
+		assert.Greater(t, diff, 3,
+			"SPDX package set differs across Talos versions %s vs %s by %d (name, version) entries; expected > 3 (was 0 under the cache-collision bug)",
+			spdxRegressionVersionA, spdxRegressionVersionB, diff)
 	})
 
 	t.Run("cached response", func(t *testing.T) {


### PR DESCRIPTION
extractTalosSPDX was building the imager profile via ParseFromPath
alone, leaving prof.Version empty. The asset cache keys on 
factoryprofile.Hash(prof), so every Talos version for a given (arch,
output kind) collapsed to the same hash and reused whichever
initramfs was built first. Two different versions therefore returned
SPDX bundles extracted from identical initramfs payloads - only 
DocumentName and DocumentNamespace differed between responses.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
