### PR TITLE
fix: reuse registry puller for bundle verification

### DIFF
--- a/enterprise/spdx/storage/registry/registry.go
+++ b/enterprise/spdx/storage/registry/registry.go
@@ -116,7 +116,7 @@ func (s *Storage) Get(ctx context.Context, cacheTag string) (storage.Bundle, err
 	digestRef := s.cacheRepository.Digest(desc.Digest.String())
 
 	// Verify signature
-	err = s.imageSigner.VerifyImage(ctx, digestRef)
+	err = s.imageSigner.VerifyImage(ctx, digestRef, s.puller)
 	if err != nil {
 		ctxlog.Logger(ctx, s.logger).Warn("SPDX bundle signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef))
 

--- a/internal/asset/cache/registry/registry.go
+++ b/internal/asset/cache/registry/registry.go
@@ -87,7 +87,7 @@ func (c *Cache) Get(ctx context.Context, profileID string) (cache.BootAsset, err
 
 	digestRef := c.cacheRepository.Digest(desc.Digest.String())
 
-	err = c.imageSigner.VerifyImage(ctx, digestRef)
+	err = c.imageSigner.VerifyImage(ctx, digestRef, c.puller)
 	if err != nil {
 		// signature doesn't validate, skip the cache, but keep building
 		c.logger.Info("cache image signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef))

--- a/internal/frontend/http/registry.go
+++ b/internal/frontend/http/registry.go
@@ -209,7 +209,7 @@ func (f *Frontend) handleManifest(ctx context.Context, w http.ResponseWriter, re
 			zap.Stringer("ref", imageRepository.Digest(extDesc.Digest.String())),
 		)
 
-		signatureErr := f.imageSigner.VerifyImage(ctx, imageRepository.Digest(extDesc.Digest.String()))
+		signatureErr := f.imageSigner.VerifyImage(ctx, imageRepository.Digest(extDesc.Digest.String()), f.puller)
 		if signatureErr == nil {
 			// redirect to the external registry, but use the digest directly to avoid tag changes
 			return f.handleExternalRegistry(ctx, w, req, img.Name(), schematicID, "manifests", extDesc.Digest.String())

--- a/internal/image/signer/gsa.go
+++ b/internal/image/signer/gsa.go
@@ -224,8 +224,18 @@ func (s *GSASigner) SignImage(ctx context.Context, imageRef name.Digest, pusher 
 
 // VerifyImage verifies the OCI referrer bundle for imageRef against the GSA identity.
 // Implements Signer.VerifyImage.
-func (s *GSASigner) VerifyImage(ctx context.Context, imageRef name.Digest) error {
-	_, _, err := cosign.VerifyImageAttestations(ctx, imageRef, s.GetCheckOpts(), s.nameOpts...)
+func (s *GSASigner) VerifyImage(ctx context.Context, imageRef name.Digest, puller remotewrap.Puller) error {
+	remoteOpts, err := puller.RemoteOptions()
+	if err != nil {
+		return fmt.Errorf("failed to get remote options for verification: %w", err)
+	}
+
+	checkOpts := s.GetCheckOpts()
+	checkOpts.RegistryClientOpts = []ociremote.Option{
+		ociremote.WithRemoteOptions(append(remoteOpts, gcremote.WithContext(ctx))...),
+	}
+
+	_, _, err = cosign.VerifyImageAttestations(ctx, imageRef, checkOpts, s.nameOpts...)
 
 	return err
 }

--- a/internal/image/signer/signer.go
+++ b/internal/image/signer/signer.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	gcremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/oci/empty"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
@@ -28,7 +29,7 @@ type Signer interface {
 	// SignImage signs the image in the OCI repository.
 	SignImage(ctx context.Context, imageRef name.Digest, pusher remotewrap.Pusher) error
 	// VerifyImage verifies the signature of the image.
-	VerifyImage(ctx context.Context, imageRef name.Digest) error
+	VerifyImage(ctx context.Context, imageRef name.Digest, puller remotewrap.Puller) error
 	// GetCheckOpts returns cosign compatible image signature verification options.
 	GetCheckOpts() *cosign.CheckOpts
 	// GetPublicKeyPEM returns the public key in PEM format, or nil for keyless signers.
@@ -93,8 +94,18 @@ func (s *KeySigner) GetPublicKeyPEM() []byte {
 }
 
 // VerifyImage verifies the image signature using the key-based cosign tag format.
-func (s *KeySigner) VerifyImage(ctx context.Context, imageRef name.Digest) error {
-	_, _, err := cosign.VerifyImageSignatures(ctx, imageRef, s.GetCheckOpts())
+func (s *KeySigner) VerifyImage(ctx context.Context, imageRef name.Digest, puller remotewrap.Puller) error {
+	remoteOpts, err := puller.RemoteOptions()
+	if err != nil {
+		return fmt.Errorf("failed to get remote options for verification: %w", err)
+	}
+
+	checkOpts := s.GetCheckOpts()
+	checkOpts.RegistryClientOpts = []cosignremote.Option{
+		cosignremote.WithRemoteOptions(append(remoteOpts, gcremote.WithContext(ctx))...),
+	}
+
+	_, _, err = cosign.VerifyImageSignatures(ctx, imageRef, checkOpts)
 
 	return err
 }

--- a/internal/remotewrap/remotewrap.go
+++ b/internal/remotewrap/remotewrap.go
@@ -118,6 +118,10 @@ type Puller interface {
 	Get(ctx context.Context, ref name.Reference) (*remote.Descriptor, error)
 	List(ctx context.Context, repo name.Repository) ([]string, error)
 	Layer(ctx context.Context, ref name.Digest) (v1.Layer, error)
+	// RemoteOptions returns a fresh set of go-containerregistry remote options backed by
+	// the current (possibly refreshed) *remote.Puller instance. Use this when a library
+	// accepts []remote.Option directly so it shares authentication, transport and limits.
+	RemoteOptions() ([]remote.Option, error)
 }
 
 type pullerWrapper struct {
@@ -158,6 +162,15 @@ func (p *pullerWrapper) Layer(ctx context.Context, ref name.Digest) (v1.Layer, e
 	}
 
 	return instance.Layer(ctx, ref)
+}
+
+func (p *pullerWrapper) RemoteOptions() ([]remote.Option, error) {
+	instance, err := p.refresher.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return []remote.Option{remote.Reuse(instance)}, nil
 }
 
 // NewPuller creates a new Puller with the given options.


### PR DESCRIPTION
Cosign discovers referrers once, but GetBundles loads each
descriptor by calling ociremote.Bundle. Without
RegistryClientOpts, every bundle load creates a new
go-containerregistry puller and repeats registry discovery and
authentication. A cache entry with 125 historical bundles
therefore performs that setup 125 times.

Pass the current refreshing Image Factory puller through
remote.Reuse for key-based signatures and GSA attestations.
This reuses authentication, transport, and connections while
leaving referrer discovery and cryptographic verification to
cosign.

With the same 125-referrer index, main took 6.46 seconds for
one verification and 25.18 seconds for four. Reusing the
puller took 72 ms and 157 ms respectively.

Signed-off-by: Noel Georgi <git@frezbo.dev>
