### PR TITLE
fix: serialize scanner database integration tests

### DIFF
--- a/internal/integration/scanner_db_test.go
+++ b/internal/integration/scanner_db_test.go
@@ -241,15 +241,11 @@ func testGrypeDBMirror(t *testing.T) {
 // (RUN_TESTS_* in the Makefile), so a test that is not a subtest of one of those
 // is compiled and never run.
 func testScannerDB(t *testing.T, options cmd.Options) {
-	t.Run("mirror", func(t *testing.T) {
-		t.Parallel()
-
-		testGrypeDBMirror(t)
-	})
+	// Grype's archive builder changes the process working directory while it
+	// packages a database, so mirrors cannot be published concurrently.
+	t.Run("mirror", testGrypeDBMirror)
 
 	t.Run("rotation", func(t *testing.T) {
-		t.Parallel()
-
 		testScannerDBRotation(t, options)
 	})
 }


### PR DESCRIPTION
## What?

Serialize the synthetic Grype database mirror and rotation integration subtests.

## Why?

Grype's `CreateArchive` helper changes the process working directory while packaging a database. The two subtests previously published independent mirrors in parallel, so one archive could read the other subtest's `vulnerability.db`.

This caused the mirror assertion to intermittently observe `rotation-before` instead of `mirror-first`, as seen in [the failing integration-enterprise job](https://github.com/siderolabs/image-factory/actions/runs/31600858115/job/94154893074).

## Testing

- Reproduced the failure locally before the change: expected `mirror-first`, got `rotation-before`.
- `go test -tags integration,enterprise ./internal/integration -run 'TestIntegrationDirect/TestScannerDB/mirror$' -count=1` passed 10 consecutive runs after the change.
- `go test -tags integration,enterprise ./internal/integration -run '^$'`
- `git diff --check`
