### PR TITLE
feat: add per-request correlation ID to logs

### DIFF
--- a/enterprise/auth/auth.go
+++ b/enterprise/auth/auth.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -158,14 +159,25 @@ type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request,
 // Middleware implements enterprise.AuthProvider.
 func (provider *Provider) Middleware(handler Handler) Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		// the request context already carries the request ID (set by the HTTP
+		// frontend wrapper), so auth events correlate with the rest of the request.
+		logger := ctxlog.Logger(ctx, provider.logger)
+
 		username, password, ok := r.BasicAuth()
 		if !ok {
+			logger.Debug("authentication required: no credentials provided")
+
 			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
 		}
 
 		if !provider.verifyCredentials(username, password) {
+			// log the attempted username for audit; never log the password.
+			logger.Warn("authentication failed: invalid credentials", zap.String("username", username))
+
 			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("invalid credentials"))
 		}
+
+		logger.Debug("authenticated", zap.String("username", username))
 
 		ctx = context.WithValue(ctx, authContextKey{}, username)
 

--- a/enterprise/scanner/builder/builder.go
+++ b/enterprise/scanner/builder/builder.go
@@ -33,6 +33,7 @@ import (
 	"github.com/siderolabs/image-factory/enterprise/auth"
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/cache"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
 )
 
@@ -211,8 +212,11 @@ func (b *Builder) scan(ctx context.Context, schematicID, versionTag, arch string
 	// checks (the SPDX builder re-verifies access against the schematic owner).
 	username, _ := auth.GetAuthUsername(ctx)
 
+	// carry the request ID into the detached scan so its logs keep the request_id.
+	reqID := ctxlog.RequestID(ctx)
+
 	resultCh := b.c.SF.DoChan(key, func() (any, error) { //nolint:contextcheck
-		return b.scanAndCache(username, schematicID, versionTag, arch, key)
+		return b.scanAndCache(reqID, username, schematicID, versionTag, arch, key)
 	})
 
 	select {
@@ -237,8 +241,11 @@ func cacheKey(schematicID, versionTag, arch string) string {
 }
 
 // scanAndCache runs under singleflight with a detached context.
-func (b *Builder) scanAndCache(username, schematicID, versionTag, arch, key string) (cachedScan, error) {
-	baseCtx := context.Background()
+//
+// reqID is the request ID, carried into the detached context so the scan logs
+// (and downstream SPDX/VEX builds) keep the request_id.
+func (b *Builder) scanAndCache(reqID, username, schematicID, versionTag, arch, key string) (cachedScan, error) {
+	baseCtx := ctxlog.WithRequestID(context.Background(), reqID)
 	if username != "" {
 		baseCtx = auth.WithAuthUsername(baseCtx, username)
 	}
@@ -246,7 +253,7 @@ func (b *Builder) scanAndCache(username, schematicID, versionTag, arch, key stri
 	ctx, cancel := context.WithTimeout(baseCtx, ScanTimeout)
 	defer cancel()
 
-	logger := b.logger.With(
+	logger := ctxlog.Logger(ctx, b.logger).With(
 		zap.String("schematic", schematicID),
 		zap.String("version", versionTag),
 		zap.String("arch", arch),

--- a/enterprise/spdx/builder/builder.go
+++ b/enterprise/spdx/builder/builder.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siderolabs/image-factory/enterprise/spdx/storage"
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/schematic"
 	ifconstants "github.com/siderolabs/image-factory/pkg/constants"
@@ -92,7 +93,7 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 
 	// Check cache first
 	if err := b.storage.Head(ctx, schematicID, versionTag, string(arch)); err == nil {
-		b.logger.Debug("SPDX bundle cache hit", zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
+		ctxlog.Logger(ctx, b.logger).Debug("SPDX bundle cache hit", zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
 
 		return b.storage.Get(ctx, schematicID, versionTag, string(arch))
 	}
@@ -108,8 +109,11 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 	// Build the bundle using singleflight to prevent duplicate work
 	cacheKey := CacheTag(schematicID, versionTag, string(arch))
 
+	// carry the request ID into the detached build so its logs keep the request_id.
+	reqID := ctxlog.RequestID(ctx)
+
 	resultCh := b.sf.DoChan(cacheKey, func() (any, error) { //nolint:contextcheck
-		return nil, b.buildBundle(sc, schematicID, versionTag, arch)
+		return nil, b.buildBundle(reqID, sc, schematicID, versionTag, arch)
 	})
 
 	select {
@@ -128,11 +132,12 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 // buildBundle creates and stores an SPDX bundle for a single architecture.
 // sc must be pre-fetched by the caller (Build) using the live request context,
 // since this function runs inside singleflight with context.Background().
-func (b *Builder) buildBundle(sc *schematicpkg.Schematic, schematicID, versionTag string, arch artifacts.Arch) error {
-	// Use a fresh context since we're in singleflight
-	ctx := context.Background()
+func (b *Builder) buildBundle(reqID string, sc *schematicpkg.Schematic, schematicID, versionTag string, arch artifacts.Arch) error {
+	// Use a fresh context since we're in singleflight, but carry the
+	// request ID so build logs keep the request_id.
+	ctx := ctxlog.WithRequestID(context.Background(), reqID)
 
-	logger := b.logger.With(zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
+	logger := ctxlog.Logger(ctx, b.logger).With(zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
 
 	logger.Info("building SPDX bundle")
 
@@ -324,6 +329,8 @@ func (b *Builder) extractSPDXFromInitramfs(bundle *Bundle, bootAsset asset.BootA
 
 // extractExtensionsSPDX extracts SPDX from all extensions in the schematic for a single architecture.
 func (b *Builder) extractExtensionsSPDX(ctx context.Context, bundle *Bundle, schematicData *schematicpkg.Schematic, versionTag string, arch artifacts.Arch) error {
+	logger := ctxlog.Logger(ctx, b.logger)
+
 	availableExtensions, err := b.artifactsManager.GetOfficialExtensions(ctx, versionTag)
 	if err != nil {
 		return fmt.Errorf("failed to get official extensions: %w", err)
@@ -340,7 +347,7 @@ func (b *Builder) extractExtensionsSPDX(ctx context.Context, bundle *Bundle, sch
 		}
 
 		if value.IsZero(extensionRef) {
-			b.logger.Warn("extension not found, skipping SPDX extraction",
+			logger.Warn("extension not found, skipping SPDX extraction",
 				zap.String("extension", extensionName),
 				zap.String("version", versionTag))
 
@@ -350,7 +357,7 @@ func (b *Builder) extractExtensionsSPDX(ctx context.Context, bundle *Bundle, sch
 		// Extract SPDX for the requested architecture
 		files, err := b.artifactsManager.ExtractExtensionSPDX(ctx, arch, extensionRef)
 		if err != nil {
-			b.logger.Warn("failed to extract SPDX from extension",
+			logger.Warn("failed to extract SPDX from extension",
 				zap.String("extension", extensionName),
 				zap.String("arch", string(arch)),
 				zap.Error(err))
@@ -359,7 +366,7 @@ func (b *Builder) extractExtensionsSPDX(ctx context.Context, bundle *Bundle, sch
 		}
 
 		if len(files) == 0 {
-			b.logger.Debug("no SPDX files in extension",
+			logger.Debug("no SPDX files in extension",
 				zap.String("extension", extensionName),
 				zap.String("arch", string(arch)))
 

--- a/enterprise/spdx/storage/registry/registry.go
+++ b/enterprise/spdx/storage/registry/registry.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/siderolabs/image-factory/enterprise/spdx/builder"
 	"github.com/siderolabs/image-factory/enterprise/spdx/storage"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	"github.com/siderolabs/image-factory/internal/regtransport"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
@@ -85,7 +86,7 @@ func (s *Storage) Head(ctx context.Context, schematicID, version, arch string) e
 	tag := builder.CacheTag(schematicID, version, arch)
 	taggedRef := s.cacheRepository.Tag(tag)
 
-	s.logger.Debug("heading SPDX bundle", zap.Stringer("ref", taggedRef))
+	ctxlog.Logger(ctx, s.logger).Debug("heading SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	_, err := s.puller.Head(ctx, taggedRef)
 	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
@@ -104,7 +105,7 @@ func (s *Storage) Get(ctx context.Context, schematicID, version, arch string) (s
 	tag := builder.CacheTag(schematicID, version, arch)
 	taggedRef := s.cacheRepository.Tag(tag)
 
-	s.logger.Debug("getting SPDX bundle", zap.Stringer("ref", taggedRef))
+	ctxlog.Logger(ctx, s.logger).Debug("getting SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	desc, err := s.puller.Head(ctx, taggedRef)
 	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
@@ -120,12 +121,12 @@ func (s *Storage) Get(ctx context.Context, schematicID, version, arch string) (s
 	// Verify signature
 	err = s.imageSigner.VerifyImage(ctx, digestRef)
 	if err != nil {
-		s.logger.Warn("SPDX bundle signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef))
+		ctxlog.Logger(ctx, s.logger).Warn("SPDX bundle signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef))
 
 		return nil, xerrors.NewTaggedf[storage.ErrNotFoundTag]("SPDX bundle signature verification failed")
 	}
 
-	s.logger.Info("using cached SPDX bundle", zap.Stringer("ref", taggedRef))
+	ctxlog.Logger(ctx, s.logger).Info("using cached SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	imgDesc, err := s.puller.Get(ctx, digestRef)
 	if err != nil {
@@ -164,7 +165,7 @@ func (s *Storage) Put(ctx context.Context, schematicID, version, arch string, da
 	tag := builder.CacheTag(schematicID, version, arch)
 	taggedRef := s.cacheRepository.Tag(tag)
 
-	s.logger.Info("pushing SPDX bundle", zap.Stringer("ref", taggedRef))
+	ctxlog.Logger(ctx, s.logger).Info("pushing SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	// Read all data into memory for the layer
 	content, err := io.ReadAll(data)
@@ -195,7 +196,7 @@ func (s *Storage) Put(ctx context.Context, schematicID, version, arch string, da
 
 	digestRef := s.cacheRepository.Digest(digest.String())
 
-	s.logger.Info("signing SPDX bundle", zap.Stringer("ref", digestRef))
+	ctxlog.Logger(ctx, s.logger).Info("signing SPDX bundle", zap.Stringer("ref", digestRef))
 
 	if err := s.imageSigner.SignImage(ctx, digestRef, s.pusher); err != nil {
 		return fmt.Errorf("error signing SPDX bundle: %w", err)

--- a/enterprise/vex/builder/builder.go
+++ b/enterprise/vex/builder/builder.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/image-factory/internal/cache"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/verify"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
 	"github.com/siderolabs/image-factory/pkg/constants"
@@ -109,8 +110,11 @@ func (b *Builder) Build(ctx context.Context, versionTag string) ([]byte, error) 
 		return item.Value(), nil
 	}
 
+	// carry the request ID into the detached build so its logs keep the request_id.
+	reqID := ctxlog.RequestID(ctx)
+
 	resultCh := b.c.SF.DoChan(versionTag, func() (any, error) { //nolint:contextcheck
-		return b.buildAndCache(versionTag)
+		return b.buildAndCache(reqID, versionTag)
 	})
 
 	select {
@@ -131,8 +135,11 @@ func (b *Builder) Build(ctx context.Context, versionTag string) ([]byte, error) 
 }
 
 // buildAndCache runs under singleflight with a detached context.
-func (b *Builder) buildAndCache(versionTag string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+//
+// reqID is the request ID, carried into the detached context so the build logs
+// keep the request_id.
+func (b *Builder) buildAndCache(reqID, versionTag string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctxlog.WithRequestID(context.Background(), reqID), FetchTimeout)
 	defer cancel()
 
 	expData, err := b.fetchExploitabilityData(ctx)
@@ -191,7 +198,7 @@ func (b *Builder) fetchExploitabilityData(ctx context.Context) (*v1alpha1.Exploi
 
 	digestRef := tagRef.Digest(descriptor.Digest.String())
 
-	logger := b.logger.With(zap.Stringer("image", digestRef))
+	logger := ctxlog.Logger(ctx, b.logger).With(zap.Stringer("image", digestRef))
 
 	logger.Debug("verifying VEX image signature")
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/go-containerregistry v0.21.6
+	github.com/google/uuid v1.6.0
 	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/in-toto/attestation v1.2.0
@@ -263,7 +264,6 @@ require (
 	github.com/google/nftables v0.3.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect

--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset/cache"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	factoryprofile "github.com/siderolabs/image-factory/internal/profile"
 )
 
@@ -156,14 +157,18 @@ func (b *Builder) Build(ctx context.Context, prof profile.Profile, versionString
 	b.metricAssetCachedErrors.WithLabelValues(versionString, prof.Output.Kind.String(), prof.Arch).Inc()
 
 	if b.cacheMightFail {
-		b.logger.Warn("unable to reach cache, falling back to direct delivery", zap.Error(err))
+		ctxlog.Logger(ctx, b.logger).Warn("unable to reach cache, falling back to direct delivery", zap.Error(err))
 	} else if !errors.Is(err, cache.ErrCacheNotFound) {
 		return nil, fmt.Errorf("error getting asset from cache: %w", err)
 	}
 
-	// nothing in cache, so build the asset, but make sure we do it only once
+	// nothing in cache, so build the asset, but make sure we do it only once.
+	// pass the request ID explicitly: the build runs on a detached context (so it
+	// survives request cancellation) but its logs keep the request_id.
+	reqID := ctxlog.RequestID(ctx)
+
 	ch := b.sf.DoChan(profileHash, func() (any, error) { //nolint:contextcheck
-		return b.buildAndCache(profileHash, prof, versionString, filename)
+		return b.buildAndCache(reqID, profileHash, prof, versionString, filename)
 	})
 
 	select {
@@ -187,10 +192,15 @@ func (b *Builder) Build(ctx context.Context, prof profile.Profile, versionString
 }
 
 // buildAndCache builds the asset and pushes it to the cache.
-func (b *Builder) buildAndCache(profileHash string, prof profile.Profile, versionString, filename string) (BootAsset, error) {
-	// detach the context to make sure the asset is built no matter if the request is canceled
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+//
+// reqID is the request ID, carried into the detached build context so build logs
+// keep the request_id.
+func (b *Builder) buildAndCache(reqID, profileHash string, prof profile.Profile, versionString, filename string) (BootAsset, error) {
+	// detach the context to make sure the asset is built no matter if the request is canceled.
+	ctx, cancel := context.WithTimeout(ctxlog.WithRequestID(context.Background(), reqID), 20*time.Minute)
 	defer cancel()
+
+	logger := ctxlog.Logger(ctx, b.logger)
 
 	asset, err := b.build(ctx, prof, versionString)
 	if err != nil {
@@ -201,7 +211,7 @@ func (b *Builder) buildAndCache(profileHash string, prof profile.Profile, versio
 	b.metricAssetBytesBuilt.WithLabelValues(versionString, prof.Output.Kind.String(), prof.Arch).Add(float64(asset.Size()))
 
 	if err = b.cache.Put(ctx, profileHash, asset, filename); err != nil {
-		b.logger.Error("error putting asset to cache", zap.Error(err), zap.String("profile_hash", profileHash))
+		logger.Error("error putting asset to cache", zap.Error(err), zap.String("profile_hash", profileHash))
 	}
 
 	// if the asset delivery requires a redirect to the cache, we need to return the cached asset
@@ -216,7 +226,7 @@ func (b *Builder) buildAndCache(profileHash string, prof profile.Profile, versio
 		}
 
 		// if we failed to get the asset from cache, return the built asset anyway
-		b.logger.Warn("failed to get object from cache, falling back to direct delivery", zap.Error(err))
+		logger.Warn("failed to get object from cache, falling back to direct delivery", zap.Error(err))
 
 		b.metricAssetCachedErrors.WithLabelValues(versionString, prof.Output.Kind.String(), prof.Arch).Inc()
 	}
@@ -228,6 +238,8 @@ func (b *Builder) buildAndCache(profileHash string, prof profile.Profile, versio
 //
 // A concurrency limit is enforced.
 func (b *Builder) build(ctx context.Context, prof profile.Profile, versionString string) (BootAsset, error) {
+	logger := ctxlog.Logger(ctx, b.logger)
+
 	start := time.Now()
 
 	// enforce concurrency limit
@@ -242,7 +254,7 @@ func (b *Builder) build(ctx context.Context, prof profile.Profile, versionString
 	}()
 
 	concurrencyLatency := time.Since(start)
-	b.logger.Info("building image asset", zap.Any("profile", prof), zap.String("version", versionString), zap.Duration("concurrency_latency", concurrencyLatency))
+	logger.Info("building image asset", zap.Any("profile", prof), zap.String("version", versionString), zap.Duration("concurrency_latency", concurrencyLatency))
 	b.metricConcurrencyLatency.Observe(concurrencyLatency.Seconds())
 
 	if err := b.getBuildAsset(ctx, versionString, prof.Arch, artifacts.KindKernel, &prof.Input.Kernel); err != nil {
@@ -286,7 +298,7 @@ func (b *Builder) build(ctx context.Context, prof profile.Profile, versionString
 	tmpDir.size = st.Size()
 
 	buildLatency := time.Since(start) - concurrencyLatency
-	b.logger.Info("finished building image asset", zap.Any("profile", prof), zap.String("version", versionString), zap.Duration("build_latency", buildLatency))
+	logger.Info("finished building image asset", zap.Any("profile", prof), zap.String("version", versionString), zap.Duration("build_latency", buildLatency))
 	b.metricBuildLatency.Observe(buildLatency.Seconds())
 
 	return tmpDir, nil

--- a/internal/ctxlog/ctxlog.go
+++ b/internal/ctxlog/ctxlog.go
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package ctxlog carries a request ID through a context.Context so logs emitted
+// anywhere in a request share a request_id field.
+//
+// The context carries only the request ID, not a logger. Each component keeps
+// logging through its own logger (preserving its component-specific fields) and
+// annotates it with the request_id via Logger, instead of being replaced by a
+// request-scoped logger that would lose those fields.
+package ctxlog
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type requestIDContextKey struct{}
+
+// WithRequestID returns a copy of ctx carrying the request ID.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDContextKey{}, requestID)
+}
+
+// RequestID returns the request ID carried by ctx, or "" if none.
+func RequestID(ctx context.Context) string {
+	if requestID, ok := ctx.Value(requestIDContextKey{}).(string); ok {
+		return requestID
+	}
+
+	return ""
+}
+
+// Logger annotates base with the request_id carried by ctx.
+//
+// When ctx carries no request ID (e.g. background work, tests), base is returned
+// unchanged. base keeps all its own fields, so the component-specific context is
+// preserved alongside the request_id.
+func Logger(ctx context.Context, base *zap.Logger) *zap.Logger {
+	if requestID := RequestID(ctx); requestID != "" {
+		return base.With(zap.String("request_id", requestID))
+	}
+
+	return base
+}

--- a/internal/frontend/http/context.go
+++ b/internal/frontend/http/context.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/image-factory/internal/ctxlog"
+)
+
+// RequestIDHeader is the HTTP header carrying the per-request correlation ID.
+//
+// An inbound value is honored (so callers and upstream proxies can propagate
+// their own ID); otherwise a fresh one is generated and echoed back in the
+// response.
+const RequestIDHeader = "X-Request-ID"
+
+// RequestIDFromContext returns the request ID carried by ctx, or "" if none.
+func RequestIDFromContext(ctx context.Context) string {
+	return ctxlog.RequestID(ctx)
+}
+
+// reqLogger returns the request-scoped logger for ctx, falling back to the
+// frontend logger when the request did not pass through the wrapper (e.g. tests).
+func (f *Frontend) reqLogger(ctx context.Context) *zap.Logger {
+	return ctxlog.Logger(ctx, f.logger)
+}

--- a/internal/frontend/http/context_test.go
+++ b/internal/frontend/http/context_test.go
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/siderolabs/image-factory/internal/ctxlog"
+	httpfe "github.com/siderolabs/image-factory/internal/frontend/http"
+)
+
+// requestIDOf extracts the request_id field from a logged entry.
+func requestIDOf(t *testing.T, e observer.LoggedEntry) string {
+	t.Helper()
+
+	for _, f := range e.Context {
+		if f.Key == "request_id" {
+			return f.String
+		}
+	}
+
+	return ""
+}
+
+func TestWrapHandlerRequestID(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	f := httpfe.NewTestFrontend(logger)
+
+	var (
+		handlerRequestID  string
+		handlerLoggerSeen bool
+	)
+
+	handler := func(ctx context.Context, _ http.ResponseWriter, _ *http.Request, _ httprouter.Params) error { //nolint:unparam
+		handlerRequestID = httpfe.RequestIDFromContext(ctx)
+		// a handler logging via the request-scoped logger tags its entries.
+		ctxlog.Logger(ctx, logger).Info("handler log")
+
+		handlerLoggerSeen = true
+
+		return nil
+	}
+
+	t.Run("generates and echoes a request ID", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/image/abc/v1.0.0/foo", nil)
+
+		f.WrapHandler(handler)(w, r, nil)
+
+		require.True(t, handlerLoggerSeen)
+
+		id := w.Header().Get(httpfe.RequestIDHeader)
+		assert.NotEmpty(t, id, "response must carry a generated request ID")
+		assert.Equal(t, id, handlerRequestID, "context request ID must match the echoed one")
+
+		// every log entry for the request shares the same request_id.
+		entries := logs.TakeAll()
+		require.Len(t, entries, 2) // handler log + request log
+
+		for _, e := range entries {
+			assert.Equal(t, id, requestIDOf(t, e), "log %q missing matching request_id", e.Message)
+		}
+	})
+
+	t.Run("honors an inbound request ID", func(t *testing.T) {
+		const inbound = "inbound-correlation-id"
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/image/abc/v1.0.0/foo", nil)
+		r.Header.Set(httpfe.RequestIDHeader, inbound)
+
+		f.WrapHandler(handler)(w, r, nil)
+
+		assert.Equal(t, inbound, w.Header().Get(httpfe.RequestIDHeader))
+		assert.Equal(t, inbound, handlerRequestID)
+
+		for _, e := range logs.TakeAll() {
+			assert.Equal(t, inbound, requestIDOf(t, e))
+		}
+	})
+}

--- a/internal/frontend/http/export_test.go
+++ b/internal/frontend/http/export_test.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
+)
+
+// NewTestFrontend builds a minimal Frontend wired only with a logger, for tests
+// in the external test package that need to exercise the request wrapper.
+func NewTestFrontend(logger *zap.Logger) *Frontend {
+	return &Frontend{logger: logger}
+}
+
+// WrapHandler exposes the unexported request wrapper for external tests.
+func (f *Frontend) WrapHandler(h Handler) httprouter.Handle {
+	return f.wrapper(h)
+}

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/rs/cors"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
@@ -238,9 +240,19 @@ func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := r.Context()
 
+		requestID := r.Header.Get(RequestIDHeader)
+		if requestID == "" {
+			requestID = uuid.NewString()
+		}
+
+		ctx = ctxlog.WithRequestID(ctx, requestID)
+
+		logger := ctxlog.Logger(ctx, f.logger)
+
 		start := time.Now()
 
 		w.Header().Set("Server", version.ServerString())
+		w.Header().Set(RequestIDHeader, requestID)
 
 		err := h(ctx, w, r, p)
 
@@ -254,7 +266,7 @@ func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
 			http.Error(w, message, code)
 		})
 
-		f.logger.Log(
+		logger.Log(
 			level, "request",
 			zap.String("method", r.Method),
 			zap.String("path", r.URL.Path),

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -91,7 +91,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 	if r.URL.Query().Get("filename") != "" {
 		filename = r.URL.Query().Get("filename")
 
-		f.logger.Info("using filename override", zap.String("filename", filename))
+		f.reqLogger(ctx).Info("using filename override", zap.String("filename", filename))
 	}
 
 	asset, err := f.assetBuilder.Build(ctx, prof, version.String(), path, filename)
@@ -119,7 +119,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 			return nil
 		}
 
-		f.logger.Warn("asset does not support redirection, serving directly", zap.Error(err))
+		f.reqLogger(ctx).Warn("asset does not support redirection, serving directly", zap.Error(err))
 	}
 
 	w.Header().Set("Content-Length", strconv.FormatInt(asset.Size(), 10))

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/regtransport"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
@@ -101,10 +102,10 @@ func (f *Frontend) handleBlob(ctx context.Context, w http.ResponseWriter, req *h
 
 	digest := p.ByName("digest")
 
-	return f.handleExternalRegistry(w, req, img.Name(), schematicID, "blobs", digest)
+	return f.handleExternalRegistry(ctx, w, req, img.Name(), schematicID, "blobs", digest)
 }
 
-func (f *Frontend) handleExternalRegistry(w http.ResponseWriter, req *http.Request, imageName, schematicID, manifestsOrBlobs, tagOrDigest string) error {
+func (f *Frontend) handleExternalRegistry(ctx context.Context, w http.ResponseWriter, req *http.Request, imageName, schematicID, manifestsOrBlobs, tagOrDigest string) error {
 	var redirectURL url.URL
 
 	repo := f.options.InstallerExternalRepository
@@ -120,7 +121,7 @@ func (f *Frontend) handleExternalRegistry(w http.ResponseWriter, req *http.Reque
 
 	// When auth is active, always proxy - redirecting to the backing registry would bypass the auth boundary.
 	if f.options.ProxyInstallerInternalRepository || f.options.AuthProvider != nil {
-		f.logger.Info("proxying manifest/blob", zap.Stringer("location", location))
+		f.reqLogger(ctx).Info("proxying manifest/blob", zap.Stringer("location", location))
 
 		proxy := &httputil.ReverseProxy{
 			Director: func(out *http.Request) {
@@ -140,7 +141,7 @@ func (f *Frontend) handleExternalRegistry(w http.ResponseWriter, req *http.Reque
 		return nil
 	}
 
-	f.logger.Info("redirecting manifest/blob", zap.Stringer("location", location))
+	f.reqLogger(ctx).Info("redirecting manifest/blob", zap.Stringer("location", location))
 
 	w.Header().Add("Location", location.String())
 	w.WriteHeader(http.StatusTemporaryRedirect)
@@ -176,7 +177,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 
 	// if the tag is the digest, or it doesn't look like the version, we just redirect to the external registry
 	if strings.HasPrefix(versionTag, "sha256:") || !strings.HasPrefix(versionTag, "v") {
-		return f.handleExternalRegistry(w, req, img.Name(), schematicID, "manifests", versionTag)
+		return f.handleExternalRegistry(ctx, w, req, img.Name(), schematicID, "manifests", versionTag)
 	}
 
 	imageRepository := f.options.InstallerInternalRepository.Repo(
@@ -186,7 +187,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 	)
 
 	// check if the asset has already been built
-	f.logger.Info(
+	f.reqLogger(ctx).Info(
 		"heading installer image",
 		zap.String("image", img.Name()),
 		zap.String("schematic", schematicID),
@@ -200,7 +201,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 	)
 	if err == nil {
 		// the asset has already been built, so check the signature
-		f.logger.Info(
+		f.reqLogger(ctx).Info(
 			"verifying cached installer image signature",
 			zap.String("image", img.Name()),
 			zap.String("schematic", schematicID),
@@ -211,11 +212,17 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 		signatureErr := f.imageSigner.VerifyImage(ctx, imageRepository.Digest(extDesc.Digest.String()))
 		if signatureErr == nil {
 			// redirect to the external registry, but use the digest directly to avoid tag changes
-			return f.handleExternalRegistry(w, req, img.Name(), schematicID, "manifests", extDesc.Digest.String())
+			return f.handleExternalRegistry(ctx, w, req, img.Name(), schematicID, "manifests", extDesc.Digest.String())
 		}
 
 		// log the signature verification error, but continue to build the image
-		f.logger.Error("error verifying cached image signature", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag), zap.Error(signatureErr))
+		f.reqLogger(ctx).Error(
+			"error verifying cached image signature",
+			zap.String("image", img.Name()),
+			zap.String("schematic", schematicID),
+			zap.String("version", versionTag),
+			zap.Error(signatureErr),
+		)
 	}
 
 	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
@@ -237,9 +244,12 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 	// build installer images for each architecture, combine them into a single index and push it
 	key := fmt.Sprintf("%s-%s-%s", img.Name(), schematicID, versionTag)
 
+	// carry the request ID into the detached build so build logs keep the request_id.
+	reqID := ctxlog.RequestID(ctx)
+
 	resultCh := f.sf.DoChan(key, func() (any, error) { //nolint:contextcheck
 		// we use here detached context to make sure image is built no matter if the request is canceled
-		return f.buildInstallImage(context.Background(), img, schematic, version, schematicID, versionTag)
+		return f.buildInstallImage(ctxlog.WithRequestID(context.Background(), reqID), img, schematic, version, schematicID, versionTag)
 	})
 
 	var res singleflight.Result
@@ -260,7 +270,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 	}
 
 	// now we can redirect to the external registry
-	return f.handleExternalRegistry(w, req, img.Name(), schematicID, "manifests", manifestHash.String())
+	return f.handleExternalRegistry(ctx, w, req, img.Name(), schematicID, "manifests", manifestHash.String())
 }
 
 func (f *Frontend) resolveLatest(ctx context.Context, schematicID string) (string, error) {
@@ -282,13 +292,13 @@ func (f *Frontend) resolveLatest(ctx context.Context, schematicID string) (strin
 		}
 	}
 
-	f.logger.Info("resolving latest tag to version", zap.String("schematic", schematicID), zap.String("version", versionTag))
+	f.reqLogger(ctx).Info("resolving latest tag to version", zap.String("schematic", schematicID), zap.String("version", versionTag))
 
 	return versionTag, nil
 }
 
 func (f *Frontend) buildInstallImage(ctx context.Context, img requestedImage, schematic *schematic.Schematic, version semver.Version, schematicID, versionTag string) (v1.Hash, error) {
-	f.logger.Info("building installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag))
+	f.reqLogger(ctx).Info("building installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag))
 
 	var imageIndex v1.ImageIndex = empty.Index
 
@@ -326,7 +336,7 @@ func (f *Frontend) buildInstallImage(ctx context.Context, img requestedImage, sc
 			})
 	}
 
-	f.logger.Info("pushing installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag))
+	f.reqLogger(ctx).Info("pushing installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag))
 
 	installerRepo := f.options.InstallerInternalRepository.Repo(
 		f.options.InstallerInternalRepository.RepositoryStr(),
@@ -347,7 +357,7 @@ func (f *Frontend) buildInstallImage(ctx context.Context, img requestedImage, sc
 		return v1.Hash{}, fmt.Errorf("error getting index digest: %w", err)
 	}
 
-	f.logger.Info("signing installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag), zap.Stringer("digest", digest))
+	f.reqLogger(ctx).Info("signing installer image", zap.String("image", img.Name()), zap.String("schematic", schematicID), zap.String("version", versionTag), zap.Stringer("digest", digest))
 
 	if err := f.imageSigner.SignImage(
 		ctx,

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/schematic/storage"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
@@ -71,8 +72,10 @@ func (s *Factory) Put(ctx context.Context, cfg *schematic.Schematic) (string, er
 		return "", err
 	}
 
+	logger := ctxlog.Logger(ctx, s.logger)
+
 	if err = s.storage.Head(ctx, id); err == nil {
-		s.logger.Info("schematic already exists", zap.String("id", id))
+		logger.Info("schematic already exists", zap.String("id", id))
 
 		s.metricDuplicate.Inc()
 
@@ -88,7 +91,7 @@ func (s *Factory) Put(ctx context.Context, cfg *schematic.Schematic) (string, er
 	if err == nil {
 		s.metricCreate.Inc()
 
-		s.logger.Info("schematic created", zap.String("id", id), zap.Any("customization", cfg.Customization))
+		logger.Info("schematic created", zap.String("id", id), zap.Any("customization", cfg.Customization))
 	}
 
 	return id, err


### PR DESCRIPTION
Generate (or honor inbound X-Request-ID) a request ID per HTTP
request, bind a request-scoped logger carrying it in the context,
and echo the ID in the response header. All logs for one request
now share a request_id field.

Threaded through the build path: the request logger is carried
into detached/singleflight build contexts (installer image and
asset builder) and into schematic Put, so build and create logs
keep the originating request_id even after the request returns.

Artifacts fetch helpers (behind singleflight, shared across
requests) and background htpasswd watcher logs are intentionally
left on the construction-time logger.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
