### PR TITLE
test: fix two flaky checks in the enterprise integration job

### DIFF
--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -9,12 +9,14 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -439,10 +441,7 @@ func testDownloadTokens(ctx context.Context, t *testing.T, baseURL string) {
 	t.Run("TamperedTokenRejected", func(t *testing.T) {
 		t.Parallel()
 
-		token := getDownloadToken(ctx, t, baseURL)
-
-		// Flip a character.
-		tampered := token[:len(token)-1] + "X"
+		tampered := tamperSignature(t, getDownloadToken(ctx, t, baseURL))
 		downloadURL := baseURL + "/image/" + schematicID + "/v1.9.0/kernel-amd64?token=" + tampered
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
@@ -666,6 +665,27 @@ func testAuthCDNNoRedirect(t *testing.T, pool dockertest.Pool) {
 	t.Cleanup(func() { resp2.Body.Close() }) //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// tamperSignature flips a bit in the token's signature, so it no longer matches the payload.
+//
+// Flipping the last character of the encoded signature instead changes nothing reliably:
+// base64url packs the 64-byte ES256 signature into 86 characters, so the final character
+// carries four significant bits and several values decode to the same bytes.
+func tamperSignature(t *testing.T, token string) string {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "expected a three-segment JWT")
+
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	require.NotEmpty(t, signature)
+
+	signature[0] ^= 0xff
+	parts[2] = base64.RawURLEncoding.EncodeToString(signature)
+
+	return strings.Join(parts, ".")
 }
 
 // assertRequiresAuth checks that the response is 401 with WWW-Authenticate set,

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -237,7 +237,11 @@ func setupEnterprise(t *testing.T, options *cmd.Options) {
 
 	options.Enterprise.VEX.Data = vexDataRepositoryFlag.OCIRepositoryOptions
 
-	options.Enterprise.SPDX.Cache = spdxCacheRepositoryFlag.OCIRepositoryOptions
+	// Only when the caller has not chosen one: testScannerDBRotation runs a second factory
+	// that needs its own, and this would otherwise overwrite it.
+	if options.Enterprise.SPDX.Cache == cmd.DefaultOptions.Enterprise.SPDX.Cache {
+		options.Enterprise.SPDX.Cache = spdxCacheRepositoryFlag.OCIRepositoryOptions
+	}
 
 	// Skip if the caller already configured auth (e.g. reload tests that need
 	// explicit control over the htpasswd file path, or auth0 tests that configure

--- a/internal/integration/scanner_db_test.go
+++ b/internal/integration/scanner_db_test.go
@@ -371,6 +371,16 @@ func testScannerDBRotation(t *testing.T, options cmd.Options) {
 	// holds the real one the other enterprise tests scan against.
 	options.Enterprise.Scanner.DatabaseRootDir = t.TempDir()
 
+	// Every factory gets a fresh cache signing key, so two of them sharing an SPDX cache
+	// reject each other's signatures: both build the same tag, whoever tags last wins, and
+	// the other one's read-back fails to verify. Production replicas share a key and do not
+	// have this problem, so give this factory its own repository rather than model it.
+	//
+	// Derived from the flag rather than the default, since CI points it at a local registry.
+	options.Enterprise.SPDX.Cache = mustNewDefaultOCIRepository(
+		spdxCacheRepositoryFlag.String() + "rotation",
+	).OCIRepositoryOptions
+
 	ctx, listenAddr, _ := setupFactory(t, options)
 	baseURL := "http://" + listenAddr
 


### PR DESCRIPTION
This PR fixes two integration tests that fail for reasons of their own rather than anything
in the product. https://github.com/siderolabs/image-factory/pull/520 fixed the publish ordering behind one of them, but this part survived.

testScannerDBRotation runs a second factory in the same process, and every factory gets a
fresh cache signing key. Sharing one SPDX cache repository meant both built the same tag,
whoever tagged last won, and the loser's read-back could not verify the winner's signature.
It now gets its own repository, the way it already keeps its metrics namespace and scanner
database to itself, and setupEnterprise leaves a caller-chosen repository alone so the
override sticks.

TamperedTokenRejected flipped the last character of the download token. base64url packs the
64-byte ES256 signature into 86 characters, so that character carries four significant bits
and several values decode to the same bytes, leaving the token valid and the request a 200.
It now flips a bit in the decoded signature instead.