### PR TITLE
feat: support public routes in enterprise plugins

### DIFF
--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -147,19 +147,26 @@ func NewFrontend(
 
 	// enterprise
 	for _, enterpriseRoute := range enterprisePlugins {
+		_, isPublic := enterpriseRoute.(enterprise.PublicRoute)
+
 		for _, method := range enterpriseRoute.Methods() {
+			var registrator func(string, httprouter.Handle)
+
 			switch method {
 			case http.MethodGet:
-				registerRoute(frontend.router.GET, enterpriseRoute.Path(), enterpriseRoute.Handle)
-
+				registrator = frontend.router.GET
 			case http.MethodHead:
-				registerRoute(frontend.router.HEAD, enterpriseRoute.Path(), enterpriseRoute.Handle)
-
+				registrator = frontend.router.HEAD
 			case http.MethodPost:
-				registerRoute(frontend.router.POST, enterpriseRoute.Path(), enterpriseRoute.Handle)
-
+				registrator = frontend.router.POST
 			default:
 				panic(fmt.Sprintf("unsupported method %s for enterprise route %s", method, enterpriseRoute.Path()))
+			}
+
+			if isPublic {
+				registerPublicRoute(registrator, enterpriseRoute.Path(), enterpriseRoute.Handle)
+			} else {
+				registerRoute(registrator, enterpriseRoute.Path(), enterpriseRoute.Handle)
 			}
 		}
 	}

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -28,6 +28,13 @@ type FrontendPlugin interface {
 	Handle(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error
 }
 
+// PublicRoute is implemented by FrontendPlugin instances whose routes should
+// be registered without authentication. Plugins that do not implement this
+// interface are registered as auth-protected routes.
+type PublicRoute interface {
+	PublicRoute()
+}
+
 // ReadinessChecker is implemented by FrontendPlugin instances whose readiness
 // must factor into the /readyz response. Plugins that do not implement this
 // interface are considered always ready.


### PR DESCRIPTION
This PR adds a PublicRoute interface so enterprise plugins can declare routes that skip authentication. The registration loop checks for this marker and uses registerPublicRoute accordingly. Plugins that do not implement PublicRoute are registered as protected by default.

This is kind of a cheat off of the way we already do this with ReadinessChecker for certain enterprise plugins.

I need this for JWT implementation, as we'll need to allow GETs to /.well-known/jwks.json without auth. We don't _really_ require this yet, but it seems like it's a recommended thing to do incase we have external systems later that need to make use of this endpoint.