### PR TITLE
feat: add presigned URL support for image downloads

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -571,6 +571,14 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	//
 	// It is required if authentication is enabled.
 	HTPasswdPath string `koanf:"htpasswdPath"`
+
+	// PresignedURLKey is an optional base64-encoded 32-byte HMAC key for presigned URLs.
+	// If empty, a random key is generated on startup (single-replica deployments).
+	// Set explicitly for multi-replica deployments behind a shared load balancer.
+	PresignedURLKey string `koanf:"presignedURLKey"`
+
+	// PresignedURLTTL is the validity duration for presigned URLs. Defaults to 5 minutes.
+	PresignedURLTTL time.Duration `koanf:"presignedURLTTL"`
 }
 
 // EnterpriseOptions contains configuration for enterprise-specific features.

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,6 +46,7 @@ import (
 	auditlog "github.com/siderolabs/image-factory/internal/audit/sink/log"
 	frontendhttp "github.com/siderolabs/image-factory/internal/frontend/http"
 	"github.com/siderolabs/image-factory/internal/image/signer"
+	"github.com/siderolabs/image-factory/internal/presign"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
 	"github.com/siderolabs/image-factory/internal/schematic"
 	schematiccache "github.com/siderolabs/image-factory/internal/schematic/storage/cache"
@@ -146,12 +148,18 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 
 	defer auditSink.Close() //nolint:errcheck
 
+	presignSigner, err := buildPresignSigner(opts)
+	if err != nil {
+		return err
+	}
+
 	frontendOptions, err := buildFrontendOptions(cacheImageSigner, authProvider, opts)
 	if err != nil {
 		return err
 	}
 
 	frontendOptions.AuditSink = auditSink
+	frontendOptions.PresignedURLSigner = presignSigner
 
 	frontendHTTP, err := frontendhttp.NewFrontend(
 		logger,
@@ -213,6 +221,30 @@ func buildAuthProvider(logger *zap.Logger, opts Options) (enterprise.AuthProvide
 	}
 
 	return authProvider, nil
+}
+
+const defaultPresignedURLTTL = 5 * time.Minute
+
+func buildPresignSigner(opts Options) (*presign.Signer, error) {
+	if !enterprise.Enabled() || !opts.Authentication.Enabled {
+		return nil, nil //nolint:nilnil
+	}
+
+	ttl := opts.Authentication.PresignedURLTTL
+	if ttl == 0 {
+		ttl = defaultPresignedURLTTL
+	}
+
+	if key := opts.Authentication.PresignedURLKey; key != "" {
+		decoded, err := base64.StdEncoding.DecodeString(key)
+		if err != nil {
+			return nil, fmt.Errorf("presignedURLKey must be base64-encoded: %w", err)
+		}
+
+		return presign.NewSigner(decoded, ttl), nil
+	}
+
+	return presign.GenerateSigner(ttl)
 }
 
 func buildEnterprisePlugins(

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/image-factory/internal/audit"
 	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/signer"
+	"github.com/siderolabs/image-factory/internal/presign"
 	"github.com/siderolabs/image-factory/internal/profile"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
 	"github.com/siderolabs/image-factory/internal/schematic"
@@ -67,6 +68,7 @@ type Options struct {
 	ImageProxy                       ImageProxyOptions
 	CacheImageSigner                 signer.Signer
 	AuthProvider                     enterprise.AuthProvider
+	PresignedURLSigner               *presign.Signer
 	ExternalURL                      *url.URL
 	ExternalPXEURL                   *url.URL
 	AuditSink                        audit.Sink
@@ -170,9 +172,12 @@ func NewFrontend(
 	registerPublicRoute(frontend.router.GET, "/readyz", frontend.handleReady)
 	registerPublicRoute(frontend.router.HEAD, "/readyz", frontend.handleReady)
 
-	// images - require auth
+	// images - require auth (presigned URLs bypass auth via signature verification)
 	registerRoute(frontend.router.GET, "/image/:schematic/:version/:path", frontend.handleImage)
 	registerRoute(frontend.router.HEAD, "/image/:schematic/:version/:path", frontend.handleImage)
+
+	// presign - auth-protected endpoint that issues presigned URLs
+	registerRoute(frontend.router.POST, "/presign/image/:schematic/:version/:path", frontend.handlePresign)
 
 	// PXE - require auth
 	registerRoute(frontend.router.GET, "/pxe/:schematic/:version/:path", frontend.handlePXE)
@@ -299,6 +304,20 @@ func requestIDFrom(r *http.Request) string {
 	return uuid.NewString()
 }
 
+// presignedUsername is the synthetic username recorded in audit logs for
+// requests authorized via presigned URL (no real user identity is available).
+const presignedUsername = "presigned"
+
+// presignedKey is a context key marking a request as authorized via presigned URL.
+type presignedKey struct{}
+
+// isPresigned reports whether the request context was authorized via a presigned URL.
+func isPresigned(ctx context.Context) bool {
+	v, ok := ctx.Value(presignedKey{}).(bool)
+
+	return ok && v
+}
+
 // withAuth wraps h with the auth middleware when authentication is required.
 //
 // The middleware stores the username on a context it derives internally, which
@@ -311,11 +330,33 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string) Handl
 
 	authProvider := f.options.AuthProvider
 
-	return authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
-		*username, _ = authProvider.UsernameFromContext(ctx)
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		// Presigned URL: if the request carries a valid signature, bypass auth.
+		// Verify parses the query internally, so just check for a non-empty query string
+		// to avoid a redundant r.URL.Query() allocation on non-presigned requests.
+		if f.options.PresignedURLSigner != nil && r.URL.RawQuery != "" {
+			if f.options.PresignedURLSigner.Verify(r) == nil {
+				*username = presignedUsername
 
-		return h(ctx, w, r, p)
-	})
+				return h(context.WithValue(ctx, presignedKey{}, true), w, r, p)
+			}
+		}
+
+		return authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+			*username, _ = authProvider.UsernameFromContext(ctx)
+
+			return h(ctx, w, r, p)
+		})(ctx, w, r, p)
+	}
+}
+
+// getSchematic retrieves a schematic, skipping ownership checks for presigned requests.
+func (f *Frontend) getSchematic(ctx context.Context, id string) (*schematicpkg.Schematic, error) {
+	if isPresigned(ctx) {
+		return f.schematicFactory.GetUnchecked(ctx, id)
+	}
+
+	return f.schematicFactory.Get(ctx, id, f.options.AuthProvider)
 }
 
 // audit records one entry for an authenticated request; a sink failure is logged

--- a/internal/frontend/http/image.go
+++ b/internal/frontend/http/image.go
@@ -61,7 +61,7 @@ func (f *Frontend) handleImage(ctx context.Context, w http.ResponseWriter, r *ht
 		return xerrors.NewTaggedf[enterrors.NotEnabledTag]("enterprise not enabled: checksum endpoint is not available")
 	}
 
-	schematic, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider)
+	schematic, err := f.getSchematic(ctx, schematicID)
 	if err != nil {
 		return err
 	}

--- a/internal/frontend/http/presign.go
+++ b/internal/frontend/http/presign.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// handlePresign creates a presigned URL for an image artifact download.
+// The endpoint is auth-protected; the returned URL carries an HMAC signature
+// so the actual download needs no credentials.
+func (f *Frontend) handlePresign(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	if f.options.PresignedURLSigner == nil {
+		http.Error(w, "presigned URLs not available", http.StatusNotFound)
+
+		return nil
+	}
+
+	// Verify the caller owns the schematic before signing a URL for it.
+	schematicID := p.ByName("schematic")
+
+	if _, err := f.schematicFactory.Get(ctx, schematicID, f.options.AuthProvider); err != nil {
+		return err
+	}
+
+	imagePath := fmt.Sprintf(
+		"/image/%s/%s/%s",
+		schematicID,
+		p.ByName("version"),
+		p.ByName("path"),
+	)
+
+	expires, sig := f.options.PresignedURLSigner.Sign(imagePath)
+
+	presignedURL := f.options.ExternalURL.ResolveReference(&url.URL{
+		Path:     imagePath,
+		RawQuery: url.Values{"expires": {expires}, "signature": {sig}}.Encode(),
+	}).String()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	return json.NewEncoder(w).Encode(map[string]string{
+		"url": presignedURL,
+	})
+}

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -9,6 +9,7 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,6 +57,12 @@ func testAuthFrontend(ctx context.Context, t *testing.T, baseURL string) {
 	})
 
 	t.Run("Reload", testAuthReload)
+
+	t.Run("PresignedURLs", func(t *testing.T) {
+		t.Parallel()
+
+		testPresignedURLs(ctx, t, baseURL)
+	})
 }
 
 func testAuthEnforcement(ctx context.Context, t *testing.T, baseURL string) {
@@ -468,6 +475,109 @@ func testAuthCDNNoRedirect(t *testing.T, pool *dockertest.Pool) {
 	t.Cleanup(func() { resp2.Body.Close() }) //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// testPresignedURLs verifies the presign endpoint: create a schematic, request a
+// presigned URL with auth, then download using only the presigned URL (no auth).
+func testPresignedURLs(ctx context.Context, t *testing.T, baseURL string) {
+	t.Helper()
+
+	// Create a schematic with auth.
+	c, err := client.New(baseURL, clientAuthCredentials()...)
+	require.NoError(t, err)
+
+	schematicID, _, err := c.SchematicCreate(ctx, schematicpkg.Schematic{})
+	require.NoError(t, err)
+
+	t.Run("PresignEndpointRequiresAuth", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/presign/image/"+schematicID+"/v1.9.0/kernel-amd64", nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("PresignAndDownload", func(t *testing.T) {
+		t.Parallel()
+
+		presignedURL := getPresignedURL(ctx, t, baseURL, schematicID, "v1.9.0", "kernel-amd64")
+
+		// Download with the presigned URL — no auth headers.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, presignedURL, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("TamperedSignatureRejected", func(t *testing.T) {
+		t.Parallel()
+
+		presignedURL := getPresignedURL(ctx, t, baseURL, schematicID, "v1.9.0", "kernel-amd64")
+
+		// Tamper with the signature.
+		tampered := presignedURL[:len(presignedURL)-1] + "0"
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tampered, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("ClientPresignImageURL", func(t *testing.T) {
+		t.Parallel()
+
+		presignedURL, err := c.PresignImageURL(ctx, schematicID, "v1.9.0", "kernel-amd64")
+		require.NoError(t, err)
+		assert.Contains(t, presignedURL, "signature=")
+		assert.Contains(t, presignedURL, "expires=")
+	})
+}
+
+// getPresignedURL calls the presign endpoint with htpasswd auth and returns the presigned URL.
+func getPresignedURL(ctx context.Context, t *testing.T, baseURL, schematicID, version, path string) string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		baseURL+"/presign/image/"+schematicID+"/"+version+"/"+path, nil)
+	require.NoError(t, err)
+
+	addTestAuth(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result struct {
+		URL string `json:"url"`
+	}
+
+	require.NoError(t, json.Unmarshal(body, &result))
+	require.NotEmpty(t, result.URL)
+
+	return result.URL
 }
 
 // assertRequiresAuth checks that the response is 401 with WWW-Authenticate set,

--- a/internal/presign/presign.go
+++ b/internal/presign/presign.go
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package presign implements HMAC-SHA256 signed URLs for time-limited,
+// auth-free downloads of image artifacts.
+package presign
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Signer creates and verifies HMAC-SHA256 presigned URLs.
+type Signer struct {
+	hmacKey []byte
+	ttl     time.Duration
+}
+
+// GenerateSigner creates a Signer with a random 32-byte HMAC key.
+func GenerateSigner(ttl time.Duration) (*Signer, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("presign: failed to generate HMAC key: %w", err)
+	}
+
+	return NewSigner(key, ttl), nil
+}
+
+// NewSigner creates a Signer with an explicit HMAC key.
+func NewSigner(hmacKey []byte, ttl time.Duration) *Signer {
+	return &Signer{
+		hmacKey: hmacKey,
+		ttl:     ttl,
+	}
+}
+
+// Sign returns the expires timestamp and hex-encoded HMAC signature for the
+// given URL path. The caller appends these as query parameters.
+//
+// Signing string: "{path}\n{expires}".
+func (s *Signer) Sign(urlPath string) (expires, signature string) {
+	exp := time.Now().Add(s.ttl).Unix()
+	expires = strconv.FormatInt(exp, 10)
+	signature = computeMAC(s.hmacKey, urlPath, expires)
+
+	return expires, signature
+}
+
+// Verify checks the signature and expiry on an incoming request.
+// It returns nil on success, or an error describing the failure.
+func (s *Signer) Verify(r *http.Request) error {
+	q := r.URL.Query()
+
+	sig := q.Get("signature")
+	if sig == "" {
+		return fmt.Errorf("presign: missing signature")
+	}
+
+	expiresStr := q.Get("expires")
+	if expiresStr == "" {
+		return fmt.Errorf("presign: missing expires")
+	}
+
+	exp, err := strconv.ParseInt(expiresStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("presign: invalid expires: %w", err)
+	}
+
+	if time.Now().Unix() > exp {
+		return fmt.Errorf("presign: URL expired")
+	}
+
+	expected := computeMAC(s.hmacKey, r.URL.Path, expiresStr)
+
+	provided, err := hex.DecodeString(sig)
+	if err != nil {
+		return fmt.Errorf("presign: invalid signature encoding: %w", err)
+	}
+
+	expectedBytes, _ := hex.DecodeString(expected) //nolint:errcheck // computeMAC always returns valid hex
+
+	if !hmac.Equal(provided, expectedBytes) {
+		return fmt.Errorf("presign: invalid signature")
+	}
+
+	return nil
+}
+
+func computeMAC(key []byte, path, expires string) string {
+	mac := hmac.New(sha256.New, key)
+	fmt.Fprintf(mac, "%s\n%s", path, expires) //nolint:errcheck // hash.Write never returns an error
+
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/presign/presign_test.go
+++ b/internal/presign/presign_test.go
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package presign_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/internal/presign"
+)
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := presign.NewSigner(make([]byte, 32), 5*time.Minute)
+	path := "/image/abc123/v1.9.0/metal-amd64.iso"
+
+	expires, sig := s.Sign(path)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     path,
+		RawQuery: "expires=" + expires + "&signature=" + sig,
+	}}
+
+	require.NoError(t, s.Verify(r))
+}
+
+func TestExpiredURL(t *testing.T) {
+	t.Parallel()
+
+	// TTL of 0 means the URL expires immediately.
+	s := presign.NewSigner(make([]byte, 32), 0)
+	path := "/image/abc123/v1.9.0/metal-amd64.iso"
+
+	expires, sig := s.Sign(path)
+
+	// Sleep briefly to ensure expiry.
+	time.Sleep(time.Second)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     path,
+		RawQuery: "expires=" + expires + "&signature=" + sig,
+	}}
+
+	err := s.Verify(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestTamperedSignature(t *testing.T) {
+	t.Parallel()
+
+	s := presign.NewSigner(make([]byte, 32), 5*time.Minute)
+	path := "/image/abc123/v1.9.0/metal-amd64.iso"
+
+	expires, _ := s.Sign(path)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     path,
+		RawQuery: "expires=" + expires + "&signature=deadbeef",
+	}}
+
+	err := s.Verify(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid signature")
+}
+
+func TestTamperedPath(t *testing.T) {
+	t.Parallel()
+
+	s := presign.NewSigner(make([]byte, 32), 5*time.Minute)
+	origPath := "/image/abc123/v1.9.0/metal-amd64.iso"
+
+	expires, sig := s.Sign(origPath)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     "/image/EVIL/v1.9.0/metal-amd64.iso",
+		RawQuery: "expires=" + expires + "&signature=" + sig,
+	}}
+
+	err := s.Verify(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid signature")
+}
+
+func TestMissingParams(t *testing.T) {
+	t.Parallel()
+
+	s := presign.NewSigner(make([]byte, 32), 5*time.Minute)
+
+	t.Run("MissingSignature", func(t *testing.T) {
+		t.Parallel()
+
+		r := &http.Request{URL: &url.URL{
+			Path:     "/image/abc/v1/foo",
+			RawQuery: "expires=9999999999",
+		}}
+
+		err := s.Verify(r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing signature")
+	})
+
+	t.Run("MissingExpires", func(t *testing.T) {
+		t.Parallel()
+
+		r := &http.Request{URL: &url.URL{
+			Path:     "/image/abc/v1/foo",
+			RawQuery: "signature=deadbeef",
+		}}
+
+		err := s.Verify(r)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing expires")
+	})
+}
+
+func TestDifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	key2[0] = 1
+
+	s1 := presign.NewSigner(key1, 5*time.Minute)
+	s2 := presign.NewSigner(key2, 5*time.Minute)
+
+	path := "/image/abc123/v1.9.0/metal-amd64.iso"
+
+	expires, sig := s1.Sign(path)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     path,
+		RawQuery: "expires=" + expires + "&signature=" + sig,
+	}}
+
+	require.Error(t, s2.Verify(r))
+}
+
+func TestGenerateSigner(t *testing.T) {
+	t.Parallel()
+
+	s, err := presign.GenerateSigner(5 * time.Minute)
+	require.NoError(t, err)
+
+	path := "/image/abc/v1/foo"
+
+	expires, sig := s.Sign(path)
+
+	r := &http.Request{URL: &url.URL{
+		Path:     path,
+		RawQuery: "expires=" + expires + "&signature=" + sig,
+	}}
+
+	require.NoError(t, s.Verify(r))
+}

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -142,6 +142,14 @@ func (s *Factory) get(ctx context.Context, id string) (*schematic.Schematic, err
 	return sct, nil
 }
 
+// GetUnchecked retrieves the stored schematic without ownership checks.
+//
+// This is intended for pre-authorized code paths (e.g. presigned URL downloads)
+// where authorization was already verified at an earlier stage.
+func (s *Factory) GetUnchecked(ctx context.Context, id string) (*schematic.Schematic, error) {
+	return s.get(ctx, id)
+}
+
 // Get retrieves the stored schematic and enforces ownership.
 //
 // If auth is non-nil and the caller is unauthenticated, RequiresAuthenticationTag is returned

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -175,6 +175,24 @@ func (c *Client) OverlaysVersions(ctx context.Context, talosVersion string) ([]O
 	return versions, nil
 }
 
+// PresignImageURL requests a short-lived presigned URL for downloading an image artifact.
+// The returned URL carries an HMAC signature so the download needs no credentials.
+func (c *Client) PresignImageURL(ctx context.Context, schematicID, version, path string) (string, error) {
+	var response struct {
+		URL string `json:"url"`
+	}
+
+	if err := c.do(
+		ctx, http.MethodPost,
+		fmt.Sprintf("/presign/image/%s/%s/%s", schematicID, version, path),
+		&response,
+	); err != nil {
+		return "", err
+	}
+
+	return response.URL, nil
+}
+
 // ScanReport downloads a vulnerability scan report for the given schematic, Talos version,
 // architecture, and report filename. The filename extension selects the report format:
 // ".sarif" → SARIF, ".cdx" → CycloneDX, ".json" → JSON, ".table" → plain-text table.


### PR DESCRIPTION
I ran into this need with some exploration on image factory enterprise.

This PR adds a new authenticated endpoint which will generate short-lived presigned URLs for image downloads. It works kind of in the way that S3 does with HMAC links that expire after some time.

After generating a schematic ID, a user can post to /presign/image/:schematic/:version/:path with auth and this will return a JSON response with a URL that contains expiry and signature query params. The signature is verified in withAuth before the auth middleware, so presigned downloads need no credentials. Default expiry is 5m.

The HMAC key is auto-generated on startup (zero config) or can be set explicitly via presignedURLKey for multi-replica deployments.

Part of why I needed this is to get away from the need for user/pass when using Omni connected to IFE. With this, Omni can query IFE to generate a presigned URL when a user clicks the download on one of the images they build.

Related to https://github.com/siderolabs/image-factory/issues/498, but not implemented in the same way as described.