### PR TITLE
refactor: prepare for more than one artifact registry

### DIFF
--- a/internal/artifacts/fetch.go
+++ b/internal/artifacts/fetch.go
@@ -118,7 +118,7 @@ func (m *Manager) fetchImageByDigest(digestRef name.Digest, architecture Arch, i
 
 	var nameOptions []name.Option
 
-	if m.options.InsecureImageRegistry {
+	if digestRef.Scheme() == "http" {
 		nameOptions = append(nameOptions, name.Insecure)
 	}
 
@@ -175,7 +175,7 @@ func (m *Manager) extractOverlay(arch Arch, ref OverlayRef) error {
 
 // fetchExtensionImage fetches a specified extension image and exports it to the storage as OCI.
 func (m *Manager) fetchExtensionImage(arch Arch, ref ExtensionRef, destPath string) error {
-	imageRef := m.imageRegistry.Repo(ref.TaggedReference.RepositoryStr()).Digest(ref.Digest)
+	imageRef := ref.TaggedReference.Digest(ref.Digest)
 
 	if err := m.fetchImageByDigest(imageRef, arch, imageOCIHandler(destPath+tmpSuffix)); err != nil {
 		return err

--- a/internal/artifacts/spdx.go
+++ b/internal/artifacts/spdx.go
@@ -38,7 +38,7 @@ type SPDXFile struct {
 
 // ExtractExtensionSPDX extracts SPDX files from an extension image.
 func (m *Manager) ExtractExtensionSPDX(ctx context.Context, arch Arch, ref ExtensionRef) ([]SPDXFile, error) {
-	imageRef := m.imageRegistry.Repo(ref.TaggedReference.RepositoryStr()).Digest(ref.Digest)
+	imageRef := ref.TaggedReference.Digest(ref.Digest)
 
 	var files []SPDXFile
 

--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -137,7 +137,7 @@ func (m *Manager) fetchExtensionList(image, tag string) ([]ExtensionRef, error) 
 	err := m.fetchImageByTag(image, tag, ArchAmd64, imageExportHandler(func(_ *zap.Logger, r io.Reader) error {
 		var extractErr error
 
-		extensions, extractErr = extractExtensionList(r)
+		extensions, extractErr = extractExtensionList(r, m.imageRegistry)
 		if extractErr == nil {
 			m.logger.Info("extracted the image digests", zap.Int("count", len(extensions)))
 		}
@@ -183,7 +183,7 @@ func (m *Manager) fetchTalosctlTuples(tag string) ([]TalosctlTuple, error) {
 }
 
 //nolint:gocognit
-func extractExtensionList(r io.Reader) ([]ExtensionRef, error) {
+func extractExtensionList(r io.Reader, imageRegistry name.Registry) ([]ExtensionRef, error) {
 	var extensions []ExtensionRef
 
 	tr := tar.NewReader(r)
@@ -223,6 +223,8 @@ func extractExtensionList(r io.Reader) ([]ExtensionRef, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse tagged reference %s: %w", tagged, err)
 				}
+
+				taggedRef = imageRegistry.Repo(taggedRef.RepositoryStr()).Tag(taggedRef.TagStr())
 
 				extensions = append(extensions, ExtensionRef{
 					TaggedReference: taggedRef,


### PR DESCRIPTION
Guess the insecure via the image reference passed to get image by reference.

While fetching the extension catalog, patch in the registry into the image reference immediately, so that we don't have to patch it in later on fetch.

Part of #395.