### PR TITLE
feat: support registry namespace prefix for core artifacts

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -463,6 +463,15 @@ type CoreImagesOptions struct {
 	// E.g., "ghcr.io".
 	Registry string `koanf:"registry"`
 
+	// Namespace is an optional repository path prefix prepended to every image pulled from
+	// the registry: both the component images below and the extension/overlay images
+	// discovered via the manifests.
+	//
+	// Useful for pull-through caches which prefix the upstream repository path, e.g. a Harbor
+	// proxy-cache project: with registry "harbor.example.com" and namespace "ghcrio",
+	// "siderolabs/imager" is pulled from "harbor.example.com/ghcrio/siderolabs/imager".
+	Namespace string `koanf:"namespace"`
+
 	// Components defines the names of images used by the image factory.
 	// This typically maps to repositories and tags for core components.
 	Components ComponentsOptions `koanf:"components"`

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -472,6 +472,7 @@ func buildArtifactsManager(logger *zap.Logger, opts Options) (*artifacts.Manager
 		MinVersion:                  minVersion,
 		BrokenVersions:              brokenVersions,
 		ImageRegistry:               opts.Artifacts.Core.Registry,
+		ImageRegistryNamespace:      opts.Artifacts.Core.Namespace,
 		InsecureImageRegistry:       opts.Artifacts.Core.Insecure,
 		ImageVerifyOptions:          imageVerifyOptions,
 		TalosVersionRecheckInterval: opts.Artifacts.TalosVersionRecheckInterval,

--- a/deploy/helm/image-factory/values.yaml
+++ b/deploy/helm/image-factory/values.yaml
@@ -58,6 +58,10 @@ config:
       # insecure: false
       ## OCI registry host for base images and extensions (e.g., ghcr.io)
       # registry: ghcr.io
+      ## Optional repository path prefix prepended to every image pulled from the registry,
+      ## including extension/overlay images discovered via the manifests
+      ## (e.g. a Harbor proxy-cache project name)
+      # namespace: ""
 
     ## Installer image configuration
     # installer:

--- a/docs/air-gapped.md
+++ b/docs/air-gapped.md
@@ -18,3 +18,12 @@ artifacts:
   core:
     registry: localhost:5000
 ```
+
+If the local registry prefixes the upstream repository path (e.g. a Harbor proxy-cache project for `ghcr.io` named `ghcrio`), set the namespace so it is prepended to every pulled image, including the extension and overlay images referenced by the manifests:
+
+```yaml
+artifacts:
+  core:
+    registry: harbor.example.com
+    namespace: ghcrio
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -582,6 +582,21 @@ E.g., "ghcr.io".
 
 ---
 
+### `artifacts.core.namespace`
+
+- **Type:** `string`
+- **Env:** `ARTIFACTS_CORE_NAMESPACE`
+
+Namespace is an optional repository path prefix prepended to every image pulled from
+the registry: both the component images below and the extension/overlay images
+discovered via the manifests.
+
+Useful for pull-through caches which prefix the upstream repository path, e.g. a Harbor
+proxy-cache project: with registry "harbor.example.com" and namespace "ghcrio",
+"siderolabs/imager" is pulled from "harbor.example.com/ghcrio/siderolabs/imager".
+
+---
+
 ### `artifacts.core.components`
 
 Components defines the names of images used by the image factory.
@@ -853,6 +868,59 @@ Enterprise contains configuration for enterprise-specific features.
 
 ---
 
+### `enterprise.extraExtensions`
+
+ExtraExtensions contains configuration for extra (custom) extensions.
+
+---
+
+### `enterprise.extraExtensions.manifest`
+
+Manifest specifies the OCI repository holding the extra extensions manifest image.
+
+It may live in a different registry than the official images.
+
+---
+
+### `enterprise.extraExtensions.manifest.registry`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REGISTRY`
+
+Registry is the hostname of the container registry, e.g., `ghcr.io`.
+This is where images are stored.
+
+---
+
+### `enterprise.extraExtensions.manifest.namespace`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_NAMESPACE`
+
+Namespace is the repository namespace or organization within the registry, e.g., `sidero-labs`.
+Some registries allow repositories without a namespace.
+
+---
+
+### `enterprise.extraExtensions.manifest.repository`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REPOSITORY`
+
+Repository is the name of the repository inside the namespace, e.g., `talos`.
+Combined with Registry and Namespace, it forms the fully qualified repository path.
+
+---
+
+### `enterprise.extraExtensions.manifest.insecure`
+
+- **Type:** `bool`
+- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_INSECURE`
+
+Insecure allows connections to registries over HTTP or with invalid TLS certificates.
+
+---
+
 ### `enterprise.scanner`
 
 Scanner contains configuration for the vulnerability scanner.
@@ -1017,59 +1085,6 @@ Capacity caps the number of cached objects before LRU eviction.
 
 ---
 
-### `enterprise.extraExtensions`
-
-ExtraExtensions contains configuration for extra (custom) extensions.
-
----
-
-### `enterprise.extraExtensions.manifest`
-
-Manifest specifies the OCI repository holding the extra extensions manifest image.
-
-It may live in a different registry than the official images.
-
----
-
-### `enterprise.extraExtensions.manifest.registry`
-
-- **Type:** `string`
-- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REGISTRY`
-
-Registry is the hostname of the container registry, e.g., `ghcr.io`.
-This is where images are stored.
-
----
-
-### `enterprise.extraExtensions.manifest.namespace`
-
-- **Type:** `string`
-- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_NAMESPACE`
-
-Namespace is the repository namespace or organization within the registry, e.g., `sidero-labs`.
-Some registries allow repositories without a namespace.
-
----
-
-### `enterprise.extraExtensions.manifest.repository`
-
-- **Type:** `string`
-- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REPOSITORY`
-
-Repository is the name of the repository inside the namespace, e.g., `talos`.
-Combined with Registry and Namespace, it forms the fully qualified repository path.
-
----
-
-### `enterprise.extraExtensions.manifest.insecure`
-
-- **Type:** `bool`
-- **Env:** `ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_INSECURE`
-
-Insecure allows connections to registries over HTTP or with invalid TLS certificates.
-
----
-
 ### `registry`
 
 Registry contains low-level tuning for the registry client (pull/push concurrency, debugging).
@@ -1117,6 +1132,7 @@ artifacts:
             overlayManifest: siderolabs/overlays
             talosctl: siderolabs/talosctl-all
         insecure: false
+        namespace: ""
         registry: ghcr.io
     installer:
         external:
@@ -1244,6 +1260,7 @@ IF_ARTIFACTS_CORE_COMPONENTS_INSTALLERBASE=siderolabs/installer-base
 IF_ARTIFACTS_CORE_COMPONENTS_OVERLAYMANIFEST=siderolabs/overlays
 IF_ARTIFACTS_CORE_COMPONENTS_TALOSCTL=siderolabs/talosctl-all
 IF_ARTIFACTS_CORE_INSECURE=false
+IF_ARTIFACTS_CORE_NAMESPACE=
 IF_ARTIFACTS_CORE_REGISTRY=ghcr.io
 IF_ARTIFACTS_INSTALLER_EXTERNAL_INSECURE=false
 IF_ARTIFACTS_INSTALLER_EXTERNAL_NAMESPACE=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -34,6 +34,20 @@ Image Factory now generates disk images with Secure Boot supporting automaticall
 Image Factory now supports generating disk images with 4096 byte sector size (custom size), set via schematic customization.
 """
 
+    [notes.core_artifacts_namespace]
+        title = "Core Artifacts Namespace"
+        description = """\
+Image Factory now supports setting namespace for core artifacts - an optional
+repository path prefix prepended to every image pulled from the core registry:
+the component images as well as the extension and overlay images discovered
+via the manifests. Previously only the registry host could be overridden, so
+pull-through caches which prefix the upstream repository path (e.g. a Harbor
+proxy-cache project) could not be used.
+
+The prefix only affects pull references; extension identities (matched against
+schematics, the UI, and the meta API) are unchanged.
+"""
+
 [make_deps]
 
     [make_deps.pkgs]

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -20,6 +20,10 @@ type Options struct { //nolint:govet
 	//
 	// For official images, this is "ghcr.io".
 	ImageRegistry string
+	// ImageRegistryNamespace is an optional repository path prefix (e.g. a Harbor
+	// proxy-cache project) prepended to every image pulled from ImageRegistry,
+	// including extension and overlay images discovered via the manifests.
+	ImageRegistryNamespace string
 	// Repository to source extra extensions from.
 	ExtraExtensionsImageRegistry string
 	// Allow using an image registry without TLS.

--- a/internal/artifacts/export_test.go
+++ b/internal/artifacts/export_test.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package artifacts
+
+import (
+	"io"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// ExtractExtensionList exposes extractExtensionList for testing.
+func ExtractExtensionList(r io.Reader, registry name.Registry, namespace string) ([]ExtensionRef, error) {
+	return extractExtensionList(r, registryWithNamespace{registry: registry, namespace: namespace})
+}
+
+// PullReference exposes the extension pull reference for testing.
+func (e ExtensionRef) PullReference() name.Tag {
+	return e.pullReference
+}
+
+// RepoWithNamespace exposes registryWithNamespace.Repo for testing.
+func RepoWithNamespace(registry name.Registry, namespace, repoPath string) name.Repository {
+	return registryWithNamespace{registry: registry, namespace: namespace}.Repo(repoPath)
+}

--- a/internal/artifacts/fetch.go
+++ b/internal/artifacts/fetch.go
@@ -29,7 +29,7 @@ func (m *Manager) fetchImageByTag(imageName, tag string, architecture Arch, imag
 }
 
 // fetchImageByTag contains combined logic of image handling: heading, downloading, verifying signatures, and exporting.
-func (m *Manager) fetchImageByTagWithRepo(imageName, tag string, reg name.Registry, architecture Arch, imageHandler imagehandler.Handler) error {
+func (m *Manager) fetchImageByTagWithRepo(imageName, tag string, reg registryWithNamespace, architecture Arch, imageHandler imagehandler.Handler) error {
 	// set a timeout for fetching, but don't bind it to any context, as we want fetch operation to finish
 	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
 	defer cancel()
@@ -121,7 +121,7 @@ func (m *Manager) extractOverlay(arch Arch, ref OverlayRef) error {
 
 // fetchExtensionImage fetches a specified extension image and exports it to the storage as OCI.
 func (m *Manager) fetchExtensionImage(arch Arch, ref ExtensionRef, destPath string) error {
-	imageRef := ref.TaggedReference.Digest(ref.Digest)
+	imageRef := ref.pullReference.Digest(ref.Digest)
 
 	if err := m.fetchImageByDigest(imageRef, arch, imagehandler.OCI(destPath+tmpSuffix)); err != nil {
 		return err

--- a/internal/artifacts/manager.go
+++ b/internal/artifacts/manager.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -30,14 +31,26 @@ import (
 	"github.com/siderolabs/image-factory/internal/remotewrap"
 )
 
+// registryWithNamespace couples a registry with an optional repository path prefix
+// (e.g. a Harbor proxy-cache project) prepended to every repository pulled from it.
+type registryWithNamespace struct {
+	registry  name.Registry
+	namespace string
+}
+
+// Repo returns a repository in the registry with the namespace prefix applied.
+func (r registryWithNamespace) Repo(repoPath string) name.Repository {
+	return r.registry.Repo(path.Join(r.namespace, repoPath))
+}
+
 // Manager supports loading, caching and serving Talos release artifacts.
 type Manager struct { //nolint:govet
 	options                 Options
 	storagePath             string
 	schematicsPath          string
 	logger                  *zap.Logger
-	imageRegistry           name.Registry
-	extraExtensionsRegistry name.Registry
+	imageRegistry           registryWithNamespace
+	extraExtensionsRegistry registryWithNamespace
 	pullers                 map[Arch]remotewrap.Puller
 
 	sf singleflight.Group
@@ -71,12 +84,17 @@ func NewManager(logger *zap.Logger, options Options) (*Manager, error) {
 		opts = append(opts, name.Insecure)
 	}
 
-	imageRegistry, err := name.NewRegistry(options.ImageRegistry, opts...)
+	registry, err := name.NewRegistry(options.ImageRegistry, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image registry: %w", err)
 	}
 
-	var extraExtensionsImageRegistry name.Registry
+	imageRegistry := registryWithNamespace{
+		registry:  registry,
+		namespace: options.ImageRegistryNamespace,
+	}
+
+	var extraExtensionsImageRegistry registryWithNamespace
 
 	if options.ExtraExtensionsImageRegistry != "" {
 		opts = []name.Option{}
@@ -84,7 +102,7 @@ func NewManager(logger *zap.Logger, options Options) (*Manager, error) {
 			opts = append(opts, name.Insecure)
 		}
 
-		extraExtensionsImageRegistry, err = name.NewRegistry(options.ExtraExtensionsImageRegistry, opts...)
+		extraExtensionsImageRegistry.registry, err = name.NewRegistry(options.ExtraExtensionsImageRegistry, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse extra extensions image registry: %w", err)
 		}

--- a/internal/artifacts/spdx.go
+++ b/internal/artifacts/spdx.go
@@ -13,7 +13,7 @@ import (
 
 // ExtractExtensionSPDX extracts SPDX files from an extension image.
 func (m *Manager) ExtractExtensionSPDX(ctx context.Context, arch Arch, ref ExtensionRef) ([]imagehandler.SPDXFile, error) {
-	imageRef := ref.TaggedReference.Digest(ref.Digest)
+	imageRef := ref.pullReference.Digest(ref.Digest)
 
 	var files []imagehandler.SPDXFile
 

--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -102,6 +102,10 @@ type ExtensionRef struct {
 	Author          string
 
 	imageDigest string
+	// pullReference is the reference the extension image is pulled from; unlike
+	// TaggedReference (which serves as the extension identity, e.g. "siderolabs/gvisor"),
+	// it includes the registry namespace prefix, if any.
+	pullReference name.Tag
 }
 
 // OverlayRef is a ref to the overlay for some Talos version.
@@ -133,7 +137,7 @@ type overlaysDescription struct {
 	Digest string `yaml:"digest"`
 }
 
-func (m *Manager) fetchExtensionList(image, tag string, registry name.Registry) ([]ExtensionRef, error) {
+func (m *Manager) fetchExtensionList(image, tag string, registry registryWithNamespace) ([]ExtensionRef, error) {
 	var extensions []ExtensionRef
 
 	err := m.fetchImageByTagWithRepo(image, tag, registry, ArchAmd64, imagehandler.Export(func(_ *zap.Logger, r io.Reader) error {
@@ -185,7 +189,7 @@ func (m *Manager) fetchTalosctlTuples(tag string) ([]TalosctlTuple, error) {
 }
 
 //nolint:gocognit
-func extractExtensionList(r io.Reader, imageRegistry name.Registry) ([]ExtensionRef, error) {
+func extractExtensionList(r io.Reader, imageRegistry registryWithNamespace) ([]ExtensionRef, error) {
 	var extensions []ExtensionRef
 
 	tr := tar.NewReader(r)
@@ -226,13 +230,14 @@ func extractExtensionList(r io.Reader, imageRegistry name.Registry) ([]Extension
 					return nil, fmt.Errorf("failed to parse tagged reference %s: %w", tagged, err)
 				}
 
-				taggedRef = imageRegistry.Repo(taggedRef.RepositoryStr()).Tag(taggedRef.TagStr())
+				repoPath, tag := taggedRef.RepositoryStr(), taggedRef.TagStr()
 
 				extensions = append(extensions, ExtensionRef{
-					TaggedReference: taggedRef,
+					TaggedReference: imageRegistry.registry.Repo(repoPath).Tag(tag),
 					Digest:          digest,
 
-					imageDigest: line,
+					imageDigest:   line,
+					pullReference: imageRegistry.Repo(repoPath).Tag(tag),
 				})
 			}
 

--- a/internal/artifacts/versions_test.go
+++ b/internal/artifacts/versions_test.go
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package artifacts_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/internal/artifacts"
+)
+
+func buildExtensionsManifestArchive(t *testing.T, files map[string]string) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	tw := tar.NewWriter(&buf)
+
+	for name, contents := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(contents)),
+		}))
+
+		_, err := tw.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+
+	return &buf
+}
+
+func TestExtractExtensionList(t *testing.T) {
+	t.Parallel()
+
+	registry, err := name.NewRegistry("harbor.example.com")
+	require.NoError(t, err)
+
+	const (
+		gvisorLine = "ghcr.io/siderolabs/gvisor:20231214.0@sha256:5ab365f2b98ab885b1d9a6ebb2e2b06d0a7887d2c173a2b7d3f9e0e4f2f4f1cb"
+		zfsLine    = "ghcr.io/siderolabs/zfs:2.2.2@sha256:6f9e2d0c8a9d18b9a54c3d0f7c6b3a2f4e5d6c7b8a9f0e1d2c3b4a5f6e7d8c9b"
+	)
+
+	archive := map[string]string{
+		"image-digests": gvisorLine + "\n" + zfsLine + "\n",
+		"descriptions.yaml": `"` + gvisorLine + `":
+  author: Sidero Labs
+  description: gVisor container runtime
+`,
+	}
+
+	for _, test := range []struct {
+		name      string
+		namespace string
+
+		expectedGvisorPullRef string
+	}{
+		{
+			name: "no namespace",
+
+			expectedGvisorPullRef: "harbor.example.com/siderolabs/gvisor:20231214.0",
+		},
+		{
+			name:      "with namespace",
+			namespace: "ghcrio",
+
+			expectedGvisorPullRef: "harbor.example.com/ghcrio/siderolabs/gvisor:20231214.0",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			extensions, err := artifacts.ExtractExtensionList(
+				buildExtensionsManifestArchive(t, archive),
+				registry,
+				test.namespace,
+			)
+			require.NoError(t, err)
+			require.Len(t, extensions, 2)
+
+			gvisor := extensions[0]
+
+			// TaggedReference is the extension identity (matched against schematics), so
+			// the namespace must never leak into it.
+			assert.Equal(t, "siderolabs/gvisor", gvisor.TaggedReference.RepositoryStr())
+			assert.Equal(t, "harbor.example.com", gvisor.TaggedReference.RegistryStr())
+			assert.Equal(t, test.expectedGvisorPullRef, gvisor.PullReference().String())
+			assert.Equal(t, "sha256:5ab365f2b98ab885b1d9a6ebb2e2b06d0a7887d2c173a2b7d3f9e0e4f2f4f1cb", gvisor.Digest)
+			assert.Equal(t, "Sidero Labs", gvisor.Author)
+			assert.Equal(t, "gVisor container runtime", gvisor.Description)
+
+			zfs := extensions[1]
+
+			assert.Equal(t, "siderolabs/zfs", zfs.TaggedReference.RepositoryStr())
+			assert.Empty(t, zfs.Description)
+		})
+	}
+}
+
+func TestRepoWithNamespace(t *testing.T) {
+	t.Parallel()
+
+	registry, err := name.NewRegistry("harbor.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "harbor.example.com/siderolabs/imager",
+		artifacts.RepoWithNamespace(registry, "", "siderolabs/imager").String())
+	assert.Equal(t, "harbor.example.com/ghcrio/siderolabs/imager",
+		artifacts.RepoWithNamespace(registry, "ghcrio", "siderolabs/imager").String())
+	assert.Equal(t, "harbor.example.com/ghcrio/siderolabs/imager",
+		artifacts.RepoWithNamespace(registry, "ghcrio/", "siderolabs/imager").String())
+}


### PR DESCRIPTION
## Summary

Only the registry *host* of `artifacts.core` could be overridden, so pull-through caches which prefix the upstream repository path — e.g. a Harbor proxy-cache project — could not be used: the configurable component images worked, but the extension/overlay images discovered inside the manifests were rewritten to the registry host with their upstream path kept as-is, dropping the required prefix.

This adds `artifacts.core.namespace`, an optional repository path prefix prepended to every image pulled from the core registry — the component images as well as the extension and overlay images referenced by the manifests:

```yaml
artifacts:
  core:
    registry: harbor.example.com
    namespace: ghcrio
```

now pulls `ghcr.io/siderolabs/gvisor` via `harbor.example.com/ghcrio/siderolabs/gvisor`.

## Implementation notes

- The prefix is applied to **pull references only**. `ExtensionRef.TaggedReference` (matched against schematic extension names, the UI filter, the meta API, and the official/extra dedupe) is unchanged; the pull reference is carried separately.
- Overlay pull references are rebuilt from the configured registry at fetch time, so they pick up the prefix without touching overlay identity.
- The enterprise extra-extensions registry is unaffected (its manifest is operator-authored, so image paths can be authored with any required prefix).
- `docs/configuration.md` regenerated via docgen (also picks up the previously missing `enterprise.extraExtensions` section).

## Testing

- New unit tests for `extractExtensionList` covering identity vs. pull reference with and without a namespace.
- `helm template` renders the chart correctly; `helm lint` and schema generation (`make chart-gen-schema`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)