### PR TITLE
fix: record the status the client actually received

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/anchore/syft v1.50.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-oidc/v3 v3.20.0
+	github.com/felixge/httpsnoop v1.1.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-containerregistry v0.21.9
@@ -207,7 +208,6 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/fgprof v0.9.5 // indirect
-	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/foxboron/go-uefi v0.0.0-20251010190908-d29549a44f29 // indirect
 	github.com/freddierice/go-losetup/v2 v2.0.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -272,27 +272,44 @@ func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
 		ctx := ctxlog.WithRequestID(r.Context(), requestID)
 		logger := ctxlog.Logger(ctx, f.logger)
 
-		w.Header().Set("Server", version.ServerString())
-		w.Header().Set(RequestIDHeader, requestID)
+		var state responseState
+
+		sw := wrapResponseWriter(w, &state)
+
+		sw.Header().Set("Server", version.ServerString())
+		sw.Header().Set(RequestIDHeader, requestID)
 
 		var username string
 
-		handler := f.withAuth(h, requireAuth, &username)
+		handler := f.withAuth(h, requireAuth, &username, &state)
 
 		start := time.Now()
-		err := handler(ctx, w, r, p)
+		err := handler(ctx, sw, r, p)
 		duration := time.Since(start)
 
 		level, status := MatchError(err, func(message string, code int) {
+			if state.status != 0 {
+				// The handler already responded; this error is only here to be logged.
+				return
+			}
+
 			if code == http.StatusUnauthorized {
 				// Fallback only: a provider that already picked its challenges keeps them.
-				if w.Header().Get("WWW-Authenticate") == "" {
-					w.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
+				if sw.Header().Get("WWW-Authenticate") == "" {
+					sw.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
 				}
 			}
 
-			http.Error(w, message, code)
+			http.Error(sw, message, code)
 		})
+
+		// A handler that answered for itself returns nil, which would log as a 200.
+		if state.status != 0 {
+			status = state.status
+		} else {
+			// Nothing was committed, so net/http sends an implicit 200 that reaches no hook.
+			state.applyCacheControlPin(sw)
+		}
 
 		logger.Log(
 			level, "request",
@@ -333,7 +350,7 @@ func requestIDFrom(r *http.Request) string {
 // The middleware stores the username on a context it derives internally, which
 // never reaches wrapHandler's context; a thin capture layer reads it from inside
 // the middleware call stack and writes it to username.
-func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string) Handler {
+func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string, state *responseState) Handler {
 	if !requireAuth || f.options.AuthProvider == nil {
 		return h
 	}
@@ -359,6 +376,9 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string) Handl
 
 		err := authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 			*username, _ = authProvider.UsernameFromContext(ctx)
+
+			// The provider has decided by now, so pin the Cache-Control it chose.
+			state.pinCacheControl(w)
 
 			return h(ctx, w, r, p)
 		})(ctx, w, r, p)
@@ -397,6 +417,9 @@ func errString(err error) string {
 
 // MatchError matches the error and returns the appropriate HTTP status code and log level.
 // It also calls the callback with the message and code to write the response.
+//
+// enterrors.RespondedTag is the exception: no callback, and the status is a placeholder that
+// callers replace with the one on the response writer.
 func MatchError(err error, callback func(message string, code int)) (zapcore.Level, int) {
 	status := http.StatusOK
 	level := zap.InfoLevel
@@ -404,6 +427,8 @@ func MatchError(err error, callback func(message string, code int)) (zapcore.Lev
 	switch {
 	case err == nil:
 		// happy case
+	case xerrors.TagIs[enterrors.RespondedTag](err):
+		level = zap.WarnLevel
 	case xerrors.TagIs[enterrors.NotEnabledTag](err):
 		level = zap.WarnLevel
 		status = http.StatusPaymentRequired

--- a/internal/frontend/http/http_test.go
+++ b/internal/frontend/http/http_test.go
@@ -144,6 +144,16 @@ func TestMatchError(t *testing.T) {
 			callbackCode:   nethttp.StatusBadRequest,
 		},
 
+		{
+			// The handler already wrote its own response, so there is nothing to write and
+			// the status here is a placeholder: wrapHandler takes the real one off the writer.
+			name:           "handler already responded",
+			err:            xerrors.NewTagged[enterrors.RespondedTag](errors.New("redirected to login")),
+			expectedLevel:  zap.WarnLevel,
+			expectedStatus: nethttp.StatusOK,
+			expectCallback: false,
+		},
+
 		// --- context cancellation wrapping ---
 		{
 			name:           "wrapped context canceled",

--- a/internal/frontend/http/responsewriter.go
+++ b/internal/frontend/http/responsewriter.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/felixge/httpsnoop"
+)
+
+// responseState records what a handler actually sent, so the log and the audit record can
+// report the client's status instead of inferring it from the returned error.
+type responseState struct {
+	pinnedCacheControl string
+	status             int
+}
+
+// pinCacheControl fixes the current Cache-Control so a later handler cannot weaken a no-store.
+func (s *responseState) pinCacheControl(w http.ResponseWriter) {
+	s.pinnedCacheControl = strings.Join(w.Header().Values("Cache-Control"), ", ")
+}
+
+// applyCacheControlPin restores the pinned value over whatever a later handler set.
+func (s *responseState) applyCacheControlPin(w http.ResponseWriter) {
+	if s.pinnedCacheControl != "" {
+		w.Header().Set("Cache-Control", s.pinnedCacheControl)
+	}
+}
+
+// wrapResponseWriter wraps w to report into state, keeping w's exact interface set.
+func wrapResponseWriter(w http.ResponseWriter, state *responseState) http.ResponseWriter {
+	// Only the first response counts, which is the one net/http would keep.
+	commit := func(status int) {
+		if state.status != 0 {
+			return
+		}
+
+		state.status = status
+
+		state.applyCacheControlPin(w)
+	}
+
+	return httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(status int) {
+				// An informational 1xx precedes the real response, which is still to come.
+				if status >= 200 {
+					commit(status)
+				}
+
+				next(status)
+			}
+		},
+
+		// Also covers WriteString, which httpsnoop routes here.
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(b []byte) (int, error) {
+				commit(http.StatusOK)
+
+				return next(b)
+			}
+		},
+
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				commit(http.StatusOK)
+
+				return next(src)
+			}
+		},
+
+		// A flush commits the header, so settle the status and the pin first.
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+			return func() {
+				commit(http.StatusOK)
+				next()
+			}
+		},
+	})
+}

--- a/internal/frontend/http/responsewriter_internal_test.go
+++ b/internal/frontend/http/responsewriter_internal_test.go
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+)
+
+func TestWrapResponseWriterRecordsStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		write func(http.ResponseWriter)
+		name  string
+		want  int
+	}{
+		{
+			name:  "explicit status",
+			write: func(w http.ResponseWriter) { w.WriteHeader(http.StatusSeeOther) },
+			want:  http.StatusSeeOther,
+		},
+		{
+			name:  "body only",
+			write: func(w http.ResponseWriter) { w.Write([]byte("hi")) }, //nolint:errcheck // recorder
+			want:  http.StatusOK,
+		},
+		{
+			name: "second status ignored",
+			write: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusForbidden)
+				w.WriteHeader(http.StatusOK)
+			},
+			want: http.StatusForbidden,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var state responseState
+
+			rec := httptest.NewRecorder()
+
+			test.write(wrapResponseWriter(rec, &state))
+
+			require.Equal(t, test.want, state.status, "the status the log and audit record read")
+			require.Equal(t, test.want, rec.Code, "and what the client actually received")
+		})
+	}
+
+	// Only state.status is checked: httptest.ResponseRecorder latches the first WriteHeader
+	// either way, where a real response sends the 1xx and reads on.
+	t.Run("informational then final", func(t *testing.T) {
+		t.Parallel()
+
+		var state responseState
+
+		sw := wrapResponseWriter(httptest.NewRecorder(), &state)
+
+		sw.WriteHeader(http.StatusEarlyHints)
+		require.Zero(t, state.status, "the real response is still to come")
+
+		sw.WriteHeader(http.StatusNotFound)
+		require.Equal(t, http.StatusNotFound, state.status)
+	})
+}
+
+func TestWrapResponseWriterPinsCacheControl(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		handler  string
+		expected string
+		pinned   []string
+		flush    bool
+	}{
+		{
+			name:     "handler cannot weaken no-store",
+			pinned:   []string{"no-store"},
+			handler:  "public, max-age=31536000",
+			expected: "no-store",
+		},
+		{
+			name:     "nothing pinned",
+			handler:  "public, max-age=31536000",
+			expected: "public, max-age=31536000",
+		},
+		{
+			name:     "handler sets nothing",
+			pinned:   []string{"no-store"},
+			handler:  "",
+			expected: "no-store",
+		},
+		{
+			name:     "every field value is pinned",
+			pinned:   []string{"private", "no-store"},
+			handler:  "public, max-age=31536000",
+			expected: "private, no-store",
+		},
+		{
+			// A flush commits the header, so the pin has to be applied by then too.
+			name:     "flush before any status",
+			pinned:   []string{"no-store"},
+			handler:  "public, max-age=31536000",
+			expected: "no-store",
+			flush:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var state responseState
+
+			rec := httptest.NewRecorder()
+			sw := wrapResponseWriter(rec, &state)
+
+			for _, value := range test.pinned {
+				sw.Header().Add("Cache-Control", value)
+			}
+
+			state.pinCacheControl(sw)
+
+			if test.handler != "" {
+				sw.Header().Set("Cache-Control", test.handler)
+			}
+
+			if test.flush {
+				flusher, ok := sw.(http.Flusher)
+				require.True(t, ok)
+
+				flusher.Flush()
+			} else {
+				sw.WriteHeader(http.StatusOK)
+			}
+
+			require.Equal(t, test.expected, rec.Header().Get("Cache-Control"))
+		})
+	}
+}
+
+func TestWrapHandlerPinsCacheControlWhenHandlerNeverWrites(t *testing.T) {
+	t.Parallel()
+
+	f := &Frontend{
+		logger: zaptest.NewLogger(t),
+		options: Options{
+			AuthProvider: pinningAuthProvider{},
+		},
+	}
+
+	handler := f.wrapHandler(func(_ context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+		w.Header().Set("Cache-Control", "public, max-age=31536000")
+
+		return nil
+	}, true)
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), nil)
+
+	require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}
+
+// pinningAuthProvider stands in for a provider that sets a no-store before the handler runs.
+type pinningAuthProvider struct{}
+
+func (pinningAuthProvider) Run(context.Context) error { return nil }
+
+func (pinningAuthProvider) Middleware(next enterprise.Handler) enterprise.Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+		w.Header().Set("Cache-Control", "no-store")
+
+		return next(ctx, w, r, p)
+	}
+}
+
+func (pinningAuthProvider) UsernameFromContext(context.Context) (string, bool) { return "", false }
+
+func (pinningAuthProvider) ContextWithUsername(ctx context.Context, _ string) context.Context {
+	return ctx
+}
+
+func TestWrapResponseWriterForwardsReadFrom(t *testing.T) {
+	t.Parallel()
+
+	var state responseState
+
+	rec := &readerFromRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sw := wrapResponseWriter(rec, &state)
+
+	rf, ok := sw.(io.ReaderFrom)
+	require.True(t, ok, "the wrapper has to keep the underlying writer's ReadFrom")
+
+	n, err := rf.ReadFrom(strings.NewReader("payload"))
+	require.NoError(t, err)
+	require.EqualValues(t, len("payload"), n)
+
+	require.True(t, rec.called, "the streaming fast path has to reach the underlying writer")
+	require.Equal(t, http.StatusOK, state.status, "streaming a body still implies a 200")
+}
+
+func TestWrapResponseWriterKeepsInterfaceSet(t *testing.T) {
+	t.Parallel()
+
+	var state responseState
+
+	// httptest.ResponseRecorder flushes, but neither takes a reader nor hijacks.
+	rec := httptest.NewRecorder()
+	sw := wrapResponseWriter(rec, &state)
+
+	_, isReaderFrom := sw.(io.ReaderFrom)
+	require.False(t, isReaderFrom)
+
+	_, isHijacker := sw.(http.Hijacker)
+	require.False(t, isHijacker)
+
+	flusher, ok := sw.(http.Flusher)
+	require.True(t, ok)
+
+	flusher.Flush()
+	require.True(t, rec.Flushed, "artifact streaming through the registry proxy relies on this")
+
+	unwrapper, ok := sw.(interface{ Unwrap() http.ResponseWriter })
+	require.True(t, ok)
+	require.Same(t, rec, unwrapper.Unwrap(), "http.ResponseController has to reach past the wrapper")
+}
+
+// readerFromRecorder adds the ReadFrom that httptest.ResponseRecorder lacks.
+type readerFromRecorder struct {
+	*httptest.ResponseRecorder
+
+	called bool
+}
+
+func (r *readerFromRecorder) ReadFrom(src io.Reader) (int64, error) {
+	r.called = true
+
+	return io.Copy(r.Body, src)
+}

--- a/pkg/enterprise/errors/errors.go
+++ b/pkg/enterprise/errors/errors.go
@@ -14,3 +14,7 @@ type InvalidErrorTag struct{}
 
 // NotReadyTag tags errors that occur when an enterprise feature is.
 type NotReadyTag struct{}
+
+// RespondedTag tags an error from a handler that already wrote its own response: the status
+// comes off the writer, the error only carries the reason into the log.
+type RespondedTag struct{}


### PR DESCRIPTION
The request log and the audit record inferred the status from the error a handler
returned, so anything that answered for itself was recorded as a 200: redirects,
error pages, and every proxied registry response, including an upstream 404 or 500.
Wrap the response writer with felixge/httpsnoop and read the status off it instead.

Two more pieces land without callers, both for browser login. enterrors.RespondedTag
drops an already-answered error from error to warning level. The wrapper also pins the
Cache-Control the auth provider chose, on every path that commits the header, so a
later handler cannot weaken a no-store.