### PR TITLE
fix: make PXE copyable on SecureBoot

### DIFF
--- a/internal/frontend/http/templates/wizard-final.html
+++ b/internal/frontend/http/templates/wizard-final.html
@@ -457,7 +457,9 @@
                 target="_blank">{{ t .Localizer "final.pxe.docs" }}</a>)
         {{ end }}
 </dt>
-<dd>{{ .PlatformMeta.SecureBootPXEScriptPath .Arch | $.PXEBaseURL.JoinPath }}</dd>
+<dd>
+        {{ template "copyable-text" (.PlatformMeta.SecureBootPXEScriptPath .Arch | $.PXEBaseURL.JoinPath) }}
+</dd>
 
 {{ else }}
 <dt>


### PR DESCRIPTION
Fix bug where the PXE script path was not copyable when SecureBoot was enabled.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
