### PR TITLE
feat: allow excluding Talos releases

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -86,6 +86,10 @@ type AssetBuilderOptions struct {
 	// MinTalosVersion specifies the minimum supported Talos version for assets.
 	MinTalosVersion string `koanf:"minTalosVersion"`
 
+	// BrokenTalosVersions lists Talos versions that should be considered broken and avoided when building assets.
+	// Those are versions that are known to have critical issues that prevent them from working correctly, such as bugs in Talos that cause build failures or runtime errors.
+	BrokenTalosVersions []string `koanf:"brokenTalosVersions"`
+
 	// MaxConcurrency sets the maximum number of simultaneous asset build operations.
 	MaxConcurrency int `koanf:"maxConcurrency"`
 }

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -449,8 +449,22 @@ func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager
 		return nil, fmt.Errorf("failed to parse minimum Talos version: %w", err)
 	}
 
+	brokenVersions := make([]semver.Version, 0, len(opts.Build.BrokenTalosVersions))
+
+	for _, v := range opts.Build.BrokenTalosVersions {
+		var parsed semver.Version
+
+		parsed, err = semver.Parse(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse broken Talos version %q: %w", v, err)
+		}
+
+		brokenVersions = append(brokenVersions, parsed)
+	}
+
 	artifactsManager, err := artifacts.NewManager(logger, artifacts.Options{
 		MinVersion:                  minVersion,
+		BrokenVersions:              brokenVersions,
 		ImageRegistry:               opts.Artifacts.Core.Registry,
 		InsecureImageRegistry:       opts.Artifacts.Core.Insecure,
 		ImageVerifyOptions:          imageVerifyOptions,

--- a/cmd/image-factory/flags/config.go
+++ b/cmd/image-factory/flags/config.go
@@ -5,6 +5,7 @@
 package flags
 
 import (
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -116,7 +117,35 @@ func splitProvider(s string) (string, string) {
 
 func newEnvConfig(prefix string) Config {
 	return Config{
-		Provider: env.Provider(".", env.Opt{Prefix: prefix}),
+		Provider: env.Provider(".", env.Opt{
+			Prefix:        prefix,
+			TransformFunc: envTransform(prefix),
+		}),
+	}
+}
+
+// envTransform maps a prefixed environment variable to a koanf-style dotted, lower-cased key,
+// and JSON-decodes values that look like a JSON array or object so that complex types
+// (e.g. []string, []struct{...}) can be set from a single environment variable.
+//
+// Examples:
+//   - IF_HTTP_EXTERNALURL=https://x         → http.externalurl = "https://x"
+//   - IF_HTTP_ALLOWEDORIGINS=["*","foo"]    → http.allowedorigins = []any{"*","foo"}
+//   - IF_BUILD_BROKENTALOSVERSIONS=[{...}]  → build.brokentalosversions = []any{map[...]}
+func envTransform(prefix string) func(k, v string) (string, any) {
+	return func(k, v string) (string, any) {
+		key := strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(k, prefix), "_", "."))
+
+		trimmed := strings.TrimSpace(v)
+		if trimmed != "" && (trimmed[0] == '[' || trimmed[0] == '{') {
+			var parsed any
+
+			if err := stdjson.Unmarshal([]byte(trimmed), &parsed); err == nil {
+				return key, parsed
+			}
+		}
+
+		return key, v
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,16 @@ MinTalosVersion specifies the minimum supported Talos version for assets.
 
 ---
 
+### `build.brokenTalosVersions`
+
+- **Type:** `[]string`
+- **Env:** `BUILD_BROKENTALOSVERSIONS`
+
+BrokenTalosVersions lists Talos versions that should be considered broken and avoided when building assets.
+Those are versions that are known to have critical issues that prevent them from working correctly, such as bugs in Talos that cause build failures or runtime errors.
+
+---
+
 ### `build.maxConcurrency`
 
 - **Type:** `int`
@@ -1045,6 +1055,7 @@ authentication:
     enabled: false
     htpasswdPath: ""
 build:
+    brokenTalosVersions: []
     maxConcurrency: 6
     minTalosVersion: 1.2.0
 cache:
@@ -1156,6 +1167,7 @@ IF_ARTIFACTS_SCHEMATIC_REPOSITORY=schematics
 IF_ARTIFACTS_TALOSVERSIONRECHECKINTERVAL=15m0s
 IF_AUTHENTICATION_ENABLED=false
 IF_AUTHENTICATION_HTPASSWDPATH=
+IF_BUILD_BROKENTALOSVERSIONS=[]
 IF_BUILD_MAXCONCURRENCY=6
 IF_BUILD_MINTALOSVERSION=1.2.0
 IF_CACHE_CDN_ENABLED=false
@@ -1197,7 +1209,7 @@ IF_ENTERPRISE_VEX_DATA_INSECURE=false
 IF_ENTERPRISE_VEX_DATA_NAMESPACE=siderolabs/talos-vex
 IF_ENTERPRISE_VEX_DATA_REGISTRY=ghcr.io
 IF_ENTERPRISE_VEX_DATA_REPOSITORY=talos-vex-data
-IF_HTTP_ALLOWEDORIGINS=[*]
+IF_HTTP_ALLOWEDORIGINS=["*"]
 IF_HTTP_CERTFILE=
 IF_HTTP_EXTERNALPXEURL=
 IF_HTTP_EXTERNALURL=https://localhost/

--- a/hack/dev/config.yaml
+++ b/hack/dev/config.yaml
@@ -15,6 +15,7 @@ artifacts:
     internal:
       registry: registry.local:5000
       namespace: siderolabs
+
 cache:
   oci:
     # private registry repository for cached assets

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -24,6 +24,8 @@ type Options struct { //nolint:govet
 	InsecureImageRegistry bool
 	// MinVersion is the minimum version of Talos to use.
 	MinVersion semver.Version
+	// BrokenVersions are Talos versions that should be rejected when listing available versions.
+	BrokenVersions []semver.Version
 	// ImageVerifyOptions are the options for verifying the image signature.
 	ImageVerifyOptions ImageVerifyOptions
 	// TalosVersionRecheckInterval is the interval for rechecking Talos versions.

--- a/internal/artifacts/manager.go
+++ b/internal/artifacts/manager.go
@@ -165,6 +165,11 @@ func (m *Manager) Get(ctx context.Context, versionString string, arch Arch, kind
 	return path, nil
 }
 
+// GetBrokenTalosVersions returns the list of Talos versions marked as broken in the configuration.
+func (m *Manager) GetBrokenTalosVersions() []semver.Version {
+	return slices.Clone(m.options.BrokenVersions)
+}
+
 // GetTalosVersions returns a list of Talos versions available.
 func (m *Manager) GetTalosVersions(ctx context.Context) ([]semver.Version, error) {
 	m.talosVersionsMu.Lock()

--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -55,6 +55,10 @@ func (m *Manager) fetchTalosVersions() (any, error) {
 			return false // ignore versions below minimum
 		}
 
+		if slices.ContainsFunc(m.options.BrokenVersions, version.EQ) {
+			return false // ignore versions marked as broken
+		}
+
 		if len(version.Pre) > 0 {
 			if version.Major != maxVersion.Major || version.Minor != maxVersion.Minor {
 				return false // ignore pre-releases for older versions

--- a/internal/frontend/http/meta.go
+++ b/internal/frontend/http/meta.go
@@ -21,7 +21,15 @@ import (
 )
 
 // handleVersions handles list of Talos versions available.
-func (f *Frontend) handleVersions(ctx context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+func (f *Frontend) handleVersions(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
+	if r.URL.Query().Get("broken") == "true" {
+		return json.NewEncoder(w).Encode(
+			xslices.Map(f.artifactsManager.GetBrokenTalosVersions(), func(v semver.Version) string {
+				return "v" + v.String()
+			}),
+		)
+	}
+
 	versions, err := f.artifactsManager.GetTalosVersions(ctx)
 	if err != nil {
 		return err

--- a/internal/integration/broken_versions_test.go
+++ b/internal/integration/broken_versions_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/pkg/client"
+)
+
+// TestBrokenVersions verifies that versions listed in BrokenTalosVersions are
+// excluded from the /versions response and reported by /versions?broken=true.
+func TestBrokenVersions(t *testing.T) {
+	t.Parallel()
+
+	const brokenVersion = "v1.13.1"
+
+	options := cmd.DefaultOptions
+	options.Cache.OCI = cacheRepository.OCIRepositoryOptions
+	options.Metrics.Namespace = "test_broken_versions"
+	options.Build.BrokenTalosVersions = []string{brokenVersion[1:]}
+
+	ctx, listenAddr, _ := setupFactory(t, options)
+	baseURL := "http://" + listenAddr
+
+	c, err := client.New(baseURL, clientAuthCredentials()...)
+	require.NoError(t, err)
+
+	broken, err := c.BrokenVersions(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, broken, brokenVersion)
+
+	versions, err := c.Versions(ctx)
+	require.NoError(t, err)
+
+	assert.NotContains(t, versions, brokenVersion)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -81,9 +81,11 @@ func (c *Client) SchematicCreate(ctx context.Context, sc schematic.Schematic) (s
 		Schematic string `json:"schematic"`
 	}
 
-	if err = c.do(ctx, http.MethodPost, "/schematics", data, &response, map[string]string{
-		"Content-Type": "application/yaml",
-	}); err != nil {
+	if err = c.do(
+		ctx, http.MethodPost, "/schematics", &response,
+		WithRequestData(data),
+		WithHeaders(map[string]string{"Content-Type": "application/yaml"}),
+	); err != nil {
 		return "", nil, err
 	}
 
@@ -108,7 +110,7 @@ func (c *Client) SchematicCreate(ctx context.Context, sc schematic.Schematic) (s
 func (c *Client) SchematicGet(ctx context.Context, schematicID string) (*schematic.Schematic, error) {
 	var response schematic.Schematic
 
-	if err := c.do(ctx, http.MethodGet, "/schematics/"+schematicID, nil, &response, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/schematics/"+schematicID, &response); err != nil {
 		return nil, err
 	}
 
@@ -119,7 +121,21 @@ func (c *Client) SchematicGet(ctx context.Context, schematicID string) (*schemat
 func (c *Client) Versions(ctx context.Context) ([]string, error) {
 	var versions []string
 
-	if err := c.do(ctx, http.MethodGet, "/versions", nil, &versions, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/versions", &versions); err != nil {
+		return nil, err
+	}
+
+	return versions, nil
+}
+
+// BrokenVersions gets the list of Talos versions marked as broken by the factory.
+func (c *Client) BrokenVersions(ctx context.Context) ([]string, error) {
+	var versions []string
+
+	if err := c.do(
+		ctx, http.MethodGet, "/versions", &versions,
+		WithQueryParams(url.Values{"broken": {"true"}}),
+	); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +146,7 @@ func (c *Client) Versions(ctx context.Context) ([]string, error) {
 func (c *Client) ExtensionsVersions(ctx context.Context, talosVersion string) ([]ExtensionInfo, error) {
 	var versions []ExtensionInfo
 
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/version/%s/extensions/official", talosVersion), nil, &versions, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/version/%s/extensions/official", talosVersion), &versions); err != nil {
 		return nil, err
 	}
 
@@ -141,7 +157,7 @@ func (c *Client) ExtensionsVersions(ctx context.Context, talosVersion string) ([
 func (c *Client) TalosctlList(ctx context.Context, talosVersion string) ([]string, error) {
 	var urls []string
 
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/talosctl/%s", talosVersion), nil, &urls, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/talosctl/%s", talosVersion), &urls); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +168,7 @@ func (c *Client) TalosctlList(ctx context.Context, talosVersion string) ([]strin
 func (c *Client) OverlaysVersions(ctx context.Context, talosVersion string) ([]OverlayInfo, error) {
 	var versions []OverlayInfo
 
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/version/%s/overlays/official", talosVersion), nil, &versions, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/version/%s/overlays/official", talosVersion), &versions); err != nil {
 		return nil, err
 	}
 
@@ -167,26 +183,68 @@ func (c *Client) ScanReport(ctx context.Context, schematicID, talosVersion, arch
 
 	if err := c.do(ctx, http.MethodGet,
 		fmt.Sprintf("/scans/%s/%s/%s/%s", schematicID, talosVersion, arch, filename),
-		nil, &data, nil); err != nil {
+		&data); err != nil {
 		return nil, err
 	}
 
 	return data, nil
 }
 
-func (c *Client) do(ctx context.Context, method, uri string, requestData []byte, responseData any, headers map[string]string) error {
-	var reader io.Reader
+// requestOptions are options that can be applied to a request via [requestOption] functions.
+type requestOptions struct {
+	headers     map[string]string
+	query       url.Values
+	requestData []byte
+}
 
-	if requestData != nil {
-		reader = bytes.NewReader(requestData)
+// requestOption configures a request issued via [Client.do].
+type requestOption func(*requestOptions)
+
+// WithRequestData attaches a request body.
+func WithRequestData(data []byte) requestOption {
+	return func(o *requestOptions) {
+		o.requestData = data
+	}
+}
+
+// WithHeaders attaches request headers.
+func WithHeaders(headers map[string]string) requestOption {
+	return func(o *requestOptions) {
+		o.headers = headers
+	}
+}
+
+// WithQueryParams attaches URL query parameters.
+func WithQueryParams(query url.Values) requestOption {
+	return func(o *requestOptions) {
+		o.query = query
+	}
+}
+
+func (c *Client) do(ctx context.Context, method, uri string, responseData any, opts ...requestOption) error {
+	var ro requestOptions
+
+	for _, opt := range opts {
+		opt(&ro)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL.JoinPath(uri).String(), reader)
+	var reader io.Reader
+
+	if ro.requestData != nil {
+		reader = bytes.NewReader(ro.requestData)
+	}
+
+	endpoint := c.baseURL.JoinPath(uri)
+	if len(ro.query) > 0 {
+		endpoint.RawQuery = ro.query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), reader)
 	if err != nil {
 		return err
 	}
 
-	for k, v := range headers {
+	for k, v := range ro.headers {
 		req.Header.Add(k, v)
 	}
 

--- a/tools/docgen/docgen.go
+++ b/tools/docgen/docgen.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -139,6 +140,8 @@ func isBasicType(e ast.Expr) bool {
 }
 
 // walkStruct traverses struct fields recursively but only documents basic types.
+//
+//nolint:gocognit
 func walkStruct(
 	prefix string,
 	st *ast.StructType,
@@ -179,6 +182,30 @@ func walkStruct(
 				walkStruct(path, nested, structDefs, out)
 
 				continue
+			}
+		}
+
+		// Document arrays of nested structs as `[]StructName` and recurse into the element type
+		// using a `path[].field` prefix.
+		if arr, ok := field.Type.(*ast.ArrayType); ok {
+			if ident, ok := arr.Elt.(*ast.Ident); ok {
+				if nested, exists := structDefs[ident.Name]; exists {
+					desc := ""
+
+					if field.Doc != nil {
+						desc = strings.TrimSpace(field.Doc.Text())
+					}
+
+					*out = append(*out, FieldDoc{
+						Path:        path,
+						Type:        "[]" + ident.Name,
+						Description: desc,
+					})
+
+					walkStruct(path+"[]", nested, structDefs, out)
+
+					continue
+				}
 			}
 		}
 
@@ -250,7 +277,14 @@ func printMarkdown(docs []FieldDoc, help string, wr io.Writer) error {
 
 		if d.Type != "" {
 			fmt.Fprintf(&b, "- **Type:** `%s`\n", d.Type)
-			fmt.Fprintf(&b, "- **Env:** `%s`\n\n", strings.ReplaceAll(strings.ToUpper(d.Path), ".", "_"))
+
+			// Children of array fields (path contains "[]") can't be set via flat env vars; the
+			// whole slice must be set on the parent env var as a JSON literal.
+			if !strings.Contains(d.Path, "[]") {
+				fmt.Fprintf(&b, "- **Env:** `%s`\n", strings.ReplaceAll(strings.ToUpper(d.Path), ".", "_"))
+			}
+
+			b.WriteString("\n")
 		}
 
 		if d.Description != "" {
@@ -316,6 +350,22 @@ func flatten(prefix string, in map[string]any, out map[string]string) {
 			flatten(key, val, out)
 		default:
 			envKey := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+
+			if rv := reflect.ValueOf(v); rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+				if rv.Len() == 0 {
+					out[envKey] = "[]"
+
+					continue
+				}
+
+				data, err := json.Marshal(val)
+				if err == nil {
+					out[envKey] = string(data)
+
+					continue
+				}
+			}
+
 			out[envKey] = fmt.Sprint(val)
 		}
 	}


### PR DESCRIPTION
In case of broken Talos release, we keep serving it in the UI/API. This
can lead to issues when customers download broken release and try to run
it. We should be able to exclude the broken versions without creating
new release of Image Factory, purely by specifying them in config.

For API completeness, we will also serve /versions?broken=true endpoint
that lists the broken releases that should not be used.
