### PR TITLE
feat: add secureboot enrollKeys schematic option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,9 @@ customization:
     secureboot: # optional, only applies to SecureBoot images
        # optional, include well-known UEFI certificates into auto-enrollment database (SecureBoot ISO only)
       includeWellKnownCertificates: true
+       # optional, how systemd-boot enrolls SecureBoot keys on first boot: off, manual, if-safe, force
+       # defaults to if-safe (auto-enrolls only in a VM); use force for unattended bare-metal enrollment in setup mode
+      enrollKeys: force
     bootloader: sd-boot # optional, defaults to auto (bootloader chosen by imager), other options: dual-boot, grub
     embeddedMachineConfiguration: | # optional, embedded machine configuration (YAML-encoded)
       apiVersion: v1alpha1

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -359,6 +359,30 @@ func EnhanceFromSchematic(
 		}
 
 		prof.Input.SecureBoot = &secureBootAssetsCopy
+
+		if enroll := schematic.Customization.SecureBoot.EnrollKeys; enroll != "" {
+			enrollKeys, err := profile.SDBootEnrollKeysString(enroll)
+			if err != nil {
+				return prof, xerrors.NewTaggedf[InvalidErrorTag]("invalid secureboot enrollKeys value %q: %w", enroll, err)
+			}
+
+			// secure-boot-enroll only applies to the ESP loader.conf, i.e. the ISO and
+			// disk image outputs; it is meaningless for installer/UKI outputs.
+			switch prof.Output.Kind { //nolint:exhaustive
+			case profile.OutKindISO:
+				if prof.Output.ISOOptions == nil {
+					prof.Output.ISOOptions = &profile.ISOOptions{}
+				}
+
+				prof.Output.ISOOptions.SDBootEnrollKeys = enrollKeys
+			case profile.OutKindImage:
+				if prof.Output.ImageOptions == nil {
+					prof.Output.ImageOptions = &profile.ImageOptions{}
+				}
+
+				prof.Output.ImageOptions.SDBootEnrollKeys = enrollKeys
+			}
+		}
 	}
 
 	if schematic.Overlay.Name != "" && !quirks.New(versionTag).SupportsOverlay() {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -973,3 +973,68 @@ func TestInstallerProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestEnhanceFromSchematicEnrollKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	secureBootService, err := secureboot.NewService(secureboot.Options{
+		Enabled:         true,
+		SigningKeyPath:  "sign-key.pem",
+		SigningCertPath: "sign-cert.pem",
+		PCRKeyPath:      "pcr-key.pem",
+	})
+	require.NoError(t, err)
+
+	base := func(name string) profile.Profile {
+		p := profile.Default[name]
+		p.Arch = "amd64"
+
+		return p.DeepCopy()
+	}
+
+	const version = "v1.13.0"
+
+	enrollKeysSchematic := func(value string) *schematic.Schematic {
+		return &schematic.Schematic{
+			Customization: schematic.Customization{
+				SecureBoot: schematic.SecureBootCustomization{EnrollKeys: value},
+			},
+		}
+	}
+
+	t.Run("force on disk image sets image options", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := imageprofile.EnhanceFromSchematic(ctx, base("secureboot-"+constants.PlatformMetal), enrollKeysSchematic("force"), mockArtifactProducer{}, secureBootService, version)
+		require.NoError(t, err)
+		require.NotNil(t, out.Output.ImageOptions)
+		require.Equal(t, profile.SDBootEnrollKeysForce, out.Output.ImageOptions.SDBootEnrollKeys)
+	})
+
+	t.Run("force on ISO sets ISO options", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := imageprofile.EnhanceFromSchematic(ctx, base("secureboot-iso"), enrollKeysSchematic("force"), mockArtifactProducer{}, secureBootService, version)
+		require.NoError(t, err)
+		require.NotNil(t, out.Output.ISOOptions)
+		require.Equal(t, profile.SDBootEnrollKeysForce, out.Output.ISOOptions.SDBootEnrollKeys)
+	})
+
+	t.Run("invalid value is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := imageprofile.EnhanceFromSchematic(ctx, base("secureboot-"+constants.PlatformMetal), enrollKeysSchematic("bogus"), mockArtifactProducer{}, secureBootService, version)
+		require.Error(t, err)
+	})
+
+	t.Run("ignored without secureboot", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := imageprofile.EnhanceFromSchematic(ctx, base(constants.PlatformMetal), enrollKeysSchematic("force"), mockArtifactProducer{}, secureBootService, version)
+		require.NoError(t, err)
+		require.NotNil(t, out.Output.ImageOptions)
+		require.Equal(t, profile.SDBootEnrollKeysIfSafe, out.Output.ImageOptions.SDBootEnrollKeys)
+	})
+}

--- a/pkg/schematic/schematic.go
+++ b/pkg/schematic/schematic.go
@@ -31,6 +31,8 @@ type Schematic struct {
 }
 
 // Customization represents the Talos image customization.
+//
+//nolint:govet // field order is part of the stable schematic serialization (see ID()), so it cannot be reordered for alignment
 type Customization struct {
 	// EmbeddedMachineConfiguration is the initial embedded machine configuration.
 	EmbeddedMachineConfiguration string `yaml:"embeddedMachineConfiguration,omitempty"`
@@ -73,6 +75,13 @@ type Overlay struct { //nolint:govet
 
 // SecureBootCustomization represents the secure boot options for the image.
 type SecureBootCustomization struct {
+	// EnrollKeys controls how systemd-boot enrolls the SecureBoot keys on first boot
+	// (loader.conf secure-boot-enroll): one of "off", "manual", "if-safe", "force".
+	//
+	// Defaults to "if-safe", which auto-enrolls keys only inside a virtual machine.
+	// Use "force" for unattended enrollment on bare-metal when the UEFI firmware is
+	// in setup mode.
+	EnrollKeys string `yaml:"enrollKeys,omitempty"`
 	// Include well-known UEFI certificates in the auto-enrollment database.
 	IncludeWellKnownCertificates bool `yaml:"includeWellKnownCertificates,omitempty"`
 }


### PR DESCRIPTION
## What?

Add a `secureboot.enrollKeys` field to the schematic, mapping to the imager's `SDBootEnrollKeys` profile option (`off` / `manual` / `if-safe` / `force`) for the ISO and disk-image outputs. It controls systemd-boot's `secure-boot-enroll` setting in `loader.conf`. The field is `omitempty`, so schematics that don't set it produce an unchanged ID.

```yaml
customization:
  secureboot:
    enrollKeys: force
```

## Why?

The default `if-safe` auto-enrolls SecureBoot keys only inside a VM, so on bare-metal keys are never enrolled unattended. Network provisioning flows with no console operator (PXE, Tinkerbell, Metal³, …) need `force`, which enrolls once while the UEFI firmware is in setup mode — sd-boot's setup-mode gate prevents it from ever overwriting an already-enrolled platform key.

Follow-up to the imager flag (siderolabs/talos#13571), per siderolabs/talos#12568 where @smira said this "can [be] put to the Image Factory as well" (as an opt-in; default stays `if-safe`).

## Notes

- Mapped per output kind (ISO → `ISOOptions`, disk image → `ImageOptions`); `secure-boot-enroll` is meaningless for installer/UKI outputs, so it's ignored there.
- Tests added for the mapping (force → image/ISO, invalid value rejected, ignored without SecureBoot); existing golden profile and schematic-ID tests are unchanged.
