### PR TITLE
feat: add schematic owner validation

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -5,4 +5,4 @@ ignore:
     reason: |
       No fix available; golang.org/x/crypto/openpgp only reachable via cosign legacy PGP signature verification,
       which IF does not use (sigstore-based verification).
-    date: 2026-07-13
+    date: 2026-07-20

--- a/internal/frontend/http/configuration.go
+++ b/internal/frontend/http/configuration.go
@@ -15,6 +15,7 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 
 	"github.com/siderolabs/image-factory/internal/schematic/storage"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -42,6 +43,11 @@ func (f *Frontend) handleSchematicCreate(ctx context.Context, w http.ResponseWri
 
 			schematic.Owner = username
 		}
+	}
+
+	err = schematic.Validate(enterprise.Enabled())
+	if err != nil {
+		return err
 	}
 
 	id, err := f.schematicFactory.Put(ctx, schematic)

--- a/internal/frontend/http/ui.go
+++ b/internal/frontend/http/ui.go
@@ -679,6 +679,11 @@ func (f *Frontend) wizardFinal(ctx context.Context, params WizardParams) (string
 		requestedSchematic.Customization.EmbeddedMachineConfiguration = params.EmbeddedConfig
 	}
 
+	err = requestedSchematic.Validate(enterprise.Enabled())
+	if err != nil {
+		return "", nil, nil, err
+	}
+
 	schematicID, err := f.schematicFactory.Put(ctx, &requestedSchematic)
 	if err != nil {
 		return "", nil, nil, err

--- a/internal/integration/schematic_test.go
+++ b/internal/integration/schematic_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/image-factory/pkg/client"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -191,6 +192,18 @@ func testSchematic(ctx context.Context, t *testing.T, baseURL string) {
 
 	t.Run("empty once again", func(t *testing.T) {
 		assert.Equal(t, emptySchematicID, createSchematicGetID(ctx, t, c, *testSchematics[emptySchematicID]))
+	})
+
+	t.Run("owner rejected in non-enterprise", func(t *testing.T) {
+		t.Parallel()
+
+		if enterprise.Enabled() {
+			t.Skip("enterprise build")
+		}
+
+		_, _, err := c.SchematicCreate(ctx, schematic.Schematic{Owner: "bob"})
+		require.Error(t, err)
+		require.True(t, client.IsInvalidSchematicError(err))
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/pkg/schematic/schematic.go
+++ b/pkg/schematic/schematic.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 
 	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/talos/pkg/machinery/imager/imageropts"
@@ -28,6 +29,29 @@ type Schematic struct {
 	Overlay Overlay `yaml:"overlay,omitempty"`
 	// Customization represents the Talos image customization.
 	Customization Customization `yaml:"customization"`
+}
+
+// Validate validates the schematic.
+func (s *Schematic) Validate(enterprise bool) error {
+	if enterprise {
+		return s.validateEnterprise()
+	}
+
+	return s.validate()
+}
+
+func (s *Schematic) validate() error {
+	var errs error
+
+	if s.Owner != "" {
+		errs = errors.Join(errs, xerrors.NewTaggedf[InvalidErrorTag]("owner field is only supported in Enterprise edition"))
+	}
+
+	return errs
+}
+
+func (s *Schematic) validateEnterprise() error {
+	return nil
 }
 
 // Customization represents the Talos image customization.

--- a/pkg/schematic/schematic_test.go
+++ b/pkg/schematic/schematic_test.go
@@ -7,6 +7,7 @@ package schematic_test
 import (
 	"testing"
 
+	"github.com/siderolabs/gen/xerrors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/image-factory/pkg/schematic"
@@ -147,6 +148,59 @@ func TestUnmarshalID(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, test.expectedID, id)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		schematic   schematic.Schematic
+		enterprise  bool
+		expectError bool
+	}{
+		{
+			name:        "non-enterprise/empty owner",
+			enterprise:  false,
+			schematic:   schematic.Schematic{},
+			expectError: false,
+		},
+		{
+			name:       "non-enterprise/with owner",
+			enterprise: false,
+			schematic: schematic.Schematic{
+				Owner: "alice",
+			},
+			expectError: true,
+		},
+		{
+			name:        "enterprise/empty owner", // our handlers will inject the owner from credentials in authorized requests, so this is valid
+			enterprise:  true,
+			schematic:   schematic.Schematic{},
+			expectError: false,
+		},
+		{
+			name:       "enterprise/with owner",
+			enterprise: true,
+			schematic: schematic.Schematic{
+				Owner: "alice",
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.schematic.Validate(test.enterprise)
+
+			if test.expectError {
+				require.Error(t, err)
+				require.True(t, xerrors.TagIs[schematic.InvalidErrorTag](err))
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Enforce owner field policy at API boundary — rejected in
non-enterprise, required in enterprise. Includes unit and
integration tests.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
