### PR TITLE
feat: add auth0 bearer token authentication

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -5,4 +5,4 @@ ignore:
     reason: |
       No fix available; golang.org/x/crypto/openpgp only reachable via cosign legacy PGP signature verification,
       which IF does not use (sigstore-based verification).
-    date: 2026-07-27
+    date: 2026-08-03

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The file is maintained at [`internal/frontend/http/templates/llms.txt`](internal
 
 * [API reference](docs/api.md)
 * [Configuration](docs/configuration.md)
+* [Authentication](docs/authentication.md)
 * [Required Source Container Images](docs/sources.md)
 * [Air-gapped Deployment](docs/air-gapped.md)
 * [Cache](docs/cache.md)

--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -57,6 +58,33 @@ func (o *Options) Validate() error {
 
 	if !slices.Contains(auditModeOptions, o.Audit.Mode) {
 		return fmt.Errorf("audit.mode must be one of %v, got %q", auditModeOptions, o.Audit.Mode)
+	}
+
+	return o.Authentication.validate()
+}
+
+// validate checks the settings required by the selected provider, so that a misconfiguration
+// fails at startup rather than on the first request.
+func (o AuthenticationOptions) validate() error {
+	if !o.Enabled {
+		return nil
+	}
+
+	switch o.Provider {
+	case AuthProviderHTPasswd:
+		if o.HTPasswdPath == "" {
+			return errors.New(`authentication.htpasswdPath is required when authentication.provider is "htpasswd"`)
+		}
+	case AuthProviderAuth0:
+		if o.Auth0.Domain == "" {
+			return errors.New(`authentication.auth0.domain is required when authentication.provider is "auth0"`)
+		}
+
+		if o.Auth0.Audience == "" {
+			return errors.New(`authentication.auth0.audience is required when authentication.provider is "auth0"`)
+		}
+	default:
+		return fmt.Errorf("authentication.provider must be one of %v, got %q", authProviderOptions, o.Provider)
 	}
 
 	return nil
@@ -565,18 +593,41 @@ func (c ComponentsOptions) ImageMap() map[string]string {
 	}
 }
 
+// Authentication providers select the backend that verifies caller identity.
+const (
+	// AuthProviderHTPasswd verifies credentials against a local htpasswd file. Default.
+	AuthProviderHTPasswd = "htpasswd"
+	// AuthProviderAuth0 validates Auth0-issued JWTs.
+	AuthProviderAuth0 = "auth0"
+)
+
+var authProviderOptions = []string{AuthProviderHTPasswd, AuthProviderAuth0}
+
 // AuthenticationOptions holds authentication settings.
 type AuthenticationOptions struct { //nolint:govet // keeping order for semantic clarity
 	// Enabled enables authentication.
 	Enabled bool `koanf:"enabled"`
+
+	// Provider selects the authentication backend.
+	// Valid values are "htpasswd" (default) and "auth0".
+	Provider string `koanf:"provider"`
+
 	// HTPasswdPath is the path to the htpasswd file containing user credentials.
 	//
 	// The file follows the standard htpasswd format (username:bcrypt_hash, one per line).
 	// Multiple entries with the same username are supported, allowing multiple API keys per user.
 	// Only bcrypt hashes ($2y$/$2a$/$2b$) are accepted.
 	//
-	// It is required if authentication is enabled.
+	// It is required when provider is "htpasswd" (the default).
 	HTPasswdPath string `koanf:"htpasswdPath"`
+
+	// Auth0 holds configuration for the Auth0 JWT authentication provider.
+	//
+	// Tokens must carry an `org_id` claim, which becomes the caller identity in the same way a username does for htpasswd.
+	// In Auth0 this means issuing tokens to organization-scoped clients; tokens without the claim are rejected.
+	//
+	// It is required when provider is "auth0", and ignored otherwise.
+	Auth0 Auth0Options `koanf:"auth0"`
 
 	// DownloadTokenKeyPath is an optional path to a PEM-encoded ECDSA P-256 private key for signing download tokens.
 	// If empty, a key pair is generated on startup (single-replica deployments only).
@@ -584,6 +635,33 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 
 	// DownloadTokenTTL is the validity duration for download tokens.
 	DownloadTokenTTL time.Duration `koanf:"downloadTokenTTL"`
+}
+
+// Auth0Options holds configuration for the Auth0 authentication provider.
+type Auth0Options struct {
+	// Domain is the Auth0 tenant domain, e.g. `mycompany.auth0.com`.
+	//
+	// Required.
+	Domain string `koanf:"domain"`
+
+	// Audience is the Auth0 API identifier (audience claim), e.g. `https://image-factory.example.com`.
+	//
+	// Required.
+	Audience string `koanf:"audience"`
+
+	// MachineScope names a scope that marks a token as a machine credential, e.g. `factory:machine`.
+	//
+	// Tokens carrying it may only fetch artifacts: `GET`/`HEAD` on `/image/` and the `/v2/` OCI registry.
+	// Everything else is rejected with 403, including reading schematic definitions.
+	// Intended for the long-lived tokens provisioned onto Talos nodes, which need to pull installers but should not be able to inspect or create schematics.
+	//
+	// Optional; when empty every valid token has full access.
+	MachineScope string `koanf:"machineScope"`
+
+	// issuerURLOverride replaces the issuer URL constructed from Domain, for both the
+	// expected iss claim and the JWKS endpoint.
+	// Unexported so koanf cannot reach it; see SetAuth0IssuerURL, built only under the integration tag.
+	issuerURLOverride string
 }
 
 // EnterpriseOptions contains configuration for enterprise-specific features.
@@ -713,6 +791,7 @@ var DefaultOptions = Options{
 	},
 
 	Authentication: AuthenticationOptions{
+		Provider:         AuthProviderHTPasswd,
 		DownloadTokenTTL: 5 * time.Minute,
 	},
 

--- a/cmd/image-factory/cmd/options_integration.go
+++ b/cmd/image-factory/cmd/options_integration.go
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+package cmd
+
+// SetAuth0IssuerURL points issuer verification at an in-process OIDC server.
+// Built only under the integration tag, so a release binary has no way to set it.
+func (o *Options) SetAuth0IssuerURL(url string) {
+	o.Authentication.Auth0.issuerURLOverride = url
+}

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -273,6 +273,64 @@ func TestOptionsValidate(t *testing.T) {
 			},
 			expectError: "http.externalPXEURL must have a host",
 		},
+		{
+			name: "valid auth provider",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0:    cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
+				},
+			},
+		},
+		{
+			name: "auth0 provider without a domain",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0:    cmd.Auth0Options{Audience: "https://factory.sidero.dev"},
+				},
+			},
+			expectError: "authentication.auth0.domain is required",
+		},
+		{
+			name: "auth0 provider without an audience",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0:    cmd.Auth0Options{Domain: "tenant.auth0.com"},
+				},
+			},
+			expectError: "authentication.auth0.audience is required",
+		},
+		{
+			name: "unknown auth provider",
+			opts: cmd.Options{
+				HTTP:           cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{Enabled: true, Provider: "oidc"},
+			},
+			expectError: "authentication.provider must be one of",
+		},
+		{
+			name: "auth provider ignored when authentication disabled",
+			opts: cmd.Options{
+				HTTP:           cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{Provider: ""},
+			},
+		},
+		{
+			name: "htpasswd provider without a path",
+			opts: cmd.Options{
+				HTTP:           cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{Enabled: true, Provider: "htpasswd"},
+			},
+			expectError: "authentication.htpasswdPath is required",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -112,7 +112,7 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return err
 	}
 
-	authProvider, err := buildAuthProvider(logger, opts)
+	authProvider, err := buildAuthProvider(ctx, logger, opts)
 	if err != nil {
 		return err
 	}
@@ -210,18 +210,32 @@ func buildSecureBootService(opts Options) (*secureboot.Service, error) {
 	return svc, nil
 }
 
-func buildAuthProvider(logger *zap.Logger, opts Options) (enterprise.AuthProvider, error) {
-	if !enterprise.Enabled() {
+func buildAuthProvider(ctx context.Context, logger *zap.Logger, opts Options) (enterprise.AuthProvider, error) {
+	if !enterprise.Enabled() || !opts.Authentication.Enabled {
 		return nil, nil //nolint:nilnil
 	}
 
-	if !opts.Authentication.Enabled {
-		return nil, nil //nolint:nilnil
+	var (
+		authProvider enterprise.AuthProvider
+		err          error
+	)
+
+	switch opts.Authentication.Provider {
+	case AuthProviderAuth0:
+		authProvider, err = enterprise.NewAuth0Provider(ctx, logger, enterprise.Auth0Config{
+			Domain:            opts.Authentication.Auth0.Domain,
+			Audience:          opts.Authentication.Auth0.Audience,
+			MachineScope:      opts.Authentication.Auth0.MachineScope,
+			IssuerURLOverride: opts.Authentication.Auth0.issuerURLOverride,
+		})
+	case AuthProviderHTPasswd:
+		authProvider, err = enterprise.NewHTPasswdProvider(logger, opts.Authentication.HTPasswdPath)
+	default:
+		return nil, fmt.Errorf("unknown authentication provider %q", opts.Authentication.Provider)
 	}
 
-	authProvider, err := enterprise.NewAuthProvider(logger, opts.Authentication.HTPasswdPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize authentication provider: %w", err)
+		return nil, fmt.Errorf("failed to initialize %q authentication provider: %w", opts.Authentication.Provider, err)
 	}
 
 	return authProvider, nil

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,54 @@
+# Authentication
+
+The factory authenticates callers with one of two providers, selected by `authentication.provider`.
+See [Configuration](configuration.md) for the full list of settings.
+
+Only one provider is active at a time.
+There is no mode that accepts both htpasswd credentials and Auth0 tokens.
+
+## htpasswd
+
+Basic authentication against an `htpasswd` file.
+The caller identity is the username.
+
+## auth0
+
+Bearer token authentication against an Auth0 tenant.
+Tokens are validated locally against the tenant's JWKS: signature, issuer, audience and expiry.
+
+The caller identity is the token's `org_id` claim, so tokens must be issued to organization-scoped clients.
+Tokens without the claim are rejected, since there would be no principal to attribute the request to.
+
+Tokens are accepted either as `Authorization: Bearer <token>` or in the password field of a Basic credential, because OCI and Talos registry clients only speak Basic auth.
+
+### Machine credentials
+
+Talos nodes need a long-lived credential to pull installers, but a credential sitting on a node is more exposed than one held by a person.
+Setting `authentication.auth0.machineScope` names a scope that marks a token as such a credential.
+
+Tokens carrying it may only fetch artifacts: `GET` and `HEAD` on `/image/` and on the `/v2/` OCI registry.
+Everything else is rejected with `403`, including reading a schematic definition, so a stolen node credential cannot enumerate how the organization's images are built.
+
+Both the `scope` and `permissions` claims are consulted, since Auth0 uses the former for plain client-credentials grants and the latter when RBAC is enabled on the API.
+Tokens without the scope are unaffected, and leaving the setting empty gives every valid token full access.
+
+### Migrating from htpasswd
+
+Switching an existing deployment from `htpasswd` to `auth0` changes the identity namespace from usernames to `org_...` identifiers.
+Consequences:
+
+- Schematics owned by a username are not reachable by any Auth0 organization, and vice versa.
+  Existing ownership does not carry over.
+- Audit history written under the old provider records usernames, so records from before and after the switch cannot be correlated by principal.
+- Because only one provider is active at a time, there is no gradual rollout.
+  The switch takes effect for every caller at restart.
+
+Plan the cutover accordingly, or start a fresh deployment.
+
+### Revocation
+
+Access tokens are validated offline, so revoking a client at the tenant does not invalidate tokens it has already been issued.
+Those remain usable until they expire; keep token lifetimes short if that matters.
+
+The same applies to download tokens minted from a JWT.
+They stay valid for their own TTL regardless of what happens to the JWT they were obtained with.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -859,6 +859,16 @@ Enabled enables authentication.
 
 ---
 
+### `authentication.provider`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_PROVIDER`
+
+Provider selects the authentication backend.
+Valid values are "htpasswd" (default) and "auth0".
+
+---
+
 ### `authentication.htpasswdPath`
 
 - **Type:** `string`
@@ -870,7 +880,55 @@ The file follows the standard htpasswd format (username:bcrypt_hash, one per lin
 Multiple entries with the same username are supported, allowing multiple API keys per user.
 Only bcrypt hashes ($2y$/$2a$/$2b$) are accepted.
 
-It is required if authentication is enabled.
+It is required when provider is "htpasswd" (the default).
+
+---
+
+### `authentication.auth0`
+
+Auth0 holds configuration for the Auth0 JWT authentication provider.
+
+Tokens must carry an `org_id` claim, which becomes the caller identity in the same way a username does for htpasswd.
+In Auth0 this means issuing tokens to organization-scoped clients; tokens without the claim are rejected.
+
+It is required when provider is "auth0", and ignored otherwise.
+
+---
+
+### `authentication.auth0.domain`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_DOMAIN`
+
+Domain is the Auth0 tenant domain, e.g. `mycompany.auth0.com`.
+
+Required.
+
+---
+
+### `authentication.auth0.audience`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_AUDIENCE`
+
+Audience is the Auth0 API identifier (audience claim), e.g. `https://image-factory.example.com`.
+
+Required.
+
+---
+
+### `authentication.auth0.machineScope`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_MACHINESCOPE`
+
+MachineScope names a scope that marks a token as a machine credential, e.g. `factory:machine`.
+
+Tokens carrying it may only fetch artifacts: `GET`/`HEAD` on `/image/` and the `/v2/` OCI registry.
+Everything else is rejected with 403, including reading schematic definitions.
+Intended for the long-lived tokens provisioned onto Talos nodes, which need to pull installers but should not be able to inspect or create schematics.
+
+Optional; when empty every valid token has full access.
 
 ---
 
@@ -1222,10 +1280,15 @@ audit:
         path: ""
     mode: ""
 authentication:
+    auth0:
+        audience: ""
+        domain: ""
+        machineScope: ""
     downloadTokenKeyPath: ""
     downloadTokenTTL: 5m0s
     enabled: false
     htpasswdPath: ""
+    provider: htpasswd
 build:
     brokenTalosVersions: []
     maxConcurrency: 6
@@ -1353,10 +1416,14 @@ IF_AUDIT_FILE_MAXBACKUPS=16
 IF_AUDIT_FILE_MAXSIZEMB=256
 IF_AUDIT_FILE_PATH=
 IF_AUDIT_MODE=
+IF_AUTHENTICATION_AUTH0_AUDIENCE=
+IF_AUTHENTICATION_AUTH0_DOMAIN=
+IF_AUTHENTICATION_AUTH0_MACHINESCOPE=
 IF_AUTHENTICATION_DOWNLOADTOKENKEYPATH=
 IF_AUTHENTICATION_DOWNLOADTOKENTTL=5m0s
 IF_AUTHENTICATION_ENABLED=false
 IF_AUTHENTICATION_HTPASSWDPATH=
+IF_AUTHENTICATION_PROVIDER=htpasswd
 IF_BUILD_BROKENTALOSVERSIONS=[]
 IF_BUILD_MAXCONCURRENCY=6
 IF_BUILD_MINTALOSVERSION=1.2.0

--- a/enterprise/auth/auth.go
+++ b/enterprise/auth/auth.go
@@ -185,11 +185,6 @@ func (provider *Provider) Middleware(handler Handler) Handler {
 	}
 }
 
-// VerifyCredentials implements enterprise.AuthProvider.
-func (provider *Provider) VerifyCredentials(username, password string) bool {
-	return provider.verifyCredentials(username, password)
-}
-
 // UsernameFromContext implements enterprise.AuthProvider.
 func (provider *Provider) UsernameFromContext(ctx context.Context) (string, bool) {
 	return GetAuthUsername(ctx)

--- a/enterprise/auth/auth0/export_test.go
+++ b/enterprise/auth/auth0/export_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth0
+
+// ExtractToken exposes the Authorization header parser for external tests, which cannot
+// otherwise distinguish "no token found" from "token found and rejected".
+var ExtractToken = extractToken
+
+// NormalizeDomain exposes the domain parser so tests can assert the issuer string it
+// produces, not just whether the domain was accepted.
+var NormalizeDomain = normalizeDomain

--- a/enterprise/auth/auth0/provider.go
+++ b/enterprise/auth/auth0/provider.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package auth0 provides an Auth0-backed authentication provider.
+package auth0
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+
+	"github.com/siderolabs/image-factory/enterprise/auth"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+// Handler is the type of HTTP handlers used by the enterprise frontend.
+type Handler = auth.Handler
+
+const (
+	// jwksFetchTimeout bounds the JWKS fetch, which happens inline on the request path.
+	jwksFetchTimeout = 5 * time.Second
+
+	// clockSkew tolerates the factory's clock running ahead of the Auth0 tenant's.
+	// go-oidc runs both checks off one Now hook, so moving the clock back widens the exp
+	// window and narrows go-oidc's own 5m nbf tolerance by the same amount.
+	// Keep this well under 5m or freshly issued tokens carrying nbf start failing.
+	clockSkew = 30 * time.Second
+
+	// jwksRefetchInterval and jwksRefetchBurst bound how often the JWKS endpoint is refetched.
+	// Auth0 rotates keys rarely, so this only has to keep up with real rotations.
+	jwksRefetchInterval = 5 * time.Second
+	jwksRefetchBurst    = 3
+)
+
+// jwksTransport bounds JWKS refetches. go-oidc refetches whenever no cached key verifies
+// the signature, so without this any well-formed JWT costs one request to the Auth0 tenant,
+// which rate-limits that endpoint. Concurrent verifications coalesce into a single fetch
+// inside go-oidc, so this only has to bound the sequential case.
+type jwksTransport struct {
+	next    http.RoundTripper
+	limiter *rate.Limiter
+	logger  *zap.Logger
+}
+
+func (t *jwksTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Queue rather than fail: during a key rotation a valid token needs this fetch, and
+	// dropping it would 401 a legitimate caller. Wait returns immediately when the delay
+	// would outlive the request, so the client timeout bounds how many callers pile up.
+	if err := t.limiter.Wait(r.Context()); err != nil {
+		// Warn because the caller only sees a 401, indistinguishable from bad credentials:
+		// during a rotation under load this log is the only signal that it was throttling.
+		// Safe to log loudly: the limiter caps this well below the request rate.
+		t.logger.Warn("auth0: jwks refetch throttled, key rotation may be delayed", zap.Error(err))
+
+		return nil, fmt.Errorf("jwks refetch rate exceeded: %w", err)
+	}
+
+	return t.next.RoundTrip(r)
+}
+
+// Config is the full configuration for the Auth0 provider.
+type Config struct {
+	Domain   string
+	Audience string
+
+	// MachineScope, when set, marks tokens carrying it as machine credentials, limited to
+	// artifact fetches. Leave empty to give every token full access.
+	MachineScope string
+
+	// IssuerURLOverride replaces the default issuer URL constructed from Domain.
+	// It sets both the expected iss claim and the JWKS endpoint.
+	// Intended for testing only; leave empty in production.
+	IssuerURLOverride string
+}
+
+// normalizeDomain accepts the tenant domain with or without a scheme or trailing slash,
+// so that a copy-paste from the Auth0 console fails at startup rather than on every token.
+// The result is the trust anchor for every token, so anything but a bare host is rejected
+// rather than trimmed into something that resolves elsewhere.
+func normalizeDomain(domain string) (string, error) {
+	// Lowercased first because the result is compared byte-for-byte against the iss claim;
+	// a console copy-paste with any capitals would otherwise fail on every token instead.
+	lowered := strings.ToLower(domain)
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(strings.TrimPrefix(lowered, "https://"), "http://"), "/")
+
+	// Empty is checked explicitly: trimming reduces "/" and "https://" to "", which
+	// url.Parse then accepts as a bare (empty) host.
+	u, err := url.Parse("https://" + trimmed)
+	if trimmed == "" || err != nil || u.Host != trimmed || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("auth0: domain must be a bare tenant host, got %q", domain)
+	}
+
+	return trimmed, nil
+}
+
+// customClaims holds Auth0-specific JWT claims beyond the standard registered set.
+type customClaims struct {
+	OrgID string `json:"org_id"`
+
+	// Auth0 puts granted scopes in scope for plain client-credentials tokens and in
+	// permissions when RBAC is enabled on the API, so both have to be consulted.
+	Scope       string   `json:"scope"`
+	Permissions []string `json:"permissions"`
+}
+
+// hasScope reports whether the token was granted scope.
+func (c *customClaims) hasScope(scope string) bool {
+	return slices.Contains(strings.Fields(c.Scope), scope) || slices.Contains(c.Permissions, scope)
+}
+
+// Validate rejects claims that cannot produce an identity principal.
+// Every token path goes through validateToken, so this is enforced everywhere.
+func (c *customClaims) Validate() error {
+	if c.OrgID == "" {
+		return errors.New("org_id claim is required")
+	}
+
+	return nil
+}
+
+// Provider is an authentication provider backed by Auth0 JWTs.
+type Provider struct {
+	verifier     *oidc.IDTokenVerifier
+	logger       *zap.Logger
+	machineScope string
+}
+
+// NewProvider creates a new Auth0 authentication provider.
+// It validates config only and never reaches the network; ctx scopes the JWKS HTTP client.
+func NewProvider(ctx context.Context, logger *zap.Logger, cfg Config) (*Provider, error) {
+	if cfg.Domain == "" && cfg.IssuerURLOverride == "" {
+		return nil, errors.New("auth0: domain must not be empty")
+	}
+
+	if cfg.Audience == "" {
+		return nil, errors.New("auth0: audience must not be empty")
+	}
+
+	// Issuer URL doubles as the expected iss claim.
+	issuerURL := cfg.IssuerURLOverride
+	if issuerURL == "" {
+		domain, err := normalizeDomain(cfg.Domain)
+		if err != nil {
+			return nil, err
+		}
+
+		issuerURL = "https://" + domain + "/"
+	}
+
+	providerLogger := logger.With(zap.String("component", "auth0-provider"))
+
+	// Cloned so the JWKS client doesn't inherit later mutations of the process-wide pool.
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("auth0: http.DefaultTransport is not an *http.Transport")
+	}
+
+	// The key set is fetched lazily on the first token, so a tenant outage at startup is not fatal.
+	keyCtx := oidc.ClientContext(ctx, &http.Client{
+		Timeout: jwksFetchTimeout,
+		Transport: &jwksTransport{
+			next:    baseTransport.Clone(),
+			limiter: rate.NewLimiter(rate.Every(jwksRefetchInterval), jwksRefetchBurst),
+			logger:  providerLogger,
+		},
+	})
+	keySet := oidc.NewRemoteKeySet(keyCtx, strings.TrimSuffix(issuerURL, "/")+"/.well-known/jwks.json")
+
+	verifier := oidc.NewVerifier(issuerURL, keySet, &oidc.Config{
+		ClientID:             cfg.Audience,
+		SupportedSigningAlgs: []string{oidc.RS256},
+		Now:                  func() time.Time { return time.Now().Add(-clockSkew) },
+	})
+
+	return &Provider{
+		verifier:     verifier,
+		logger:       providerLogger,
+		machineScope: cfg.MachineScope,
+	}, nil
+}
+
+// machineAllowed reports whether a machine-scoped token may make this request.
+//
+// Nodes pull installers through the OCI registry and boot artifacts from /image, and need
+// nothing else. In particular the schematic body stays out of reach, so a credential sitting
+// on a node cannot enumerate how the org's images are built.
+func machineAllowed(r *http.Request) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+
+	return strings.HasPrefix(r.URL.Path, "/image/") ||
+		r.URL.Path == "/v2" ||
+		strings.HasPrefix(r.URL.Path, "/v2/")
+}
+
+// Run blocks until ctx is canceled, satisfying the enterprise.AuthProvider lifecycle.
+// There is nothing to start: the key set is fetched on demand.
+func (p *Provider) Run(ctx context.Context) error {
+	<-ctx.Done()
+
+	return nil
+}
+
+// Middleware implements enterprise.AuthProvider.
+// The token is read from the Authorization header, either as a Bearer value or in the
+// Basic password field; anything else gets a 401 with a WWW-Authenticate challenge.
+func (p *Provider) Middleware(next Handler) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, params httprouter.Params) error {
+		logger := ctxlog.Logger(ctx, p.logger)
+
+		tokenStr := extractToken(r)
+		if tokenStr == "" {
+			logger.Debug("auth0: authentication required: no token provided")
+			setChallenge(w)
+
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+		}
+
+		claims, err := p.validateToken(ctx, tokenStr)
+		if err != nil {
+			// Debug, not Warn: an unauthenticated caller controls how often this fires.
+			logger.Debug("auth0: authentication failed", zap.Error(err))
+			setChallenge(w)
+
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("invalid token"))
+		}
+
+		ctx = auth.WithAuthUsername(ctx, claims.OrgID)
+
+		// Written back to the request so the principal survives a denial below: next never
+		// runs then, and the request context is the only channel the caller still sees.
+		*r = *r.WithContext(ctx)
+
+		// Forbidden rather than a challenge: the token is valid, it just isn't allowed here,
+		// and re-authenticating with the same credential would not change that.
+		if p.machineScope != "" && claims.hasScope(p.machineScope) && !machineAllowed(r) {
+			logger.Debug("auth0: machine-scoped token denied",
+				zap.String("org_id", claims.OrgID), zap.String("path", r.URL.Path))
+
+			return xerrors.NewTagged[schematicpkg.ForbiddenTag](errors.New("machine-scoped token"))
+		}
+
+		logger.Debug("auth0: authenticated", zap.String("org_id", claims.OrgID))
+
+		return next(ctx, w, r, params)
+	}
+}
+
+// setChallenge advertises Basic ahead of Bearer, as separate header values so a parser
+// cannot read "Bearer" as a parameter of the Basic challenge.
+// Order matters: OCI clients take the first scheme they recognize, and only Basic carries
+// a usable token here.
+func setChallenge(w http.ResponseWriter) {
+	w.Header().Add("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
+	w.Header().Add("WWW-Authenticate", `Bearer realm="Image Factory Enterprise"`)
+}
+
+// UsernameFromContext implements enterprise.AuthProvider.
+func (p *Provider) UsernameFromContext(ctx context.Context) (string, bool) {
+	return auth.GetAuthUsername(ctx)
+}
+
+// ContextWithUsername implements enterprise.AuthProvider.
+func (p *Provider) ContextWithUsername(ctx context.Context, username string) context.Context {
+	return auth.WithAuthUsername(ctx, username)
+}
+
+// extractToken pulls the JWT from the Authorization header, accepting it either
+// as a Bearer value or in the Basic password field (used by OCI/Talos registry
+// clients, which only speak Basic Auth).
+func extractToken(r *http.Request) string {
+	scheme, value, _ := strings.Cut(r.Header.Get("Authorization"), " ")
+
+	// RFC 9110 makes the scheme case-insensitive; some clients send "bearer".
+	if strings.EqualFold(scheme, "Bearer") {
+		return value
+	}
+
+	if _, password, ok := r.BasicAuth(); ok {
+		return password
+	}
+
+	return ""
+}
+
+// validateToken validates the token and returns its claims, whose org_id is the identity
+// principal, matching the htpasswd provider where the username maps to an org.
+// This is the only path that turns a token into an identity, so every caller gets the
+// signature, issuer, audience, expiry and org_id checks.
+func (p *Provider) validateToken(ctx context.Context, tokenStr string) (*customClaims, error) {
+	token, err := p.verifier.Verify(ctx, tokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("auth0: token validation failed: %w", err)
+	}
+
+	var claims customClaims
+
+	if err = token.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("auth0: failed to parse claims: %w", err)
+	}
+
+	if err = claims.Validate(); err != nil {
+		return nil, fmt.Errorf("auth0: %w", err)
+	}
+
+	return &claims, nil
+}

--- a/enterprise/auth/auth0/provider_test.go
+++ b/enterprise/auth/auth0/provider_test.go
@@ -1,0 +1,536 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth0_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/image-factory/enterprise/auth"
+	"github.com/siderolabs/image-factory/enterprise/auth/auth0"
+	"github.com/siderolabs/image-factory/internal/testoidc"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+const (
+	testDomain   = "test.auth0.com"
+	testAudience = "https://image-factory.test"
+	testSubject  = "user1|abc123"
+	testOrgID    = "org_abc123"
+	testKeyID    = "test-key-1"
+)
+
+// setupProvider starts an in-process OIDC discovery + JWKS server, creates a
+// Provider wired to it via IssuerURLOverride, and returns both.
+// The returned issuerURL is the server base URL — use it when signing test tokens
+// so that the iss claim matches the provider's expected issuer.
+func setupProvider(t *testing.T, privateKey *rsa.PrivateKey) (*auth0.Provider, string) {
+	t.Helper()
+
+	issuerURL := testoidc.StartServer(t, privateKey, testKeyID)
+
+	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
+		Domain:            testDomain,
+		Audience:          testAudience,
+		IssuerURLOverride: issuerURL,
+	})
+	require.NoError(t, err)
+
+	return p, issuerURL
+}
+
+// signToken builds and signs a JWT with the given fields.
+func signToken(t *testing.T, privateKey *rsa.PrivateKey, iss, aud, orgID string, exp time.Time) string {
+	t.Helper()
+
+	return testoidc.SignToken(t, privateKey, testoidc.TokenOptions{
+		KeyID:    testKeyID,
+		Issuer:   iss,
+		Subject:  testSubject,
+		Audience: []string{aud},
+		OrgID:    orgID,
+		Expiry:   exp,
+	})
+}
+
+// captureHandler records the username the middleware authenticated as.
+func captureHandler(capturedUsername *string) auth0.Handler {
+	return func(ctx context.Context, _ http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+		*capturedUsername, _ = auth.GetAuthUsername(ctx)
+
+		return nil
+	}
+}
+
+func TestAuth0ProviderMiddleware(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	p, issuerURL := setupProvider(t, privateKey)
+
+	validToken := signToken(t, privateKey, issuerURL, testAudience, testOrgID, time.Now().Add(time.Hour))
+	expiredToken := signToken(t, privateKey, issuerURL, testAudience, testOrgID, time.Now().Add(-time.Hour))
+	noOrgToken := signToken(t, privateKey, issuerURL, testAudience, "", time.Now().Add(time.Hour))
+	wrongAudToken := signToken(t, privateKey, issuerURL, "https://wrong-audience", "", time.Now().Add(time.Hour))
+	wrongIssToken := signToken(t, privateKey, "https://wrong.auth0.com/", testAudience, "", time.Now().Add(time.Hour))
+
+	// wrongKeyToken is signed by a different key — signature check must fail.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	wrongKeyToken := signToken(t, otherKey, issuerURL, testAudience, "", time.Now().Add(time.Hour))
+
+	// Auth0 issues a multi-valued aud; ours only has to be present, not alone.
+	multiAudToken := testoidc.SignToken(t, privateKey, testoidc.TokenOptions{
+		KeyID:    testKeyID,
+		Issuer:   issuerURL,
+		Subject:  testSubject,
+		Audience: []string{testAudience, "https://other-api.test"},
+		OrgID:    testOrgID,
+		Expiry:   time.Now().Add(time.Hour),
+	})
+
+	// The JWKS server only publishes testKeyID, so this drives the refetch path.
+	unknownKidToken := testoidc.SignToken(t, privateKey, testoidc.TokenOptions{
+		KeyID:    "unknown-kid",
+		Issuer:   issuerURL,
+		Subject:  testSubject,
+		Audience: []string{testAudience},
+		OrgID:    testOrgID,
+		Expiry:   time.Now().Add(time.Hour),
+	})
+
+	// Expired, but inside the clock-skew window; pins that the skew widens the window.
+	recentlyExpiredToken := signToken(t, privateKey, issuerURL, testAudience, testOrgID, time.Now().Add(-10*time.Second))
+
+	// nbf a minute out: go-oidc allows 5m, which clockSkew eats into. Pins that the two
+	// stay compatible, so bumping clockSkew toward 5m fails here rather than in production.
+	notYetValidToken := testoidc.SignToken(t, privateKey, testoidc.TokenOptions{
+		KeyID:     testKeyID,
+		Issuer:    issuerURL,
+		Subject:   testSubject,
+		Audience:  []string{testAudience},
+		OrgID:     testOrgID,
+		Expiry:    time.Now().Add(time.Hour),
+		NotBefore: time.Now().Add(time.Minute),
+	})
+
+	for _, tc := range []struct {
+		name            string
+		setupRequest    func(*http.Request)
+		expectUsername  string
+		expectAuthError bool
+	}{
+		{
+			name:            "no credentials",
+			setupRequest:    func(r *http.Request) {},
+			expectAuthError: true,
+		},
+		{
+			name: "valid bearer token",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+validToken)
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			name: "valid token in basic auth password",
+			setupRequest: func(r *http.Request) {
+				r.SetBasicAuth("ignored", validToken)
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			// Bearer and Basic share one header, so both can only appear as two header
+			// values, and Header.Get reads the first.
+			name: "second authorization header value is ignored",
+			setupRequest: func(r *http.Request) {
+				r.Header.Add("Authorization", "Bearer "+validToken)
+				r.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString(
+					[]byte("ignored:"+expiredToken),
+				))
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			// RFC 9110 makes the auth scheme case-insensitive.
+			name: "lowercase bearer scheme",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "bearer "+validToken)
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			name: "unsupported authorization scheme",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Token "+validToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "expired token",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+expiredToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "wrong audience",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+wrongAudToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "wrong issuer",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+wrongIssToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "wrong signing key",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+wrongKeyToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "malformed token",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer not.a.jwt")
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "empty basic auth password",
+			setupRequest: func(r *http.Request) {
+				r.SetBasicAuth("user", "")
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "valid jwt but no org_id claim",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+noOrgToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "audience is one of several",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+multiAudToken)
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			name: "unknown key id",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+unknownKidToken)
+			},
+			expectAuthError: true,
+		},
+		{
+			name: "expired within the clock-skew window",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+recentlyExpiredToken)
+			},
+			expectUsername: testOrgID,
+		},
+		{
+			name: "nbf within go-oidc's tolerance",
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+notYetValidToken)
+			},
+			expectUsername: testOrgID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			tc.setupRequest(req)
+
+			var capturedUsername string
+
+			middleware := p.Middleware(captureHandler(&capturedUsername))
+
+			err = middleware(ctx, httptest.NewRecorder(), req, nil)
+
+			if tc.expectAuthError {
+				require.Error(t, err)
+				require.True(t, xerrors.TagIs[schematicpkg.RequiresAuthenticationTag](err),
+					"expected RequiresAuthenticationTag error, got: %v", err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectUsername, capturedUsername)
+		})
+	}
+}
+
+// TestAuth0ProviderMachineScope covers the artifact-only allowlist applied to tokens
+// carrying the machine scope.
+func TestAuth0ProviderMachineScope(t *testing.T) {
+	t.Parallel()
+
+	const machineScope = "factory:machine"
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	issuerURL := testoidc.StartServer(t, privateKey, testKeyID)
+
+	newProvider := func(scope string) *auth0.Provider {
+		p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
+			Domain:            testDomain,
+			Audience:          testAudience,
+			MachineScope:      scope,
+			IssuerURLOverride: issuerURL,
+		})
+		require.NoError(t, err)
+
+		return p
+	}
+
+	signMachineToken := func(opts testoidc.TokenOptions) string {
+		opts.KeyID = testKeyID
+		opts.Issuer = issuerURL
+		opts.Subject = testSubject
+		opts.Audience = []string{testAudience}
+		opts.OrgID = testOrgID
+		opts.Expiry = time.Now().Add(time.Hour)
+
+		return testoidc.SignToken(t, privateKey, opts)
+	}
+
+	// Auth0 puts the grant in scope for client credentials and in permissions under RBAC.
+	scopeClaimToken := signMachineToken(testoidc.TokenOptions{Scope: "openid " + machineScope})
+	permissionsClaimToken := signMachineToken(testoidc.TokenOptions{Permissions: []string{machineScope}})
+	humanToken := signMachineToken(testoidc.TokenOptions{Scope: "openid profile"})
+
+	for _, test := range []struct {
+		name         string
+		token        string
+		method       string
+		path         string
+		scope        string
+		expectDenied bool
+	}{
+		{name: "image download", token: scopeClaimToken, method: http.MethodGet, path: "/image/abc/v1.9.0/metal-amd64.iso", scope: machineScope},
+		{name: "image head", token: scopeClaimToken, method: http.MethodHead, path: "/image/abc/v1.9.0/metal-amd64.iso", scope: machineScope},
+		{name: "registry root", token: scopeClaimToken, method: http.MethodGet, path: "/v2", scope: machineScope},
+		{name: "registry manifest", token: scopeClaimToken, method: http.MethodGet, path: "/v2/installer/manifests/v1.9.0", scope: machineScope},
+		{name: "permissions claim is read too", token: permissionsClaimToken, method: http.MethodGet, path: "/schematics/abc", scope: machineScope, expectDenied: true},
+
+		{name: "schematic creation", token: scopeClaimToken, method: http.MethodPost, path: "/schematics", scope: machineScope, expectDenied: true},
+		{name: "schematic read", token: scopeClaimToken, method: http.MethodGet, path: "/schematics/abc", scope: machineScope, expectDenied: true},
+		{name: "pxe", token: scopeClaimToken, method: http.MethodGet, path: "/pxe/abc/v1.9.0/metal-amd64", scope: machineScope, expectDenied: true},
+		{name: "sbom", token: scopeClaimToken, method: http.MethodGet, path: "/spdx/abc/v1.9.0/amd64", scope: machineScope, expectDenied: true},
+		{name: "ui", token: scopeClaimToken, method: http.MethodGet, path: "/ui/schematics", scope: machineScope, expectDenied: true},
+
+		// A token without the scope, and any token when no scope is configured, keep full access.
+		{name: "token without the scope", token: humanToken, method: http.MethodPost, path: "/schematics", scope: machineScope},
+		{name: "scope not configured", token: scopeClaimToken, method: http.MethodPost, path: "/schematics"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedUsername string
+
+			r := httptest.NewRequestWithContext(t.Context(), test.method, test.path, nil)
+			r.Header.Set("Authorization", "Bearer "+test.token)
+
+			err := newProvider(test.scope).Middleware(captureHandler(&capturedUsername))(t.Context(), httptest.NewRecorder(), r, nil)
+
+			if test.expectDenied {
+				require.Error(t, err)
+				require.Truef(t, xerrors.TagIs[schematicpkg.ForbiddenTag](err), "expected ForbiddenTag error, got: %v", err)
+
+				// The frontend reads the principal back off the request to attribute the
+				// denial in the audit log, since the wrapped handler never runs.
+				principal, ok := auth.GetAuthUsername(r.Context())
+				require.True(t, ok, "denied request should still carry the principal")
+				require.Equal(t, testOrgID, principal)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testOrgID, capturedUsername)
+		})
+	}
+}
+
+// TestAuth0ProviderChallengeOrder pins Basic ahead of Bearer on a 401, since OCI clients
+// authenticate with the first scheme they recognize and only Basic is usable here.
+func TestAuth0ProviderChallengeOrder(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	p, _ := setupProvider(t, privateKey)
+
+	for _, test := range []struct {
+		setupFn func(*http.Request)
+		name    string
+	}{
+		{name: "no credentials", setupFn: func(*http.Request) {}},
+		{
+			name:    "invalid token",
+			setupFn: func(r *http.Request) { r.Header.Set("Authorization", "Bearer not-a-token") },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", nil)
+			test.setupFn(r)
+
+			w := httptest.NewRecorder()
+
+			next := func(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error {
+				t.Fatal("handler must not run for an unauthenticated request")
+
+				return nil
+			}
+
+			require.Error(t, p.Middleware(next)(t.Context(), w, r, nil))
+
+			require.Equal(t, []string{
+				`Basic realm="Image Factory Enterprise", charset="UTF-8"`,
+				`Bearer realm="Image Factory Enterprise"`,
+			}, w.Header().Values("WWW-Authenticate"))
+		})
+	}
+}
+
+func TestAuth0ProviderUsernameFromContext(t *testing.T) {
+	t.Parallel()
+
+	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{Domain: testDomain, Audience: testAudience})
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	_, ok := p.UsernameFromContext(ctx)
+	require.False(t, ok, "empty context should return no username")
+
+	ctx = auth.WithAuthUsername(ctx, "alice")
+	username, ok := p.UsernameFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "alice", username)
+}
+
+func TestNewProviderValidation(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+
+	_, err := auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: "", Audience: testAudience})
+	require.Error(t, err, "empty domain should be rejected")
+
+	_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: testDomain, Audience: ""})
+	require.Error(t, err, "empty audience should be rejected")
+
+	_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: testDomain, Audience: testAudience})
+	require.NoError(t, err, "domain and audience alone should be a valid, bearer-token-only setup")
+
+	// The domain is the trust anchor, so anything that could point elsewhere is rejected
+	// rather than trimmed into shape.
+	for _, domain := range []string{
+		"user@evil.example",
+		"tenant.auth0.com/path",
+		"tenant.auth0.com?q=1",
+		"tenant.auth0.com#frag",
+		"tenant.auth0.com/../evil.example",
+	} {
+		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: domain, Audience: testAudience})
+		require.Errorf(t, err, "domain %q should be rejected", domain)
+	}
+
+	// A scheme or trailing slash is what the Auth0 console shows, so accept it.
+	for _, domain := range []string{"https://" + testDomain, "https://" + testDomain + "/", testDomain + "/"} {
+		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: domain, Audience: testAudience})
+		require.NoErrorf(t, err, "domain %q should be accepted", domain)
+	}
+
+	// The result becomes the issuer, which is compared byte-for-byte against iss, so
+	// accepting a mixed-case domain is not enough — it has to come back lowercased.
+	for _, domain := range []string{"Tenant.Auth0.com", "HTTPS://Tenant.Auth0.com/"} {
+		normalized, normalizeErr := auth0.NormalizeDomain(domain)
+		require.NoErrorf(t, normalizeErr, "domain %q should be accepted", domain)
+		require.Equalf(t, "tenant.auth0.com", normalized, "domain %q should normalize to lowercase", domain)
+	}
+
+	// Each of these trims to the empty host, which url.Parse accepts; without an explicit
+	// check they yield issuer "https:///" and fail on the first token instead of at startup.
+	for _, domain := range []string{"", "/", "https://", "http://", "https:///"} {
+		_, normalizeErr := auth0.NormalizeDomain(domain)
+		require.Errorf(t, normalizeErr, "domain %q should be rejected", domain)
+	}
+}
+
+// TestExtractToken covers which Authorization headers yield a token candidate.
+// The Basic cases matter because OCI and Talos registry clients only speak Basic,
+// so the password field has to be accepted as a token.
+func TestExtractToken(t *testing.T) {
+	t.Parallel()
+
+	const jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.c2ln"
+
+	for _, test := range []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{"absent", "", ""},
+		{"bearer", "Bearer " + jwt, jwt},
+		{"bearer lowercase", "bearer " + jwt, jwt},
+		{"bearer mixed case", "BeArEr " + jwt, jwt},
+		{"unsupported scheme", "Token " + jwt, ""},
+		{"scheme only", "Bearer", ""},
+		{"basic password", "Basic " + basicValue("ignored", jwt), jwt},
+		{"basic with empty password", "Basic " + basicValue("developer", ""), ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			if test.header != "" {
+				r.Header.Set("Authorization", test.header)
+			}
+
+			require.Equal(t, test.expected, auth0.ExtractToken(r))
+		})
+	}
+}
+
+// basicValue builds the base64 credentials part of a Basic Authorization header.
+func basicValue(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/anchore/grype v0.115.0
 	github.com/anchore/syft v1.46.0
 	github.com/blang/semver/v4 v4.0.0
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-containerregistry v0.21.7
@@ -57,6 +58,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.40.0
+	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
@@ -178,7 +180,6 @@ require (
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
 	github.com/containernetworking/cni v1.3.0 // indirect
-	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
 	github.com/cosi-project/runtime v1.16.1 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
@@ -463,7 +464,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10 // indirect

--- a/internal/frontend/http/challenge_test.go
+++ b/internal/frontend/http/challenge_test.go
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	httpfe "github.com/siderolabs/image-factory/internal/frontend/http"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+// TestUnauthorizedChallengeHeader pins the WWW-Authenticate behavior on a 401.
+// The wrapper only supplies the Basic challenge as a fallback, so htpasswd (which sets
+// nothing) keeps the challenge OCI registry clients require, while a provider that set
+// its own keeps them — including their order, which is what those clients select on.
+func TestUnauthorizedChallengeHeader(t *testing.T) {
+	t.Parallel()
+
+	unauthorized := xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+
+	for _, test := range []struct {
+		name      string
+		setHeader func(http.ResponseWriter)
+		expected  []string
+	}{
+		{
+			name:      "htpasswd sets no challenge, so the Basic fallback applies",
+			setHeader: func(http.ResponseWriter) {},
+			expected:  []string{`Basic realm="Image Factory Enterprise", charset="UTF-8"`},
+		},
+		{
+			name: "provider-set challenges are preserved in order",
+			setHeader: func(w http.ResponseWriter) {
+				w.Header().Add("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
+				w.Header().Add("WWW-Authenticate", `Bearer realm="Image Factory Enterprise"`)
+			},
+			expected: []string{
+				`Basic realm="Image Factory Enterprise", charset="UTF-8"`,
+				`Bearer realm="Image Factory Enterprise"`,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := httpfe.NewTestFrontend(zaptest.NewLogger(t))
+
+			handler := func(_ context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+				test.setHeader(w)
+
+				return unauthorized
+			}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", nil)
+
+			f.WrapHandler(handler)(w, r, nil)
+
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+			assert.Equal(t, test.expected, w.Header().Values("WWW-Authenticate"))
+		})
+	}
+}

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -271,7 +271,10 @@ func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
 
 		level, status := MatchError(err, func(message string, code int) {
 			if code == http.StatusUnauthorized {
-				w.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise"`)
+				// Fallback only: a provider that already picked its challenges keeps them.
+				if w.Header().Get("WWW-Authenticate") == "" {
+					w.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
+				}
 			}
 
 			http.Error(w, message, code)
@@ -340,11 +343,20 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string) Handl
 			}
 		}
 
-		return authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		err := authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 			*username, _ = authProvider.UsernameFromContext(ctx)
 
 			return h(ctx, w, r, p)
 		})(ctx, w, r, p)
+
+		// A provider can authenticate the caller and then refuse the request, in which case
+		// the layer above never ran. The provider leaves the principal on the request so the
+		// denial is still attributable.
+		if *username == "" {
+			*username, _ = authProvider.UsernameFromContext(r.Context()) //nolint:contextcheck // the provider derived this context from ctx
+		}
+
+		return err
 	}
 }
 

--- a/internal/integration/auth0_test.go
+++ b/internal/integration/auth0_test.go
@@ -1,0 +1,298 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration
+
+// auth0_test.go: integration tests for the Auth0 authentication provider.
+// Spins up a full image-factory instance backed by an in-process OIDC server
+// and verifies that authenticated and unauthenticated requests are handled correctly.
+
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
+	"github.com/siderolabs/image-factory/internal/testoidc"
+	"github.com/siderolabs/image-factory/pkg/client"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
+)
+
+const (
+	auth0TestDomain   = "test.auth0.com"
+	auth0TestAudience = "https://image-factory.test"
+	auth0TestKeyID    = "integration-test-key"
+
+	auth0OrgA = "org_aaa111"
+	auth0OrgB = "org_bbb222"
+)
+
+// auth0TokenFixtures holds pre-signed tokens for a test run.
+type auth0TokenFixtures struct {
+	orgAToken    string
+	orgBToken    string
+	expiredToken string
+	noOrgToken   string
+}
+
+// auth0SignToken creates and signs a JWT using the shared test helper.
+func auth0SignToken(t *testing.T, privateKey *rsa.PrivateKey, iss, aud, orgID string, exp time.Time) string {
+	t.Helper()
+
+	return testoidc.SignToken(t, privateKey, testoidc.TokenOptions{
+		KeyID:    auth0TestKeyID,
+		Issuer:   iss,
+		Subject:  "user|test",
+		Audience: []string{aud},
+		OrgID:    orgID,
+		Expiry:   exp,
+	})
+}
+
+// setupEnterpriseAuth0 configures opts for the auth0 provider using an
+// in-process OIDC server. Returns token fixtures for use in test assertions.
+func setupEnterpriseAuth0(t *testing.T, opts *cmd.Options) auth0TokenFixtures {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serverURL := testoidc.StartServer(t, privateKey, auth0TestKeyID)
+
+	opts.Authentication.Enabled = true
+	opts.Authentication.Provider = cmd.AuthProviderAuth0
+	opts.Authentication.Auth0.Domain = auth0TestDomain
+	opts.Authentication.Auth0.Audience = auth0TestAudience
+	opts.SetAuth0IssuerURL(serverURL)
+
+	now := time.Now()
+
+	return auth0TokenFixtures{
+		orgAToken:    auth0SignToken(t, privateKey, serverURL, auth0TestAudience, auth0OrgA, now.Add(time.Hour)),
+		orgBToken:    auth0SignToken(t, privateKey, serverURL, auth0TestAudience, auth0OrgB, now.Add(time.Hour)),
+		expiredToken: auth0SignToken(t, privateKey, serverURL, auth0TestAudience, auth0OrgA, now.Add(-time.Hour)),
+		noOrgToken:   auth0SignToken(t, privateKey, serverURL, auth0TestAudience, "", now.Add(time.Hour)),
+	}
+}
+
+func TestIntegrationAuth0(t *testing.T) {
+	if !enterprise.Enabled() {
+		t.Skip("enterprise features are disabled")
+	}
+
+	options := cmd.DefaultOptions
+	options.Cache.OCI = cacheRepository.OCIRepositoryOptions
+	options.Metrics.Namespace = "test_auth0"
+
+	fixtures := setupEnterpriseAuth0(t, &options)
+
+	ctx, listenAddr, _ := setupFactory(t, options)
+	baseURL := "http://" + listenAddr
+
+	t.Run("Enforcement", func(t *testing.T) {
+		t.Parallel()
+
+		testAuth0Enforcement(ctx, t, baseURL, fixtures)
+	})
+
+	t.Run("NodeFlow", func(t *testing.T) {
+		t.Parallel()
+
+		testAuth0NodeFlow(ctx, t, baseURL, fixtures)
+	})
+
+	t.Run("Ownership", func(t *testing.T) {
+		t.Parallel()
+
+		testAuth0Ownership(ctx, t, baseURL, fixtures)
+	})
+}
+
+// testAuth0Enforcement verifies that protected endpoints reject missing/invalid
+// tokens and accept a valid JWT as a Bearer token.
+func testAuth0Enforcement(ctx context.Context, t *testing.T, baseURL string, fx auth0TokenFixtures) {
+	t.Helper()
+
+	protectedEndpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/v2/"},
+		{http.MethodPost, "/schematics"},
+		{http.MethodGet, "/schematics/" + nonexistentSchematicID},
+		{http.MethodGet, "/"},
+	}
+
+	t.Run("NoCredentials_401", func(t *testing.T) {
+		t.Parallel()
+
+		for _, ep := range protectedEndpoints {
+			t.Run(ep.method+"_"+ep.path, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequestWithContext(ctx, ep.method, baseURL+ep.path, bytes.NewReader([]byte("customization: {}")))
+				require.NoError(t, err)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+
+				t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+				assertRequiresAuth(t, resp)
+			})
+		}
+	})
+
+	t.Run("ExpiredToken_401", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+fx.expiredToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("NoOrgID_401", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+fx.noOrgToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+
+	t.Run("ValidBearerToken_200", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+fx.orgAToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// testAuth0NodeFlow verifies that a JWT sent as the Basic Auth password (the
+// way Talos injects a node token as a registry credential) is accepted.
+func testAuth0NodeFlow(ctx context.Context, t *testing.T, baseURL string, fx auth0TokenFixtures) {
+	t.Helper()
+
+	t.Run("JWTAsBasicAuthPassword_200", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/", nil)
+		require.NoError(t, err)
+
+		// Username is ignored; JWT goes in the password field.
+		req.SetBasicAuth("node", fx.orgAToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("JWTAsBasicAuthPassword_SchematicCreate_200", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := client.New(baseURL, client.WithBasicAuth("node", fx.orgAToken))
+		require.NoError(t, err)
+
+		_, _, err = c.SchematicCreate(ctx, schematicpkg.Schematic{})
+		require.NoError(t, err)
+	})
+}
+
+// testAuth0Ownership verifies that org-scoped schematics are not accessible
+// to tokens from a different org.
+func testAuth0Ownership(ctx context.Context, t *testing.T, baseURL string, fx auth0TokenFixtures) {
+	t.Helper()
+
+	// Create a schematic as org A.
+	c, err := client.New(baseURL, client.WithBasicAuth("node", fx.orgAToken))
+	require.NoError(t, err)
+
+	schematicID, _, err := c.SchematicCreate(ctx, schematicpkg.Schematic{})
+	require.NoError(t, err)
+
+	schematicURL := baseURL + "/schematics/" + schematicID
+
+	t.Run("Owner_200", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+fx.orgAToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("DifferentOrg_403", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Authorization", "Bearer "+fx.orgBToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("NoCredentials_401", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, schematicURL, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
+	})
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -256,8 +256,9 @@ func setupEnterprise(t *testing.T, options *cmd.Options) {
 	options.Enterprise.SPDX.Cache = spdxCacheRepositoryFlag.OCIRepositoryOptions
 
 	// Skip if the caller already configured auth (e.g. reload tests that need
-	// explicit control over the htpasswd file path).
-	if options.Authentication.Enabled && options.Authentication.HTPasswdPath != "" {
+	// explicit control over the htpasswd file path, or auth0 tests that configure
+	// the provider directly).
+	if options.Authentication.Enabled && (options.Authentication.HTPasswdPath != "" || options.Authentication.Provider == cmd.AuthProviderAuth0) {
 		return
 	}
 

--- a/internal/testoidc/testoidc.go
+++ b/internal/testoidc/testoidc.go
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build enterprise || integration
+
+// Package testoidc provides an in-process OIDC discovery + JWKS server and
+// JWT signing helper for use in auth0 unit and integration tests.
+package testoidc
+
+import (
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+// StartServer starts an in-process HTTP server serving the public key set at
+// GET /.well-known/jwks.json.
+//
+// The returned URL is the server base URL, suitable for use as the
+// IssuerURLOverride and as the iss claim when signing test JWTs.
+func StartServer(t *testing.T, privateKey *rsa.PrivateKey, keyID string) string {
+	t.Helper()
+
+	keySet := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:       privateKey.Public(),
+				KeyID:     keyID,
+				Use:       "sig",
+				Algorithm: string(jose.RS256),
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/jwks.json" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(keySet) //nolint:errcheck
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+// TokenOptions describes the JWT to sign. A struct rather than positional arguments
+// because most of these are strings that would be easy to transpose.
+type TokenOptions struct {
+	Expiry time.Time
+
+	// NotBefore is omitted when zero.
+	NotBefore time.Time
+
+	KeyID string
+
+	// Issuer must match the URL returned by StartServer for the token to be valid.
+	Issuer  string
+	Subject string
+
+	// OrgID is omitted when empty, producing a token without an org_id claim.
+	OrgID string
+
+	// Scope is the space-delimited scope claim Auth0 issues for client credentials.
+	// Omitted when empty.
+	Scope string
+
+	// Audience takes more than one entry to produce the multi-valued aud Auth0 issues in practice.
+	Audience []string
+
+	// Permissions is the array claim Auth0 issues instead of Scope when RBAC is enabled.
+	// Omitted when empty.
+	Permissions []string
+}
+
+// SignToken builds and signs a JWT from opts.
+func SignToken(t *testing.T, privateKey *rsa.PrivateKey, opts TokenOptions) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", opts.KeyID),
+	)
+	require.NoError(t, err)
+
+	claims := jwt.Claims{
+		Subject:  opts.Subject,
+		Issuer:   opts.Issuer,
+		Audience: jwt.Audience(opts.Audience),
+		Expiry:   jwt.NewNumericDate(opts.Expiry),
+	}
+
+	if !opts.NotBefore.IsZero() {
+		claims.NotBefore = jwt.NewNumericDate(opts.NotBefore)
+	}
+
+	builder := jwt.Signed(signer).Claims(claims)
+
+	extra := map[string]any{}
+
+	if opts.OrgID != "" {
+		extra["org_id"] = opts.OrgID
+	}
+
+	if opts.Scope != "" {
+		extra["scope"] = opts.Scope
+	}
+
+	if len(opts.Permissions) > 0 {
+		extra["permissions"] = opts.Permissions
+	}
+
+	if len(extra) > 0 {
+		builder = builder.Claims(extra)
+	}
+
+	signed, err := builder.Serialize()
+	require.NoError(t, err)
+
+	return signed
+}

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -149,10 +149,11 @@ type AuthProvider interface {
 	Run(ctx context.Context) error
 
 	// Middleware returns an HTTP middleware that enforces authentication on the provided handler.
+	//
+	// A provider that authenticates a caller and then refuses the request must leave the
+	// principal on the request context, since the wrapped handler never runs and the audit
+	// record would otherwise attribute the denial to nobody.
 	Middleware(Handler) Handler
-
-	// VerifyCredentials checks if the username/password pair is valid.
-	VerifyCredentials(username, password string) bool
 
 	// UsernameFromContext retrieves the authenticated username stored by the middleware.
 	UsernameFromContext(ctx context.Context) (string, bool)
@@ -161,4 +162,19 @@ type AuthProvider interface {
 	// the middleware had set it. Used by the download-token path to inject the
 	// JWT subject so that downstream ownership checks work normally.
 	ContextWithUsername(ctx context.Context, username string) context.Context
+}
+
+// Auth0Config holds configuration for the Auth0 authentication provider.
+//
+// This restates cmd.Auth0Options rather than reusing it because auth0.Config lives behind
+// the enterprise build tag, so cmd cannot name it; this struct is the seam between them.
+type Auth0Config struct {
+	Domain       string
+	Audience     string
+	MachineScope string
+
+	// IssuerURLOverride replaces the default issuer URL constructed from Domain.
+	// It sets both the expected iss claim and the JWKS endpoint.
+	// Intended for testing only; leave empty in production.
+	IssuerURLOverride string
 }

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -48,8 +48,13 @@ func NewSignatureWriter(_ *zap.Logger, _ signer.Signer, _ assetcache.Cache) (Sig
 	return nil, errors.New("signature writing is not supported in the non-enterprise version")
 }
 
-// NewAuthProvider creates a new authentication provider.
-func NewAuthProvider(_ *zap.Logger, _ string) (AuthProvider, error) {
+// NewHTPasswdProvider creates a new htpasswd-backed authentication provider.
+func NewHTPasswdProvider(_ *zap.Logger, _ string) (AuthProvider, error) {
+	return nil, errors.New("authentication is not supported in the non-enterprise version")
+}
+
+// NewAuth0Provider creates a new Auth0 JWT authentication provider.
+func NewAuth0Provider(_ context.Context, _ *zap.Logger, _ Auth0Config) (AuthProvider, error) {
 	return nil, errors.New("authentication is not supported in the non-enterprise version")
 }
 

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/siderolabs/image-factory/enterprise/assetsignature"
 	"github.com/siderolabs/image-factory/enterprise/auth"
+	"github.com/siderolabs/image-factory/enterprise/auth/auth0"
 	"github.com/siderolabs/image-factory/enterprise/checksum"
 	enterprisedt "github.com/siderolabs/image-factory/enterprise/downloadtoken"
 	"github.com/siderolabs/image-factory/enterprise/scanner"
@@ -170,9 +171,19 @@ func NewSignatureWriter(logger *zap.Logger, imageSigner signer.Signer, cache ass
 	return assetsignature.NewWriter(logger, blobSigner, cache), nil
 }
 
-// NewAuthProvider creates a new authentication provider.
-func NewAuthProvider(logger *zap.Logger, configPath string) (AuthProvider, error) {
+// NewHTPasswdProvider creates a new htpasswd-backed authentication provider.
+func NewHTPasswdProvider(logger *zap.Logger, configPath string) (AuthProvider, error) {
 	return auth.NewProvider(configPath, logger)
+}
+
+// NewAuth0Provider creates a new Auth0 JWT authentication provider.
+func NewAuth0Provider(ctx context.Context, logger *zap.Logger, cfg Auth0Config) (AuthProvider, error) {
+	return auth0.NewProvider(ctx, logger, auth0.Config{
+		Domain:            cfg.Domain,
+		Audience:          cfg.Audience,
+		MachineScope:      cfg.MachineScope,
+		IssuerURLOverride: cfg.IssuerURLOverride,
+	})
 }
 
 // NewDownloadTokenIssuer creates a new download token issuer.


### PR DESCRIPTION
This PR adds an Auth0 JWT provider alongside htpasswd, selected with the new authentication.provider option, which defaults to htpasswd.

The org_id claim is the identity principal, so the existing ownership and audit machinery works unchanged. Tokens are read from the Bearer header or the Basic password field, since OCI and Talos registry clients only speak Basic.

I decided to break up the previous PR into two bits. One to handle the M2M stuff, then I will chase that with the UI updates to support Auth0 on that side. I just found it too confusing to parse through otherwise.