### PR TITLE
feat: narrow sbom cache key to extension list only

### DIFF
--- a/enterprise/scanner/builder/builder.go
+++ b/enterprise/scanner/builder/builder.go
@@ -55,6 +55,7 @@ type VEXSource interface {
 // It must enforce ownership before returning bytes.
 type SPDXSource interface {
 	Build(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (io.ReadCloser, error)
+	PayloadHash(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (string, error)
 }
 
 // Options configures the Builder.
@@ -199,9 +200,15 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag, arch strin
 }
 
 func (b *Builder) scan(ctx context.Context, schematicID, versionTag, arch string) (*models.Document, *sbom.SBOM, error) {
-	key := cacheKey(schematicID, versionTag, arch)
+	// Derive the cache key from only the inputs that affect the SBOM content,
+	// so schematics that share the same extension list, version and arch
+	// reuse scan results.
+	sbomHash, err := b.spdxSource.PayloadHash(ctx, schematicID, versionTag, artifacts.Arch(arch))
+	if err != nil {
+		return nil, nil, err
+	}
 
-	if item := b.c.TTL.Get(key); item != nil && !item.IsExpired() {
+	if item := b.c.TTL.Get(sbomHash); item != nil && !item.IsExpired() {
 		entry := item.Value()
 
 		return entry.document, entry.sbom, nil
@@ -215,8 +222,8 @@ func (b *Builder) scan(ctx context.Context, schematicID, versionTag, arch string
 	// carry the request ID into the detached scan so its logs keep the request_id.
 	reqID := ctxlog.RequestID(ctx)
 
-	resultCh := b.c.SF.DoChan(key, func() (any, error) { //nolint:contextcheck
-		return b.scanAndCache(reqID, username, schematicID, versionTag, arch, key)
+	resultCh := b.c.SF.DoChan(sbomHash, func() (any, error) { //nolint:contextcheck
+		return b.scanAndCache(reqID, username, schematicID, versionTag, arch, sbomHash)
 	})
 
 	select {
@@ -234,10 +241,6 @@ func (b *Builder) scan(ctx context.Context, schematicID, versionTag, arch string
 
 		return entry.document, entry.sbom, nil
 	}
-}
-
-func cacheKey(schematicID, versionTag, arch string) string {
-	return schematicID + "|" + versionTag + "|" + arch
 }
 
 // scanAndCache runs under singleflight with a detached context.

--- a/enterprise/spdx/builder/builder.go
+++ b/enterprise/spdx/builder/builder.go
@@ -79,6 +79,22 @@ func NewBuilder(
 	}
 }
 
+// PayloadHash returns the SBOM cache key for the given schematic/version/arch.
+//
+// It fetches the schematic to extract the extension list, then computes a
+// content hash that reflects only the inputs that affect the SPDX bundle
+// content. Callers should use this hash as a cache key so that schematics
+// differing only in non-SBOM fields (kernel args, config, etc.) share
+// cached bundles.
+func (b *Builder) PayloadHash(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (string, error) {
+	sc, err := b.schematicFactory.Get(ctx, schematicID, b.authProvider)
+	if err != nil {
+		return "", fmt.Errorf("failed to get schematic: %w", err)
+	}
+
+	return Hash(sc.Customization.SystemExtensions.OfficialExtensions, versionTag, string(arch)), nil
+}
+
 // Build returns an SPDX bundle, building and caching if necessary.
 func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (storage.Bundle, error) {
 	// Normalize version tag
@@ -91,29 +107,32 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 		return nil, fmt.Errorf("invalid version: %w", err)
 	}
 
-	// Check cache first
-	if err := b.storage.Head(ctx, schematicID, versionTag, string(arch)); err == nil {
-		ctxlog.Logger(ctx, b.logger).Debug("SPDX bundle cache hit", zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
-
-		return b.storage.Get(ctx, schematicID, versionTag, string(arch))
-	}
-
-	// Verify access and fetch schematic data before entering singleflight.
-	// buildBundle runs with context.Background() (request context may be canceled),
-	// so ownership enforcement must happen here with the live request context.
+	// Fetch schematic first: we need the extension list to derive the cache key.
+	// Ownership enforcement happens here with the live request context, before
+	// entering singleflight which uses a detached context.
 	sc, err := b.schematicFactory.Get(ctx, schematicID, b.authProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schematic: %w", err)
 	}
 
-	// Build the bundle using singleflight to prevent duplicate work
-	cacheKey := CacheTag(schematicID, versionTag, string(arch))
+	// Compute cache key from only the inputs that affect the SBOM content
+	// (extensions list, version, architecture), so that schematics differing
+	// in other fields share the same cached bundle.
+	sbomHash := Hash(sc.Customization.SystemExtensions.OfficialExtensions, versionTag, string(arch))
 
+	// Check cache first
+	if err := b.storage.Head(ctx, sbomHash); err == nil {
+		ctxlog.Logger(ctx, b.logger).Debug("SPDX bundle cache hit", zap.String("schematic", schematicID), zap.String("version", versionTag), zap.String("arch", string(arch)))
+
+		return b.storage.Get(ctx, sbomHash)
+	}
+
+	// Build the bundle using singleflight to prevent duplicate work
 	// carry the request ID into the detached build so its logs keep the request_id.
 	reqID := ctxlog.RequestID(ctx)
 
-	resultCh := b.sf.DoChan(cacheKey, func() (any, error) { //nolint:contextcheck
-		return nil, b.buildBundle(reqID, sc, schematicID, versionTag, arch)
+	resultCh := b.sf.DoChan(sbomHash, func() (any, error) { //nolint:contextcheck
+		return nil, b.buildBundle(reqID, sc, schematicID, sbomHash, versionTag, arch)
 	})
 
 	select {
@@ -125,14 +144,14 @@ func (b *Builder) Build(ctx context.Context, schematicID, versionTag string, arc
 		}
 
 		// Retrieve from cache after building
-		return b.storage.Get(ctx, schematicID, versionTag, string(arch))
+		return b.storage.Get(ctx, sbomHash)
 	}
 }
 
 // buildBundle creates and stores an SPDX bundle for a single architecture.
 // sc must be pre-fetched by the caller (Build) using the live request context,
 // since this function runs inside singleflight with context.Background().
-func (b *Builder) buildBundle(reqID string, sc *schematicpkg.Schematic, schematicID, versionTag string, arch artifacts.Arch) error {
+func (b *Builder) buildBundle(reqID string, sc *schematicpkg.Schematic, schematicID, sbomHash, versionTag string, arch artifacts.Arch) error {
 	// Use a fresh context since we're in singleflight, but carry the
 	// request ID so build logs keep the request_id.
 	ctx := ctxlog.WithRequestID(context.Background(), reqID)
@@ -173,8 +192,8 @@ func (b *Builder) buildBundle(reqID string, sc *schematicpkg.Schematic, schemati
 		return fmt.Errorf("failed to create SPDX JSON document: %w", err)
 	}
 
-	// Store the bundle
-	if err := b.storage.Put(ctx, schematicID, versionTag, string(arch), jsonReader, size); err != nil {
+	// Store the bundle keyed by the SBOM content hash
+	if err := b.storage.Put(ctx, sbomHash, jsonReader, size); err != nil {
 		return fmt.Errorf("failed to store SPDX bundle: %w", err)
 	}
 

--- a/enterprise/spdx/builder/hash.go
+++ b/enterprise/spdx/builder/hash.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"sort"
+)
+
+// Hash returns a content hash describing the inputs that determine the SPDX
+// bundle content: the extension list, Talos version, and architecture. It is
+// used as the OCI cache tag, so that:
+//
+//   - Two schematics with the same extension list, version and architecture
+//     share a single cached bundle even when other schematic fields differ.
+//   - Fixes to the SPDX extraction/merge logic can invalidate previously
+//     cached bundles via errata strings (see internal/profile.Hash).
+func Hash(extensions []string, version, arch string) string {
+	hasher := sha256.New()
+
+	// Format version so the hash scheme can be evolved in the future.
+	hasher.Write([]byte("sbom/v1"))
+	hasher.Write([]byte{0})
+
+	// Sort extensions for deterministic hashing regardless of schematic order.
+	sorted := slices.Clone(extensions)
+	sort.Strings(sorted)
+
+	for _, ext := range sorted {
+		hasher.Write([]byte(ext))
+		hasher.Write([]byte{0})
+	}
+
+	hasher.Write([]byte(version))
+	hasher.Write([]byte{0})
+	hasher.Write([]byte(arch))
+	hasher.Write([]byte{0})
+
+	// Errata: append a marker string whenever the SPDX bundle content or
+	// extraction logic changes in a way that must invalidate existing cached
+	// bundles. Add new entries below; never remove or reorder existing ones.
+	// Guard entries with conditions when the fix is scoped.
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/enterprise/spdx/builder/spdx.go
+++ b/enterprise/spdx/builder/spdx.go
@@ -216,21 +216,6 @@ func prefixDocElementID(prefix string, id common.DocElementID) common.DocElement
 	}
 }
 
-// CacheTag returns the cache tag for an SPDX bundle.
-//
-// Format: spdx-<schematic_id>-<version>-<arch>
-//
-// Operators are expected to use distinct cache repositories for OSS vs
-// Enterprise deployments since the bundle content differs by build flavor.
-//
-// Version is sanitized to replace characters that are invalid in OCI tags.
-func CacheTag(schematicID, version, arch string) string {
-	// OCI tags cannot contain '+', replace with '-'
-	sanitizedVersion := strings.ReplaceAll(version, "+", "-")
-
-	return fmt.Sprintf("spdx-%s-%s-%s", schematicID, sanitizedVersion, arch)
-}
-
 // buildDocumentNamespace assembles the SPDX DocumentNamespace from the
 // configured external URL plus the schematic / version / arch path. It uses
 // url.URL.JoinPath rather than string concatenation to avoid producing

--- a/enterprise/spdx/builder/spdx_test.go
+++ b/enterprise/spdx/builder/spdx_test.go
@@ -23,20 +23,32 @@ import (
 	ifconstants "github.com/siderolabs/image-factory/pkg/constants"
 )
 
-func TestCacheTag(t *testing.T) {
+func TestHash(t *testing.T) {
 	t.Parallel()
 
-	tag := builder.CacheTag("schematic123", "v1.13.0", "amd64")
+	base := builder.Hash([]string{"ext1", "ext2"}, "v1.13.0", "amd64")
 
-	assert.True(t, strings.HasPrefix(tag, "spdx-"), "got %q", tag)
-	assert.Contains(t, tag, "schematic123")
-	assert.Contains(t, tag, "v1.13.0")
-	assert.Contains(t, tag, "amd64")
+	// The hash is the OCI cache tag, so it must always be valid (hex, no '+').
+	assert.NotContains(t, base, "+")
 
-	// `+` must be sanitized for OCI tag compatibility.
-	tagWithPlus := builder.CacheTag("schematic", "v1.13.0+rc.0", "amd64")
-	assert.NotContains(t, tagWithPlus, "+")
-	assert.Contains(t, tagWithPlus, "v1.13.0-rc.0")
+	// Deterministic for the same inputs.
+	assert.Equal(t, base, builder.Hash([]string{"ext1", "ext2"}, "v1.13.0", "amd64"))
+
+	// Extension order does not matter (sorting is internal).
+	assert.Equal(
+		t,
+		builder.Hash([]string{"ext2", "ext1"}, "v1.13.0", "amd64"),
+		builder.Hash([]string{"ext1", "ext2"}, "v1.13.0", "amd64"),
+	)
+
+	// Sensitive to distinct inputs so different bundles never collide.
+	assert.NotEqual(t, base, builder.Hash([]string{"ext1", "ext3"}, "v1.13.0", "amd64"))
+	assert.NotEqual(t, base, builder.Hash([]string{"ext1", "ext2"}, "v1.13.1", "amd64"))
+	assert.NotEqual(t, base, builder.Hash([]string{"ext1", "ext2"}, "v1.13.0", "arm64"))
+
+	// Empty extension list is valid and produces a consistent hash.
+	empty := builder.Hash([]string{}, "v1.13.0", "amd64")
+	assert.Equal(t, empty, builder.Hash([]string{}, "v1.13.0", "amd64"))
 }
 
 func TestBundleToJSON_DocumentNamespace(t *testing.T) {

--- a/enterprise/spdx/storage/registry/registry.go
+++ b/enterprise/spdx/storage/registry/registry.go
@@ -26,7 +26,6 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
-	"github.com/siderolabs/image-factory/enterprise/spdx/builder"
 	"github.com/siderolabs/image-factory/enterprise/spdx/storage"
 	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/signer"
@@ -81,16 +80,15 @@ func NewStorage(logger *zap.Logger, options Options) (*Storage, error) {
 	return s, nil
 }
 
-// Head checks if an SPDX bundle exists for the given schematic, version and architecture.
-func (s *Storage) Head(ctx context.Context, schematicID, version, arch string) error {
-	tag := builder.CacheTag(schematicID, version, arch)
-	taggedRef := s.cacheRepository.Tag(tag)
+// Head checks if an SPDX bundle exists for the given cache tag.
+func (s *Storage) Head(ctx context.Context, cacheTag string) error {
+	taggedRef := s.cacheRepository.Tag(cacheTag)
 
 	ctxlog.Logger(ctx, s.logger).Debug("heading SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	_, err := s.puller.Head(ctx, taggedRef)
 	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
-		return xerrors.NewTaggedf[storage.ErrNotFoundTag]("SPDX bundle for schematic %q version %q arch %q not found", schematicID, version, arch)
+		return xerrors.NewTaggedf[storage.ErrNotFoundTag]("SPDX bundle not found for tag %q", cacheTag)
 	}
 
 	if err != nil {
@@ -100,16 +98,15 @@ func (s *Storage) Head(ctx context.Context, schematicID, version, arch string) e
 	return nil
 }
 
-// Get retrieves an SPDX bundle for the given schematic, version and architecture.
-func (s *Storage) Get(ctx context.Context, schematicID, version, arch string) (storage.Bundle, error) {
-	tag := builder.CacheTag(schematicID, version, arch)
-	taggedRef := s.cacheRepository.Tag(tag)
+// Get retrieves an SPDX bundle for the given cache tag.
+func (s *Storage) Get(ctx context.Context, cacheTag string) (storage.Bundle, error) {
+	taggedRef := s.cacheRepository.Tag(cacheTag)
 
 	ctxlog.Logger(ctx, s.logger).Debug("getting SPDX bundle", zap.Stringer("ref", taggedRef))
 
 	desc, err := s.puller.Head(ctx, taggedRef)
 	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
-		return nil, xerrors.NewTaggedf[storage.ErrNotFoundTag]("SPDX bundle for schematic %q version %q arch %q not found", schematicID, version, arch)
+		return nil, xerrors.NewTaggedf[storage.ErrNotFoundTag]("SPDX bundle not found for tag %q", cacheTag)
 	}
 
 	if err != nil {
@@ -161,9 +158,8 @@ func (s *Storage) Get(ctx context.Context, schematicID, version, arch string) (s
 }
 
 // Put stores an SPDX bundle.
-func (s *Storage) Put(ctx context.Context, schematicID, version, arch string, data io.Reader, size int64) error {
-	tag := builder.CacheTag(schematicID, version, arch)
-	taggedRef := s.cacheRepository.Tag(tag)
+func (s *Storage) Put(ctx context.Context, cacheTag string, data io.Reader, size int64) error {
+	taggedRef := s.cacheRepository.Tag(cacheTag)
 
 	ctxlog.Logger(ctx, s.logger).Info("pushing SPDX bundle", zap.Stringer("ref", taggedRef))
 

--- a/enterprise/spdx/storage/storage.go
+++ b/enterprise/spdx/storage/storage.go
@@ -14,15 +14,19 @@ import (
 )
 
 // Storage is the SPDX bundle storage interface.
+//
+// cacheTag is a content-hash derived from the inputs that determine the
+// SPDX bundle content (extension list, version, architecture). It is
+// computed by the caller using builder.Hash.
 type Storage interface {
-	// Head checks if a bundle exists for the given schematic, version and architecture.
-	Head(ctx context.Context, schematicID, version, arch string) error
+	// Head checks if a bundle exists for the given cache tag.
+	Head(ctx context.Context, cacheTag string) error
 
-	// Get retrieves a bundle for the given schematic, version and architecture.
-	Get(ctx context.Context, schematicID, version, arch string) (Bundle, error)
+	// Get retrieves a bundle for the given cache tag.
+	Get(ctx context.Context, cacheTag string) (Bundle, error)
 
-	// Put stores a bundle for the given schematic, version and architecture.
-	Put(ctx context.Context, schematicID, version, arch string, data io.Reader, size int64) error
+	// Put stores a bundle for the given cache tag.
+	Put(ctx context.Context, cacheTag string, data io.Reader, size int64) error
 }
 
 // Bundle represents a stored SPDX bundle that can be read.

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -78,6 +78,12 @@ type VEXSource interface {
 // so the SBOM extraction and access control live in one place.
 type SPDXSource interface {
 	Build(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (io.ReadCloser, error)
+
+	// PayloadHash returns a content-hash describing the inputs that determine
+	// the SPDX bundle content (extension list, version, architecture). Schematics
+	// with the same SBOM-relevant inputs share the same hash. Callers should use
+	// this hash as a cache key.
+	PayloadHash(ctx context.Context, schematicID, versionTag string, arch artifacts.Arch) (string, error)
 }
 
 // ScannerOptions holds configuration options for the Scanner frontend.


### PR DESCRIPTION
SBOM content depends only on the extension list, Talos version, and
architecture. Previously the cache key included the full schematicID,
causing cache misses when non-SBOM fields changed (kernel args, config,
meta, secureboot, etc.).

Now hash only the relevant inputs so schematics with identical
extension lists share cached bundles and scan results. Singleflight
uses the same hash for both SPDX build and vulnerability scan.

Fixes https://github.com/siderolabs/image-factory/issues/478

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
