### PR TITLE
feat(enterprise): add auth0 browser login

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/siderolabs/image-factory/internal/remotewrap"
+	"github.com/siderolabs/image-factory/pkg/enterprise"
 )
 
 // Validate checks Options for inconsistencies that would otherwise produce
@@ -82,6 +84,18 @@ func (o AuthenticationOptions) validate() error {
 
 		if o.Auth0.Audience == "" {
 			return errors.New(`authentication.auth0.audience is required when authentication.provider is "auth0"`)
+		}
+
+		// Only the key's encoding is checked here; the provider validates the group.
+		if o.Auth0.SessionKey != "" {
+			key, err := o.Auth0.DecodedSessionKey()
+			if err != nil {
+				return fmt.Errorf("authentication.auth0.sessionKey must be base64-encoded: %w", err)
+			}
+
+			if len(key) != enterprise.Auth0SessionKeySize {
+				return fmt.Errorf("authentication.auth0.sessionKey must decode to %d bytes, got %d", enterprise.Auth0SessionKeySize, len(key))
+			}
 		}
 	default:
 		return fmt.Errorf("authentication.provider must be one of %v, got %q", authProviderOptions, o.Provider)
@@ -642,6 +656,9 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	// In Auth0 this means issuing tokens to organization-scoped clients; tokens without the claim are rejected.
 	//
 	// It is required when provider is "auth0", and ignored otherwise.
+	//
+	// Domain and audience alone validate bearer tokens.
+	// The browser-login fields are optional, and add the sign-in routes on top when set.
 	Auth0 Auth0Options `koanf:"auth0"`
 
 	// DownloadTokenKeyPath is an optional path to a PEM-encoded ECDSA P-256 private key for signing download tokens.
@@ -688,10 +705,40 @@ type Auth0Options struct {
 	// Optional; when empty every valid token has full access.
 	MachineScope string `koanf:"machineScope"`
 
-	// issuerURLOverride replaces the issuer URL constructed from Domain, for both the
-	// expected iss claim and the JWKS endpoint.
+	// ClientID is the Auth0 application Client ID used for the browser login flow.
+	//
+	// Optional; part of the browser-login group.
+	ClientID string `koanf:"clientID"`
+
+	// ClientSecret is the Auth0 application Client Secret.
+	// Inject via IF_AUTHENTICATION_AUTH0_CLIENTSECRET environment variable.
+	//
+	// Optional; part of the browser-login group.
+	ClientSecret string `koanf:"clientSecret"`
+
+	// SessionKey is the base64-encoded 32-byte AES-256 key used to encrypt session cookies.
+	// Inject via IF_AUTHENTICATION_AUTH0_SESSIONKEY environment variable.
+	// Generate one with `openssl rand -base64 32`.
+	// Surrounding whitespace is trimmed, so a file or mounted secret with a trailing newline works.
+	// All replicas must share the same key, since a session or in-progress login started
+	// on one replica has to be decrypted by whichever replica handles the next request.
+	//
+	// Optional; part of the browser-login group.
+	SessionKey string `koanf:"sessionKey"`
+
+	// issuerURLOverride replaces the issuer URL constructed from Domain, for the expected
+	// iss claim and for the JWKS, authorize and token endpoints.
 	// Unexported so koanf cannot reach it; see SetAuth0IssuerURL, built only under the integration tag.
 	issuerURLOverride string
+}
+
+// DecodedSessionKey returns the session key bytes, or nil when none is configured.
+func (o Auth0Options) DecodedSessionKey() ([]byte, error) {
+	if o.SessionKey == "" {
+		return nil, nil
+	}
+
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(o.SessionKey))
 }
 
 // EnterpriseOptions contains configuration for enterprise-specific features.

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -5,6 +5,7 @@
 package cmd_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"testing"
@@ -14,6 +15,24 @@ import (
 
 	"github.com/siderolabs/image-factory/cmd/image-factory/cmd"
 )
+
+// auth0OptsWithSessionKey is an otherwise valid auth0 configuration, so the session key is
+// the only thing under test.
+func auth0OptsWithSessionKey(sessionKey string) cmd.Options {
+	return cmd.Options{
+		HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+		Authentication: cmd.AuthenticationOptions{
+			Enabled:          true,
+			Provider:         "auth0",
+			DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
+			Auth0: cmd.Auth0Options{
+				Domain:     "tenant.auth0.com",
+				Audience:   "https://factory.sidero.dev",
+				SessionKey: sessionKey,
+			},
+		},
+	}
+}
 
 func TestOCIRepositoryOptions(t *testing.T) {
 	t.Parallel()
@@ -379,6 +398,26 @@ func TestOptionsValidate(t *testing.T) {
 				Authentication: cmd.AuthenticationOptions{Enabled: true, Provider: "htpasswd"},
 			},
 			expectError: "authentication.htpasswdPath is required",
+		},
+		{
+			name:        "session key that is not base64",
+			opts:        auth0OptsWithSessionKey("not!base64"),
+			expectError: "authentication.auth0.sessionKey must be base64-encoded",
+		},
+		{
+			// A 16-byte key decodes fine but is AES-128, which the provider rejects later.
+			name:        "session key of the wrong length",
+			opts:        auth0OptsWithSessionKey(base64.StdEncoding.EncodeToString(make([]byte, 16))),
+			expectError: "authentication.auth0.sessionKey must decode to 32 bytes, got 16",
+		},
+		{
+			// A mounted secret or `openssl rand -base64 32` carries a trailing newline.
+			name: "session key with surrounding whitespace",
+			opts: auth0OptsWithSessionKey("  " + base64.StdEncoding.EncodeToString(make([]byte, 32)) + "\n"),
+		},
+		{
+			name: "no session key at all is the bearer-token-only setup",
+			opts: auth0OptsWithSessionKey(""),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -223,10 +223,20 @@ func buildAuthProvider(ctx context.Context, logger *zap.Logger, opts Options) (e
 
 	switch opts.Authentication.Provider {
 	case AuthProviderAuth0:
+		// Options.Validate has already rejected an undecodable or wrong-length key.
+		sessionKey, decodeErr := opts.Authentication.Auth0.DecodedSessionKey()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("auth0: session key must be base64-encoded: %w", decodeErr)
+		}
+
 		authProvider, err = enterprise.NewAuth0Provider(ctx, logger, enterprise.Auth0Config{
 			Domain:            opts.Authentication.Auth0.Domain,
 			Audience:          opts.Authentication.Auth0.Audience,
 			MachineScope:      opts.Authentication.Auth0.MachineScope,
+			ClientID:          opts.Authentication.Auth0.ClientID,
+			ClientSecret:      opts.Authentication.Auth0.ClientSecret,
+			ExternalURL:       opts.HTTP.ExternalURL,
+			SessionKey:        sessionKey,
 			IssuerURLOverride: opts.Authentication.Auth0.issuerURLOverride,
 		})
 	case AuthProviderHTPasswd:

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,9 @@ When it is off, every registered endpoint in this reference is public, except th
 When it is on, each endpoint below carries an **Access** table with these four fields; endpoints that never take a credential are marked `Access: public` instead.
 See [Authentication](authentication.md) for the providers, the token formats and the scopes.
 
+With [browser login](authentication.md#browser-login) configured, every endpoint below also accepts the session cookie, and a browser navigation without a credential is redirected to `/login` rather than answered `401`.
+A client that does not ask for `text/html` gets the `401` described here.
+
 | Field             | Values                                                                                                                                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Auth**          | `public` takes no credential, `required` takes an [`Authorization` header](authentication.md#the-authorization-header) for the configured provider, and a missing or invalid credential is `401`. |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -33,8 +33,9 @@ Details that decide whether a request authenticates:
   With `htpasswd`, the response carries one `WWW-Authenticate: Basic` challenge.
   With `auth0`, it carries separate Basic and Bearer challenges, in that order.
   The Auth0 order is deliberate: OCI clients take the first scheme they recognize, and only the Basic form carries a usable token for those clients.
+  With [browser login](#browser-login) configured, a page navigation is sent to `/login` with a `303` instead, and an XHR gets the `401` with no challenge on it.
 
-The one alternative to this header is the [`?token=` query parameter](#the-token-query-parameter), accepted on image downloads only.
+There are two alternatives to this header: the [`?token=` query parameter](#the-token-query-parameter), accepted on image downloads only, and the session cookie [browser login](#browser-login) issues.
 
 ## htpasswd
 
@@ -51,8 +52,8 @@ Tokens without the claim are rejected, since there would be no principal to attr
 
 Tokens are accepted either as `Authorization: Bearer <token>` or in the password field of a Basic credential; see [The `Authorization` header](#the-authorization-header).
 
-There is no interactive login.
-A browser hitting an authenticated route gets a `401` with a Basic challenge, not a redirect to Auth0, so a person presents a token the same way a machine does.
+Interactive login is opt-in; see [Browser login](#browser-login).
+Until it is configured, a browser hitting an authenticated route gets a `401` with a Basic challenge, not a redirect to Auth0, so a person presents a token the same way a machine does.
 
 ### Obtaining a token
 
@@ -86,6 +87,38 @@ Because validation is offline (see [Revocation](#revocation)), the token's Auth0
 
 A machine-scoped token also cannot mint a [download token](#download-tokens), since `POST /download-token` is not an artifact fetch.
 A deployment that both provisions nodes and hands out download links needs two clients: one carrying the machine scope, one without it.
+
+### Browser login
+
+Without it, a person opening the factory in a browser gets a `401` and nothing else.
+Enabling it redirects them to the tenant's login page instead, using an OAuth2 authorization code flow with PKCE.
+
+It is opt-in: set `clientID`, `clientSecret` and `sessionKey` together, or leave all three empty.
+A partial set is rejected at startup rather than half-enabling the flow.
+Bearer token authentication is unaffected either way.
+
+One thing must be set up in the Auth0 tenant, which the factory cannot do for you: add `<http.externalURL>/callback` to the application's **Allowed Callback URLs**, and `http.externalURL` itself to its **Allowed Logout URLs**.
+Auth0 rejects the round trip outright otherwise.
+Both are derived from `http.externalURL`; the callback route is always `/callback` and is not configurable.
+
+A session lasts as long as the access token it was established with, whose lifetime is set on the API in the tenant.
+There are no refresh tokens: `offline_access` is not requested, so nothing renews a session in place.
+When the access token expires, the next page load is sent back through `/login`, and the tenant's own SSO session normally answers it without the person entering anything.
+The visible cost is that one navigation; an in-flight background request that lands on the expiry is redirected instead of completing, so the action is retried.
+Raise the API's token lifetime to make this rarer.
+
+`sessionKey` is a 32-byte AES-256 key, base64-encoded, injected through `IF_AUTHENTICATION_AUTH0_SESSIONKEY`.
+Generate one with `openssl rand -base64 32`; surrounding whitespace is trimmed, so a value read from a file or a mounted secret works as-is.
+Session cookies are encrypted with it, so every replica must be given the same one: a cookie issued by one replica is read by another.
+Changing it signs everyone out.
+
+Session cookies are `SameSite=Lax`, which is what stops a cross-site form from making a mutating request with the visitor's session.
+There is no separate CSRF token, so relaxing that attribute — to `None` for iframe embedding, say — would need one adding first.
+
+Responses authenticated by a session cookie are sent with `Cache-Control: no-store` and `Vary: Cookie`, since a shared cache that stored one would serve a visitor's session to whoever asked next.
+
+Sessions are held in an encrypted cookie rather than server-side, which is what lets any replica serve any request without shared session storage.
+The cookie is capped at the 4096 bytes browsers accept; a tenant configured to emit very large access tokens (a long `permissions` array, typically) can exceed it, which is reported at login rather than failing silently.
 
 ### Migrating from htpasswd
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -893,6 +893,9 @@ In Auth0 this means issuing tokens to organization-scoped clients; tokens withou
 
 It is required when provider is "auth0", and ignored otherwise.
 
+Domain and audience alone validate bearer tokens.
+The browser-login fields are optional, and add the sign-in routes on top when set.
+
 ---
 
 ### `authentication.auth0.domain`
@@ -929,6 +932,45 @@ Everything else is rejected with 403, including reading schematic definitions.
 Intended for the long-lived tokens provisioned onto Talos nodes, which need to pull installers but should not be able to inspect or create schematics.
 
 Optional; when empty every valid token has full access.
+
+---
+
+### `authentication.auth0.clientID`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_CLIENTID`
+
+ClientID is the Auth0 application Client ID used for the browser login flow.
+
+Optional; part of the browser-login group.
+
+---
+
+### `authentication.auth0.clientSecret`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_CLIENTSECRET`
+
+ClientSecret is the Auth0 application Client Secret.
+Inject via IF_AUTHENTICATION_AUTH0_CLIENTSECRET environment variable.
+
+Optional; part of the browser-login group.
+
+---
+
+### `authentication.auth0.sessionKey`
+
+- **Type:** `string`
+- **Env:** `AUTHENTICATION_AUTH0_SESSIONKEY`
+
+SessionKey is the base64-encoded 32-byte AES-256 key used to encrypt session cookies.
+Inject via IF_AUTHENTICATION_AUTH0_SESSIONKEY environment variable.
+Generate one with `openssl rand -base64 32`.
+Surrounding whitespace is trimmed, so a file or mounted secret with a trailing newline works.
+All replicas must share the same key, since a session or in-progress login started
+on one replica has to be decrypted by whichever replica handles the next request.
+
+Optional; part of the browser-login group.
 
 ---
 
@@ -1331,8 +1373,11 @@ audit:
 authentication:
     auth0:
         audience: ""
+        clientID: ""
+        clientSecret: ""
         domain: ""
         machineScope: ""
+        sessionKey: ""
     downloadTokenKeyPath: ""
     downloadTokenTTL:
         default: 5m0s
@@ -1471,8 +1516,11 @@ IF_AUDIT_FILE_MAXSIZEMB=256
 IF_AUDIT_FILE_PATH=
 IF_AUDIT_MODE=
 IF_AUTHENTICATION_AUTH0_AUDIENCE=
+IF_AUTHENTICATION_AUTH0_CLIENTID=
+IF_AUTHENTICATION_AUTH0_CLIENTSECRET=
 IF_AUTHENTICATION_AUTH0_DOMAIN=
 IF_AUTHENTICATION_AUTH0_MACHINESCOPE=
+IF_AUTHENTICATION_AUTH0_SESSIONKEY=
 IF_AUTHENTICATION_DOWNLOADTOKENKEYPATH=
 IF_AUTHENTICATION_DOWNLOADTOKENTTL_DEFAULT=5m0s
 IF_AUTHENTICATION_DOWNLOADTOKENTTL_MAX=8h0m0s

--- a/enterprise/auth/auth0/browser.go
+++ b/enterprise/auth/auth0/browser.go
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// OAuth2 authorization code + PKCE browser login: the /login, callback and /logout routes.
+
+package auth0
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+
+	"github.com/siderolabs/image-factory/internal/ctxlog"
+	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
+)
+
+// callbackPath is the route Auth0 redirects back to, appended to externalURL.
+const callbackPath = "/callback"
+
+// browserLogin holds the authorization code + PKCE flow's state; nil for bearer-only.
+type browserLogin struct { //nolint:govet // keeping order for semantic clarity
+	oauth2     *oauth2.Config
+	idVerifier *oidc.IDTokenVerifier // ID tokens from the browser flow
+	cipher     cipher.AEAD
+
+	tenantLogoutURL string // the tenant's /v2/logout, client_id and returnTo already set
+
+	secure bool // externalURL is https, so cookies can carry Secure
+}
+
+// browserLoginRequested reports whether the browser login settings are present, rejecting a
+// partial set.
+func (cfg Config) browserLoginRequested() (bool, error) {
+	fields := []struct {
+		name    string
+		present bool
+	}{
+		{"clientID", cfg.ClientID != ""},
+		{"clientSecret", cfg.ClientSecret != ""},
+		{"sessionKey", len(cfg.SessionKey) > 0},
+	}
+
+	var missing []string
+
+	for _, field := range fields {
+		if !field.present {
+			missing = append(missing, field.name)
+		}
+	}
+
+	// All three or none.
+	switch len(missing) {
+	case 0:
+		return true, nil
+	case len(fields):
+		return false, nil
+	default:
+		return false, fmt.Errorf(
+			"auth0: browser login requires clientID, clientSecret and sessionKey together (missing: %s); "+
+				"omit all three to serve machine-to-machine bearer tokens only",
+			strings.Join(missing, ", "),
+		)
+	}
+}
+
+func newBrowserLogin(issuer string, keySet oidc.KeySet, tenantURL *url.URL, cfg Config) (*browserLogin, error) {
+	if len(cfg.SessionKey) != sessionKeySize {
+		return nil, fmt.Errorf("auth0: session key must be exactly %d bytes (got %d)", sessionKeySize, len(cfg.SessionKey))
+	}
+
+	// Auth0 only honors an absolute, allow-listed logout returnTo.
+	externalURL, err := url.Parse(cfg.ExternalURL)
+	if err != nil || externalURL.Scheme == "" || externalURL.Host == "" {
+		return nil, fmt.Errorf("auth0: externalURL must be absolute when browser login is enabled (got %q)", cfg.ExternalURL)
+	}
+
+	block, err := aes.NewCipher(cfg.SessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("auth0: failed to create AES cipher: %w", err)
+	}
+
+	tenantLogoutURL := *tenantURL.JoinPath("/v2/logout")
+	tenantLogoutURL.RawQuery = url.Values{
+		"client_id": {cfg.ClientID},
+		"returnTo":  {cfg.ExternalURL},
+	}.Encode()
+
+	b := &browserLogin{
+		idVerifier:      newVerifier(issuer, keySet, cfg.ClientID),
+		tenantLogoutURL: tenantLogoutURL.String(),
+		// url.Parse lowercases the scheme, so this also matches an "HTTPS://" externalURL.
+		secure: externalURL.Scheme == "https",
+	}
+
+	// Random-nonce GCM prepends the nonce to the ciphertext.
+	if b.cipher, err = cipher.NewGCMWithRandomNonce(block); err != nil {
+		return nil, fmt.Errorf("auth0: failed to create GCM cipher: %w", err)
+	}
+
+	b.oauth2 = &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		// The callback is a route on this factory, so its public URL is the factory's own.
+		RedirectURL: externalURL.JoinPath(callbackPath).String(),
+		Scopes:      []string{oidc.ScopeOpenID},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  tenantURL.JoinPath("/authorize").String(),
+			TokenURL: tenantURL.JoinPath("/oauth/token").String(),
+			// Auth0 takes the client credentials in the form body; saying so avoids
+			// the probe request x/oauth2 otherwise makes to find out.
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	return b, nil
+}
+
+// BrowserLoginEnabled reports whether the browser login flow is configured.
+func (p *Provider) BrowserLoginEnabled() bool {
+	return p.browser != nil
+}
+
+// CallbackPath returns the route Auth0 redirects to, which the frontend registers.
+func (p *Provider) CallbackPath() string {
+	return callbackPath
+}
+
+// LoginHandler returns the handler for GET /login.
+func (p *Provider) LoginHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
+		logger := ctxlog.Logger(ctx, p.logger)
+
+		query := r.URL.Query()
+		returnTo := safeReturnTo(query.Get("return_to"))
+
+		// GenerateVerifier is 32 random base64url bytes, which suits all three despite the
+		// PKCE name. State is the CSRF check, nonce binds the ID token to this flow.
+		state := oauth2.GenerateVerifier()
+		nonce := oauth2.GenerateVerifier()
+		codeVerifier := oauth2.GenerateVerifier()
+
+		sc := stateCookie{State: state, CodeVerifier: codeVerifier, Nonce: nonce, ReturnTo: returnTo}
+		if err := setStateCookie(w, sc, p.browser.cipher, p.cookiesSecure(r)); err != nil {
+			return fmt.Errorf("auth0: set state cookie: %w", err)
+		}
+
+		opts := []oauth2.AuthCodeOption{
+			oauth2.S256ChallengeOption(codeVerifier),
+			oidc.Nonce(nonce),
+			// Without an audience Auth0 issues an opaque access token instead of a JWT.
+			oauth2.SetAuthURLParam("audience", p.audience),
+		}
+
+		// Pre-selecting an Organization makes Auth0 skip its own picker.
+		org := query.Get("org")
+		if org != "" {
+			opts = append(opts, oauth2.SetAuthURLParam("organization", org))
+		}
+
+		logger.Debug(
+			"auth0: initiating browser login",
+			zap.String("return_to", returnTo),
+			zap.Bool("org_pre_selected", org != ""),
+		)
+
+		http.Redirect(w, r, p.browser.oauth2.AuthCodeURL(state, opts...), http.StatusFound)
+
+		return nil
+	}
+}
+
+// CallbackHandler returns the handler for the callback route. Failures log at debug: the
+// route is public, so an unauthenticated caller controls how often they fire.
+func (p *Provider) CallbackHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
+		logger := ctxlog.Logger(ctx, p.logger)
+		query := r.URL.Query()
+
+		// A callback with no live state is retried through /login; anything Auth0 already
+		// answered gets an error page, since retrying produces the same answer.
+		sc, err := readStateCookie(r, p.browser.cipher)
+		if err != nil {
+			logger.Debug("auth0: unusable state cookie", zap.Error(err))
+
+			if p.loginTerminal(r, err) {
+				return p.loginFailed(w, "Your browser did not keep the sign-in cookie. Check that cookies are enabled for this site.")
+			}
+
+			http.Redirect(w, r, loginURL(""), http.StatusFound)
+
+			return nil
+		}
+
+		// Aged out rather than unreadable, so return_to is still good to come back to.
+		if sc.expired() {
+			logger.Debug("auth0: login attempt expired", zap.Time("issued_at", sc.IssuedAt))
+			http.Redirect(w, r, loginURL(sc.ReturnTo), http.StatusFound)
+
+			return nil
+		}
+
+		// CSRF: state must match. The cookie is left alone on a mismatch, so a callback
+		// landing late from another tab does not take out the login in progress.
+		if query.Get("state") != sc.State {
+			logger.Debug("auth0: state mismatch in callback")
+			http.Redirect(w, r, loginURL(sc.ReturnTo), http.StatusFound)
+
+			return nil
+		}
+
+		// Single use from here: the verifier has been matched to this callback.
+		clearStateCookie(w, p.cookiesSecure(r))
+
+		// Auth0 reports errors via query params (e.g. user denied consent).
+		if errCode := truncate(query.Get("error"), maxErrCodeLen); errCode != "" {
+			logger.Debug(
+				"auth0: callback error from Auth0",
+				zap.String("error", errCode),
+				zap.String("description", truncate(query.Get("error_description"), maxErrDescriptionLen)),
+			)
+
+			return p.loginFailed(w, "The identity provider rejected the sign-in request ("+errCode+").")
+		}
+
+		payload, err := p.exchange(ctx, query.Get("code"), sc)
+		if err != nil {
+			logger.Debug("auth0: code exchange failed", zap.Error(err))
+
+			return p.loginFailed(w, "Your account could not be signed in to this factory.")
+		}
+
+		if err = setSessionCookie(w, payload, p.browser.cipher, p.cookiesSecure(r)); err != nil {
+			return fmt.Errorf("auth0: set session cookie: %w", err)
+		}
+
+		logger.Debug("auth0: browser login successful", zap.String("return_to", sc.ReturnTo))
+
+		http.Redirect(w, r, sc.ReturnTo, http.StatusFound)
+
+		return nil
+	}
+}
+
+// loginTerminal reports whether a callback with no usable state is beyond repair by /login.
+// A state cookie that arrived at all proves the browser keeps them; so does a live session.
+// One that never arrived alongside a code proves the opposite, and /login would only lose it again.
+func (p *Provider) loginTerminal(r *http.Request, readErr error) bool {
+	if !errors.Is(readErr, http.ErrNoCookie) || !r.URL.Query().Has("code") {
+		return false
+	}
+
+	_, err := readSessionPayload(r, p.browser.cipher)
+
+	return err != nil
+}
+
+// truncate bounds attacker-influenced text before it reaches a log line or an error page.
+// Cut on runes: slicing bytes can split one and put invalid UTF-8 in both.
+func truncate(s string, limit int) string {
+	runes := []rune(strings.ToValidUTF8(s, ""))
+	if len(runes) <= limit {
+		return string(runes)
+	}
+
+	return string(runes[:limit]) + "…"
+}
+
+// exchange trades the authorization code for a token set this factory accepts.
+func (p *Provider) exchange(ctx context.Context, code string, sc stateCookie) (sessionPayload, error) {
+	ctx, cancel := context.WithTimeout(ctx, tokenExchangeTimeout)
+	defer cancel()
+
+	token, err := p.browser.oauth2.Exchange(ctx, code, oauth2.VerifierOption(sc.CodeVerifier))
+	if err != nil {
+		return sessionPayload{}, err
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return sessionPayload{}, errors.New("auth0: no id_token in token response")
+	}
+
+	idToken, err := p.browser.idVerifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return sessionPayload{}, fmt.Errorf("auth0: id token: %w", err)
+	}
+
+	// Binds the ID token to the /login that started this flow.
+	if idToken.Nonce != sc.Nonce {
+		return sessionPayload{}, errors.New("auth0: id token nonce mismatch")
+	}
+
+	if _, err = p.validateToken(ctx, token.AccessToken); err != nil {
+		return sessionPayload{}, err
+	}
+
+	// A missing expiry would date the cookie in the past and have the browser drop it.
+	if token.Expiry.IsZero() {
+		return sessionPayload{}, errors.New("auth0: token response has no expiry")
+	}
+
+	return sessionPayload{AccessToken: token.AccessToken, Expiry: token.Expiry}, nil
+}
+
+// loginErrorPage is rendered for failures that would recur: Auth0's own SSO session
+// turns a bounce through /login into a redirect loop.
+//
+// TODO: this and logoutPage bypass internal/frontend/http/templates and getLocalizer, so
+// they are unstyled and English-only where every other user-facing page is neither.
+var loginErrorPage = template.Must(template.New("login-error").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Sign-in failed</title></head>
+<body>
+<h1>Sign-in failed</h1>
+<p>{{.}}</p>
+<p><a href="/logout">Sign out</a> to try again as a different user.</p>
+</body>
+</html>
+`))
+
+// loginFailed renders reason as a terminal error page, tagged so it is logged as a 403.
+func (p *Provider) loginFailed(w http.ResponseWriter, reason string) error {
+	if err := writeHTML(w, http.StatusForbidden, loginErrorPage, reason); err != nil {
+		return err
+	}
+
+	return xerrors.NewTagged[enterrors.RespondedTag](errors.New(reason))
+}
+
+// writeHTML renders page into a buffer first, so a template failure becomes an error
+// rather than a half-written response.
+func writeHTML(w http.ResponseWriter, status int, page *template.Template, data any) error {
+	var buf bytes.Buffer
+
+	if err := page.Execute(&buf, data); err != nil {
+		return fmt.Errorf("auth0: render %s: %w", page.Name(), err)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+
+	_, err := buf.WriteTo(w)
+
+	return err
+}
+
+// loginURL builds the /login target, carrying return_to so a failed attempt does not drop
+// the user at the root.
+func loginURL(returnTo string) string {
+	if safe := safeReturnTo(returnTo); safe != "/" {
+		return "/login?return_to=" + url.QueryEscape(safe)
+	}
+
+	return "/login"
+}
+
+// logoutPage confirms a sign-out. The POST it submits is what actually logs the user
+// out, so an <img src="/logout"> or a link prefetcher cannot do it for them.
+var logoutPage = template.Must(template.New("logout").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Sign out</title></head>
+<body>
+<h1>Sign out</h1>
+<form method="POST" action="/logout"><button type="submit">Sign out</button></form>
+</body>
+</html>
+`))
+
+// LogoutHandler returns the handler for /logout. Only POST logs out; the Auth0 hand-off is
+// what drops the SSO session.
+func (p *Provider) LogoutHandler() Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
+		if r.Method != http.MethodPost {
+			return writeHTML(w, http.StatusOK, logoutPage, nil)
+		}
+
+		// SameSite does not help here: this handler needs none of our cookies. An absent
+		// header means an older browser, where the interstitial is the only guard.
+		if site := r.Header.Get("Sec-Fetch-Site"); site != "" && site != "same-origin" {
+			ctxlog.Logger(ctx, p.logger).Warn("auth0: cross-origin logout rejected", zap.String("sec_fetch_site", site))
+
+			if err := writeHTML(w, http.StatusForbidden, logoutPage, nil); err != nil {
+				return err
+			}
+
+			return xerrors.NewTagged[enterrors.RespondedTag](errors.New("logout must be submitted from the factory itself"))
+		}
+
+		secure := p.cookiesSecure(r)
+
+		clearSessionCookie(w, secure)
+
+		// A login abandoned midway would otherwise keep its state cookie until it expires.
+		clearStateCookie(w, secure)
+
+		// See Other so the browser follows with a GET rather than replaying the POST.
+		http.Redirect(w, r, p.browser.tenantLogoutURL, http.StatusSeeOther)
+
+		return nil
+	}
+}
+
+// safeReturnTo clamps the caller-supplied ?return_to= to a site-relative path, so a crafted
+// /login link cannot bounce the user off-site. "//" is protocol-relative, so it is rejected too.
+func safeReturnTo(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "/"
+	}
+
+	// Empty for schemes with no path, such as "javascript:alert(1)".
+	local := (&url.URL{Path: u.Path, RawQuery: u.RawQuery, Fragment: u.Fragment}).String()
+
+	if !strings.HasPrefix(local, "/") || strings.HasPrefix(local, "//") {
+		return "/"
+	}
+
+	return local
+}
+
+// cookiesSecure treats the externalURL scheme as the floor, since a proxy terminating TLS
+// does not necessarily set X-Forwarded-Proto.
+func (p *Provider) cookiesSecure(r *http.Request) bool {
+	return p.browser.secure || r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+}

--- a/enterprise/auth/auth0/browser_test.go
+++ b/enterprise/auth/auth0/browser_test.go
@@ -1,0 +1,631 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth0_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/image-factory/enterprise/auth/auth0"
+	"github.com/siderolabs/image-factory/internal/testoidc"
+	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
+)
+
+const (
+	testClientID     = "test-client-id"
+	testClientSecret = "test-client-secret"
+	testCallbackURL  = "https://factory.example.com/callback"
+	testExternalURL  = "https://factory.example.com"
+)
+
+// browserProvider is a provider with the browser login flow enabled, bundled with
+// the issuer it was built against so tests can assert on the URLs it emits.
+type browserProvider struct {
+	*auth0.Provider
+
+	issuer *url.URL
+	key    *rsa.PrivateKey
+}
+
+// validAccessToken mints a token this provider accepts, for the paths that need a
+// request to authenticate rather than to be turned away.
+func (bp browserProvider) validAccessToken(t *testing.T) string {
+	t.Helper()
+
+	return signToken(t, bp.key, bp.issuer.String(), testAudience, testOrgID, time.Now().Add(time.Hour))
+}
+
+// setupBrowserProvider points a browser-login provider at an in-process OIDC server that
+// serves discovery and JWKS only, so a code exchange against it 404s.
+func setupBrowserProvider(t *testing.T) browserProvider {
+	t.Helper()
+
+	return newBrowserProvider(t, nil)
+}
+
+// newBrowserProvider builds a browser-login provider against an in-process OIDC server
+// serving routes on top of the key set, for the tests that need /oauth/token to answer.
+func newBrowserProvider(t *testing.T, routes map[string]http.HandlerFunc) browserProvider {
+	t.Helper()
+
+	key := testoidc.GenerateKey()
+	issuerURL := testoidc.StartServerWithRoutes(t, key, testKeyID, routes)
+
+	issuer, err := url.Parse(issuerURL)
+	require.NoError(t, err)
+
+	// No test here depends on the key being random, only on it being the right length.
+	sessionKey := make([]byte, 32)
+
+	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
+		Domain:            testDomain,
+		Audience:          testAudience,
+		ClientID:          testClientID,
+		ClientSecret:      testClientSecret,
+		ExternalURL:       testExternalURL,
+		SessionKey:        sessionKey,
+		IssuerURLOverride: issuerURL,
+	})
+	require.NoError(t, err)
+	require.True(t, p.BrowserLoginEnabled())
+
+	return browserProvider{Provider: p, issuer: issuer, key: key}
+}
+
+// login runs LoginHandler against target and returns the query parameters of
+// the resulting Auth0 authorize URL together with the state cookie it set.
+func (bp browserProvider) login(t *testing.T, target string) (url.Values, *http.Cookie) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+
+	require.NoError(t, bp.LoginHandler()(t.Context(), rec, req, nil))
+	require.Equal(t, http.StatusFound, rec.Code)
+
+	location, err := url.Parse(rec.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, bp.issuer.Host, location.Host)
+	require.Equal(t, "/authorize", location.Path)
+
+	stateCookie := auth0.FindCookie(rec, "if_auth_state")
+	require.NotNil(t, stateCookie, "login must leave the PKCE state behind for the callback")
+
+	return location.Query(), stateCookie
+}
+
+// TestLoginHandlerAuthorizeRequest pins the authorize URL parameters, each of which degrades
+// the flow silently when lost: PKCE, the ID token binding, and a JWT rather than an opaque token.
+func TestLoginHandlerAuthorizeRequest(t *testing.T) {
+	t.Parallel()
+
+	q, _ := setupBrowserProvider(t).login(t, "/login")
+
+	require.Equal(t, "code", q.Get("response_type"))
+	require.Equal(t, testClientID, q.Get("client_id"))
+	require.Equal(t, testCallbackURL, q.Get("redirect_uri"))
+	require.Equal(t, testAudience, q.Get("audience"))
+	require.Equal(t, "S256", q.Get("code_challenge_method"))
+	require.NotEmpty(t, q.Get("code_challenge"))
+	require.NotEmpty(t, q.Get("state"))
+	require.NotEmpty(t, q.Get("nonce"))
+
+	// offline_access is absent: nothing renews a session.
+	require.Equal(t, []string{"openid"}, strings.Fields(q.Get("scope")))
+	require.NotContains(t, q.Get("code_challenge"), "=", "challenge must be raw base64url")
+	require.Empty(t, q.Get("organization"), "no ?org= was supplied")
+}
+
+// TestLoginHandlerStateIsPerRequest guards against the state and nonce being derived
+// from anything stable, which would defeat the CSRF and ID token replay checks.
+func TestLoginHandlerStateIsPerRequest(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	first, firstCookie := p.login(t, "/login")
+	second, secondCookie := p.login(t, "/login")
+
+	require.NotEqual(t, first.Get("state"), second.Get("state"))
+	require.NotEqual(t, first.Get("nonce"), second.Get("nonce"))
+	require.NotEqual(t, first.Get("code_challenge"), second.Get("code_challenge"))
+	require.NotEqual(t, firstCookie.Value, secondCookie.Value)
+}
+
+func TestLoginHandlerStateCookie(t *testing.T) {
+	t.Parallel()
+
+	_, cookie := setupBrowserProvider(t).login(t, "/login")
+
+	require.Equal(t, "/callback", cookie.Path, "state cookie is scoped to the callback route")
+	require.True(t, cookie.HttpOnly)
+	require.Equal(t, http.SameSiteLaxMode, cookie.SameSite,
+		"Lax still allows the top-level GET Auth0 redirects back with")
+	require.Positive(t, cookie.MaxAge)
+}
+
+// TestLoginHandlerForwardsOrg covers Omni linking straight into one Auth0
+// organization, skipping Auth0's own org picker.
+func TestLoginHandlerForwardsOrg(t *testing.T) {
+	t.Parallel()
+
+	q, _ := setupBrowserProvider(t).login(t, "/login?org=org_abc123")
+
+	require.Equal(t, "org_abc123", q.Get("organization"))
+}
+
+// TestLoginHandlerRejectsForeignReturnTo checks the open redirect guard is wired into the
+// handler. The state cookie is encrypted, so a failed callback is the only way to read it back.
+func TestLoginHandlerRejectsForeignReturnTo(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	for _, target := range []string{
+		"/login?return_to=" + url.QueryEscape("https://evil.example/steal"),
+		"/login?return_to=" + url.QueryEscape("//evil.example/steal"),
+	} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			_, cookie := p.login(t, target)
+
+			location := p.failCallback(t, "/callback?code=some-code&state=mismatch", cookie)
+			require.Equal(t, "/steal", location.Query().Get("return_to"),
+				"the host must be stripped before the return_to is stored")
+		})
+	}
+}
+
+// failCallback runs a callback expected to send the user back to /login, and returns
+// where to.
+func (bp browserProvider) failCallback(t *testing.T, target string, cookie *http.Cookie) *url.URL {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+
+	require.NoError(t, bp.CallbackHandler()(t.Context(), rec, req, nil), "a retryable login failure is not an error")
+	require.Equal(t, http.StatusFound, rec.Code)
+
+	requireNoSession(t, rec)
+
+	location, err := url.Parse(rec.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "/login", location.Path)
+
+	return location
+}
+
+// TestCallbackHandlerRetryableFailuresRedirectToLogin covers the callbacks that are
+// not part of a live login flow. /login mints fresh state, so these are worth retrying.
+func TestCallbackHandlerRetryableFailuresRedirectToLogin(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	_, validCookie := p.login(t, "/login")
+
+	const imagePath = "/image/abc/v1.12.0/metal-amd64.iso"
+
+	_, returnToCookie := p.login(t, "/login?return_to="+url.QueryEscape(imagePath))
+
+	signedInCookie, err := p.IssueSessionCookie("access-token")
+	require.NoError(t, err)
+
+	expiredCookie, err := p.ExpiredStateCookie("stale", imagePath)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		cookie *http.Cookie
+		name   string
+		target string
+		// returnTo is what the /login redirect must carry; empty means it must gain none.
+		returnTo string
+	}{
+		{
+			name:   "stray callback",
+			target: "/callback",
+		},
+		{
+			// The cookie came back, so the browser does keep cookies; only its contents
+			// are useless. Starting over mints one this build can read.
+			name:   "undecryptable state cookie",
+			target: "/callback?code=some-code&state=whatever",
+			cookie: &http.Cookie{Name: "if_auth_state", Value: "not-a-valid-cookie"},
+		},
+		{
+			name:   "state mismatch",
+			target: "/callback?code=some-code&state=attacker-supplied",
+			cookie: validCookie,
+		},
+		{
+			// Another tab finished the login and consumed the shared state cookie. The
+			// session proves cookies work, so starting over will succeed.
+			name:   "state cookie already spent but signed in",
+			target: "/callback?code=some-code&state=whatever",
+			cookie: signedInCookie,
+		},
+		{
+			// Past stateMaxAge only the age check rejected it, so it still knows
+			// where the user was headed.
+			name:     "expired state cookie",
+			target:   "/callback?code=some-code&state=stale",
+			cookie:   expiredCookie,
+			returnTo: imagePath,
+		},
+		{
+			name:     "state mismatch keeps return_to",
+			target:   "/callback?code=some-code&state=mismatch",
+			cookie:   returnToCookie,
+			returnTo: imagePath,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			location := p.failCallback(t, tc.target, tc.cookie)
+			require.Equal(t, tc.returnTo, location.Query().Get("return_to"))
+		})
+	}
+}
+
+// TestCallbackHandlerStateMismatchKeepsCookie pins that a wrong-state callback leaves the
+// cookie alone; clearing it would cancel the login actually in progress.
+func TestCallbackHandlerStateMismatchKeepsCookie(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	_, cookie := p.login(t, "/login")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/callback?code=some-code&state=wrong", nil)
+	req.AddCookie(cookie)
+
+	require.NoError(t, p.CallbackHandler()(t.Context(), rec, req, nil))
+	require.Nil(t, auth0.FindCookie(rec, "if_auth_state"), "the in-progress login must keep its state")
+}
+
+// TestCallbackHandlerTerminalFailuresRenderErrorPage covers the callbacks Auth0 has already
+// answered, where a bounce through /login loops off Auth0's own SSO session.
+func TestCallbackHandlerTerminalFailuresRenderErrorPage(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	validQuery, validCookie := p.login(t, "/login")
+	validState := validQuery.Get("state")
+
+	for _, tc := range []struct {
+		name   string
+		target string
+	}{
+		{
+			name:   "auth0 reported an error",
+			target: "/callback?error=access_denied&error_description=User+denied&state=" + validState,
+		},
+		{
+			name:   "missing code",
+			target: "/callback?state=" + validState,
+		},
+		{
+			// The OIDC test server has no token endpoint, so the exchange 404s.
+			name:   "code exchange fails",
+			target: "/callback?code=some-code&state=" + validState,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.target, nil)
+			req.AddCookie(validCookie)
+
+			err := p.CallbackHandler()(t.Context(), rec, req, nil)
+			require.True(t, xerrors.TagIs[enterrors.RespondedTag](err), "got %v", err)
+
+			require.Equal(t, http.StatusForbidden, rec.Code)
+			require.Empty(t, rec.Header().Get("Location"), "an error page must not bounce back to /login")
+			require.Contains(t, rec.Body.String(), "/logout", "the page must offer a way out")
+
+			requireNoSession(t, rec)
+		})
+	}
+}
+
+// TestCallbackHandlerCodeWithoutStateIsTerminal covers a browser that keeps no cookies at
+// all: the state cookie was set and did not come back, so /login would only lose it again.
+func TestCallbackHandlerCodeWithoutStateIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/callback?code=some-code&state=whatever", nil)
+
+	err := p.CallbackHandler()(t.Context(), rec, req, nil)
+	require.True(t, xerrors.TagIs[enterrors.RespondedTag](err), "got %v", err)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Empty(t, rec.Header().Get("Location"))
+	require.Contains(t, rec.Body.String(), "cookies are enabled")
+}
+
+// TestCallbackHandlerClearsStateCookie checks the single-use state cookie is dropped
+// once read, so a replayed callback cannot reuse the code verifier.
+func TestCallbackHandlerClearsStateCookie(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	q, cookie := p.login(t, "/login")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/callback?code=some-code&state="+q.Get("state"), nil)
+	req.AddCookie(cookie)
+
+	// The exchange fails against the test server; the cookie is cleared before that.
+	require.Error(t, p.CallbackHandler()(t.Context(), rec, req, nil))
+
+	cleared := auth0.FindCookie(rec, "if_auth_state")
+	require.NotNil(t, cleared)
+	require.Empty(t, cleared.Value)
+	require.Negative(t, cleared.MaxAge)
+	require.Equal(t, "/callback", cleared.Path, "must match the path login used or the browser keeps it")
+}
+
+// TestLogoutHandlerGETConfirms checks a GET only offers the form. Logging out on GET
+// lets any <img src="/logout"> or link prefetcher do it on the user's behalf.
+func TestLogoutHandlerGETConfirms(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logout", nil)
+
+	require.NoError(t, p.LogoutHandler()(t.Context(), rec, req, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `method="POST"`)
+	require.Nil(t, auth0.FindCookie(rec, "if_session"), "a GET must not log the user out")
+}
+
+// TestLogoutHandler checks logout is not just local: without the redirect to Auth0
+// the SSO session survives and the next /login signs the same user straight back in.
+func TestLogoutHandler(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
+
+	require.NoError(t, p.LogoutHandler()(t.Context(), rec, req, nil))
+	require.Equal(t, http.StatusSeeOther, rec.Code, "the browser must follow with a GET, not replay the POST")
+
+	for _, name := range []string{"if_session", "if_auth_state"} {
+		cookie := auth0.FindCookie(rec, name)
+		require.NotNil(t, cookie, "%s must be cleared", name)
+		require.Empty(t, cookie.Value)
+		require.Negative(t, cookie.MaxAge)
+	}
+
+	location, err := url.Parse(rec.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, p.issuer.Host, location.Host)
+	require.Equal(t, "/v2/logout", location.Path)
+	require.Equal(t, testClientID, location.Query().Get("client_id"))
+	require.Equal(t, testExternalURL, location.Query().Get("returnTo"),
+		"Auth0 only honors an allow-listed absolute returnTo")
+}
+
+// TestLogoutHandlerRejectsCrossOrigin covers an auto-submitting form on another site, which
+// SameSite=Lax does not stop: the Auth0 redirect is followed with Auth0's own cookies.
+func TestLogoutHandlerRejectsCrossOrigin(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	for _, site := range []string{"cross-site", "same-site"} {
+		t.Run(site, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
+			req.Header.Set("Sec-Fetch-Site", site)
+
+			require.Error(t, p.LogoutHandler()(t.Context(), rec, req, nil))
+			require.Equal(t, http.StatusForbidden, rec.Code)
+			require.Empty(t, rec.Header().Get("Location"), "the browser must not reach Auth0's logout endpoint")
+		})
+	}
+}
+
+// TestMiddlewareDeniesByClient pins how each client shape is turned away: a redirect for a
+// browser, a header for htmx, a challenge for everything else. Getting it wrong is silent.
+func TestMiddlewareDeniesByClient(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	for _, tc := range []struct {
+		assert  func(*testing.T, *httptest.ResponseRecorder)
+		headers map[string]string
+		name    string
+		method  string
+	}{
+		{
+			name:    "browser navigation",
+			method:  http.MethodGet,
+			headers: map[string]string{"Accept": "text/html,application/xhtml+xml"},
+			assert: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusSeeOther, rec.Code)
+				require.Equal(t, "/login?return_to=%2Fimage%2Fabc", rec.Header().Get("Location"))
+			},
+		},
+		{
+			name:    "browser form post",
+			method:  http.MethodPost,
+			headers: map[string]string{"Accept": "text/html"},
+			assert: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusSeeOther, rec.Code, "a 302 would have the browser replay the body at /login")
+			},
+		},
+		{
+			name:   "htmx request",
+			method: http.MethodPost,
+			headers: map[string]string{
+				"Accept":         "*/*",
+				"HX-Request":     "true",
+				"HX-Current-URL": "https://factory.example.com/ui/page",
+			},
+			assert: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				require.Equal(t, "/login?return_to=%2Fui%2Fpage", rec.Header().Get("Hx-Redirect"),
+					"htmx must be sent to the page the user is on, not to the XHR endpoint")
+				require.Empty(t, rec.Header().Values("WWW-Authenticate"),
+					"a challenge on an XHR pops the browser's Basic auth dialog over the page")
+			},
+		},
+		{
+			name:    "api client",
+			method:  http.MethodGet,
+			headers: map[string]string{"Accept": "application/json"},
+			assert: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				require.Empty(t, rec.Header().Get("Location"), "an API client cannot follow a login redirect")
+				require.NotEmpty(t, rec.Header().Values("WWW-Authenticate"))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, "/image/abc", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			require.Error(t, p.Middleware(denyHandler(t))(t.Context(), rec, req, nil))
+			tc.assert(t, rec)
+		})
+	}
+}
+
+// TestCookieAuthenticatedResponsesAreNotCacheable pins the headers that keep a shared cache
+// off a session; nothing on /image/* sets Cache-Control, so a CDN may store it heuristically.
+func TestCookieAuthenticatedResponsesAreNotCacheable(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+
+	next := func(_ context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+		w.WriteHeader(http.StatusOK)
+
+		return nil
+	}
+
+	t.Run("cookie authenticated", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/image/abc/v1.11.0/metal-amd64.iso", nil)
+		sessionCookie, err := p.IssueSessionCookie(p.validAccessToken(t))
+		require.NoError(t, err)
+
+		req.AddCookie(sessionCookie)
+
+		rec := httptest.NewRecorder()
+		require.NoError(t, p.Middleware(next)(t.Context(), rec, req, nil))
+
+		require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+		require.Contains(t, rec.Header().Values("Vary"), "Cookie")
+	})
+
+	// Still Vary, so a cache cannot serve this anonymous copy to a signed-in visitor.
+	t.Run("anonymous", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/image/abc/v1.11.0/metal-amd64.iso", nil)
+		req.Header.Set("Accept", "application/json")
+
+		rec := httptest.NewRecorder()
+		require.Error(t, p.Middleware(next)(t.Context(), rec, req, nil))
+		require.Contains(t, rec.Header().Values("Vary"), "Cookie")
+	})
+
+	// The bearer case is TestMachineCredentialPullIsUnaffectedByBrowserLogin, which pins the
+	// same absent Vary along with the rest of what the cookie path must not do.
+}
+
+// TestMachineCredentialPullIsUnaffectedByBrowserLogin pins that a credentialed node pull
+// skips the session-cookie path entirely: no decrypt, no cache lookup, no cache headers.
+func TestMachineCredentialPullIsUnaffectedByBrowserLogin(t *testing.T) {
+	t.Parallel()
+
+	p := setupBrowserProvider(t)
+	token := p.validAccessToken(t)
+
+	next := func(_ context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+		w.WriteHeader(http.StatusOK)
+
+		return nil
+	}
+
+	for _, tc := range []struct {
+		auth func(*http.Request)
+		name string
+	}{
+		{
+			name: "basic credential, as Talos and OCI clients send it",
+			auth: func(r *http.Request) { r.SetBasicAuth("token", token) },
+		},
+		{
+			name: "bearer credential",
+			auth: func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+token) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/org/installer/blobs/sha256:abc", nil)
+			tc.auth(req)
+
+			// A stale browser session must not interfere with a credentialed pull.
+			sessionCookie, err := p.IssueSessionCookie("some-other-access-token")
+			require.NoError(t, err)
+
+			req.AddCookie(sessionCookie)
+
+			rec := httptest.NewRecorder()
+			require.NoError(t, p.Middleware(next)(t.Context(), rec, req, nil))
+			require.Equal(t, http.StatusOK, rec.Code, "the pull has to reach the handler")
+
+			require.Empty(t, rec.Header().Values("Vary"),
+				"the cookie path must not run for a credentialed pull")
+			require.Empty(t, rec.Header().Values("Cache-Control"))
+			require.Empty(t, rec.Result().Cookies(), //nolint:bodyclose // no body on a recorder result
+				"a node pull must never be answered with a Set-Cookie")
+		})
+	}
+}

--- a/enterprise/auth/auth0/export_test.go
+++ b/enterprise/auth/auth0/export_test.go
@@ -7,6 +7,15 @@
 
 package auth0
 
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// SafeReturnTo exposes the post-login redirect sanitizer for external tests.
+var SafeReturnTo = safeReturnTo
+
 // ExtractToken exposes the Authorization header parser for external tests, which cannot
 // otherwise distinguish "no token found" from "token found and rejected".
 var ExtractToken = extractToken
@@ -14,3 +23,48 @@ var ExtractToken = extractToken
 // NormalizeDomain exposes the domain parser so tests can assert the issuer string it
 // produces, not just whether the domain was accepted.
 var NormalizeDomain = normalizeDomain
+
+// FindCookie returns the Set-Cookie the recorder captured under name, or nil.
+func FindCookie(rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range rec.Result().Cookies() { //nolint:bodyclose // no body on a recorder result
+		if c.Name == name {
+			return c
+		}
+	}
+
+	return nil
+}
+
+// IssueSessionCookie mints a session cookie for external tests, which otherwise have no
+// way to present a signed-in browser without a working token endpoint.
+func (p *Provider) IssueSessionCookie(accessToken string) (*http.Cookie, error) {
+	return p.issueCookie(func(w http.ResponseWriter) error {
+		return setSessionCookie(w, sessionPayload{
+			AccessToken: accessToken,
+			Expiry:      time.Now().Add(time.Hour),
+		}, p.browser.cipher, false)
+	})
+}
+
+// ExpiredStateCookie mints a state cookie that has already aged out, which tests cannot
+// otherwise produce without waiting stateMaxAge.
+func (p *Provider) ExpiredStateCookie(state, returnTo string) (*http.Cookie, error) {
+	return p.issueCookie(func(w http.ResponseWriter) error {
+		return setEncryptedCookie(w, http.Cookie{Name: stateCookieName, Path: callbackPath}, stateCookie{
+			IssuedAt: time.Now().Add(-stateMaxAge - time.Minute),
+			State:    state,
+			ReturnTo: returnTo,
+		}, p.browser.cipher)
+	})
+}
+
+// issueCookie runs set against a recorder and returns the single cookie it wrote.
+func (p *Provider) issueCookie(set func(http.ResponseWriter) error) (*http.Cookie, error) {
+	rec := httptest.NewRecorder()
+
+	if err := set(rec); err != nil {
+		return nil, err
+	}
+
+	return rec.Result().Cookies()[0], nil //nolint:bodyclose // no body on a recorder result
+}

--- a/enterprise/auth/auth0/provider.go
+++ b/enterprise/auth/auth0/provider.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/siderolabs/image-factory/enterprise/auth"
 	"github.com/siderolabs/image-factory/internal/ctxlog"
+	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
 	schematicpkg "github.com/siderolabs/image-factory/pkg/schematic"
 )
 
@@ -35,6 +36,9 @@ type Handler = auth.Handler
 const (
 	// jwksFetchTimeout bounds the JWKS fetch, which happens inline on the request path.
 	jwksFetchTimeout = 5 * time.Second
+
+	// tokenExchangeTimeout bounds the code exchange against the Auth0 token endpoint.
+	tokenExchangeTimeout = 10 * time.Second
 
 	// clockSkew tolerates the factory's clock running ahead of the Auth0 tenant's.
 	// go-oidc runs both checks off one Now hook, so moving the clock back widens the exp
@@ -46,6 +50,14 @@ const (
 	// Auth0 rotates keys rarely, so this only has to keep up with real rotations.
 	jwksRefetchInterval = 5 * time.Second
 	jwksRefetchBurst    = 3
+
+	// sessionKeySize is the AES-256 key length the session cookies are sealed with.
+	sessionKeySize = 32
+
+	// maxErrCodeLen and maxErrDescriptionLen bound the Auth0 error strings that reach the
+	// error page and the log, since the callback query is caller-controlled.
+	maxErrCodeLen        = 64
+	maxErrDescriptionLen = 256
 )
 
 // jwksTransport bounds JWKS refetches. go-oidc refetches whenever no cached key verifies
@@ -83,10 +95,22 @@ type Config struct {
 	// artifact fetches. Leave empty to give every token full access.
 	MachineScope string
 
+	// Browser login via authorization code + PKCE, on top of the bearer-token validation
+	// Domain and Audience always enable. These two and SessionKey are all-or-nothing.
+	ClientID     string
+	ClientSecret string
+
+	// ExternalURL is the factory's own base URL. The callback URL and the logout returnTo are
+	// derived from it, and its scheme is the floor for the cookie Secure attribute.
+	ExternalURL string
+
 	// IssuerURLOverride replaces the default issuer URL constructed from Domain.
-	// It sets both the expected iss claim and the JWKS endpoint.
+	// It sets the expected iss claim and the JWKS, authorize and token endpoints.
 	// Intended for testing only; leave empty in production.
 	IssuerURLOverride string
+
+	// SessionKey is the 32-byte AES-256 key for the session and PKCE state cookies.
+	SessionKey []byte
 }
 
 // normalizeDomain accepts the tenant domain with or without a scheme or trailing slash,
@@ -136,8 +160,12 @@ func (c *customClaims) Validate() error {
 
 // Provider is an authentication provider backed by Auth0 JWTs.
 type Provider struct {
-	verifier     *oidc.IDTokenVerifier
-	logger       *zap.Logger
+	verifier *oidc.IDTokenVerifier // access tokens
+	logger   *zap.Logger
+
+	browser *browserLogin
+
+	audience     string
 	machineScope string
 }
 
@@ -152,15 +180,20 @@ func NewProvider(ctx context.Context, logger *zap.Logger, cfg Config) (*Provider
 		return nil, errors.New("auth0: audience must not be empty")
 	}
 
-	// Issuer URL doubles as the expected iss claim.
-	issuerURL := cfg.IssuerURLOverride
-	if issuerURL == "" {
+	// Issuer URL doubles as the expected iss claim and as the base for every tenant endpoint.
+	issuer := cfg.IssuerURLOverride
+	if issuer == "" {
 		domain, err := normalizeDomain(cfg.Domain)
 		if err != nil {
 			return nil, err
 		}
 
-		issuerURL = "https://" + domain + "/"
+		issuer = "https://" + domain + "/"
+	}
+
+	tenantURL, err := url.Parse(issuer)
+	if err != nil {
+		return nil, fmt.Errorf("auth0: invalid issuer URL %q: %w", issuer, err)
 	}
 
 	providerLogger := logger.With(zap.String("component", "auth0-provider"))
@@ -180,19 +213,37 @@ func NewProvider(ctx context.Context, logger *zap.Logger, cfg Config) (*Provider
 			logger:  providerLogger,
 		},
 	})
-	keySet := oidc.NewRemoteKeySet(keyCtx, strings.TrimSuffix(issuerURL, "/")+"/.well-known/jwks.json")
+	keySet := oidc.NewRemoteKeySet(keyCtx, tenantURL.JoinPath("/.well-known/jwks.json").String())
 
-	verifier := oidc.NewVerifier(issuerURL, keySet, &oidc.Config{
-		ClientID:             cfg.Audience,
+	p := &Provider{
+		verifier:     newVerifier(issuer, keySet, cfg.Audience),
+		audience:     cfg.Audience,
+		machineScope: cfg.MachineScope,
+		logger:       providerLogger,
+	}
+
+	browserLoginRequested, err := cfg.browserLoginRequested()
+	if err != nil {
+		return nil, err
+	}
+
+	if browserLoginRequested {
+		if p.browser, err = newBrowserLogin(issuer, keySet, tenantURL, cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return p, nil
+}
+
+// newVerifier builds a verifier for tokens issued by issuer to clientID, which is the
+// API audience for access tokens and the application's client ID for ID tokens.
+func newVerifier(issuer string, keySet oidc.KeySet, clientID string) *oidc.IDTokenVerifier {
+	return oidc.NewVerifier(issuer, keySet, &oidc.Config{
+		ClientID:             clientID,
 		SupportedSigningAlgs: []string{oidc.RS256},
 		Now:                  func() time.Time { return time.Now().Add(-clockSkew) },
 	})
-
-	return &Provider{
-		verifier:     verifier,
-		logger:       providerLogger,
-		machineScope: cfg.MachineScope,
-	}, nil
 }
 
 // machineAllowed reports whether a machine-scoped token may make this request.
@@ -219,27 +270,45 @@ func (p *Provider) Run(ctx context.Context) error {
 }
 
 // Middleware implements enterprise.AuthProvider.
-// The token is read from the Authorization header, either as a Bearer value or in the
-// Basic password field; anything else gets a 401 with a WWW-Authenticate challenge.
+// The token comes from the Authorization header, then from the session cookie.
 func (p *Provider) Middleware(next Handler) Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, params httprouter.Params) error {
 		logger := ctxlog.Logger(ctx, p.logger)
 
 		tokenStr := extractToken(r)
+
+		if tokenStr == "" && p.BrowserLoginEnabled() {
+			// The answer depends on the cookie from here on. Not needed on the bearer path:
+			// RFC 9111 already bars caching a response to an Authorization request.
+			w.Header().Add("Vary", "Cookie")
+
+			token, err := p.sessionToken(r)
+			if err != nil {
+				// Left in place: the next login overwrites it.
+				logger.Debug("auth0: unusable session cookie", zap.Error(err))
+			}
+
+			if token != "" {
+				// Cookie-authenticated: without this a CDN could hand the session to the
+				// next requester.
+				w.Header().Set("Cache-Control", "no-store")
+			}
+
+			tokenStr = token
+		}
+
 		if tokenStr == "" {
 			logger.Debug("auth0: authentication required: no token provided")
-			setChallenge(w)
 
-			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("authentication required"))
+			return p.deny(w, r, "no token provided")
 		}
 
 		claims, err := p.validateToken(ctx, tokenStr)
 		if err != nil {
 			// Debug, not Warn: an unauthenticated caller controls how often this fires.
 			logger.Debug("auth0: authentication failed", zap.Error(err))
-			setChallenge(w)
 
-			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New("invalid token"))
+			return p.deny(w, r, "invalid token")
 		}
 
 		ctx = auth.WithAuthUsername(ctx, claims.OrgID)
@@ -272,6 +341,33 @@ func setChallenge(w http.ResponseWriter) {
 	w.Header().Add("WWW-Authenticate", `Bearer realm="Image Factory Enterprise"`)
 }
 
+// deny sends browsers to /login, preserving the URL they were trying to reach, and
+// answers every other client with a 401 challenge.
+func (p *Provider) deny(w http.ResponseWriter, r *http.Request, reason string) error {
+	if p.BrowserLoginEnabled() {
+		// htmx swaps a redirect's target into the page, so it is told to navigate explicitly.
+		// It reads the header before the status, so the 401 stands; a challenge must not.
+		if r.Header.Get("Hx-Request") == "true" {
+			// The current URL is the page; the request URL is only the XHR endpoint.
+			w.Header().Set("Hx-Redirect", loginURL(r.Header.Get("Hx-Current-Url")))
+
+			return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New(reason))
+		}
+
+		if isBrowserRequest(r) {
+			// See Other rather than Found so a denied POST is not replayed at /login.
+			http.Redirect(w, r, loginURL(r.URL.RequestURI()), http.StatusSeeOther)
+
+			// Tagged so the log carries the reason; the 303 comes off the writer.
+			return xerrors.NewTagged[enterrors.RespondedTag](fmt.Errorf("redirected to login: %s", reason))
+		}
+	}
+
+	setChallenge(w)
+
+	return xerrors.NewTagged[schematicpkg.RequiresAuthenticationTag](errors.New(reason))
+}
+
 // UsernameFromContext implements enterprise.AuthProvider.
 func (p *Provider) UsernameFromContext(ctx context.Context) (string, bool) {
 	return auth.GetAuthUsername(ctx)
@@ -280,6 +376,25 @@ func (p *Provider) UsernameFromContext(ctx context.Context) (string, bool) {
 // ContextWithUsername implements enterprise.AuthProvider.
 func (p *Provider) ContextWithUsername(ctx context.Context, username string) context.Context {
 	return auth.WithAuthUsername(ctx, username)
+}
+
+// sessionToken returns the access token from the session cookie. An anonymous request yields
+// ("", nil); an expired one is an error, since nothing renews it.
+func (p *Provider) sessionToken(r *http.Request) (string, error) {
+	payload, err := readSessionPayload(r, p.browser.cipher)
+	if err != nil {
+		if errors.Is(err, http.ErrNoCookie) {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	if time.Until(payload.Expiry) <= 0 {
+		return "", errors.New("auth0: session expired")
+	}
+
+	return payload.AccessToken, nil
 }
 
 // extractToken pulls the JWT from the Authorization header, accepting it either
@@ -293,11 +408,27 @@ func extractToken(r *http.Request) string {
 		return value
 	}
 
-	if _, password, ok := r.BasicAuth(); ok {
+	// Only a JWT-shaped password is taken as a token: anything else fails validation and
+	// bounces the browser to /login, which resends the same header — a redirect loop.
+	if _, password, ok := r.BasicAuth(); ok && looksLikeJWT(password) {
 		return password
 	}
 
 	return ""
+}
+
+// looksLikeJWT reports whether s has the three non-empty dot-separated segments of
+// a JWS compact serialization. It is a shape check, not validation.
+func looksLikeJWT(s string) bool {
+	parts := strings.Split(s, ".")
+
+	return len(parts) == 3 && !slices.Contains(parts, "")
+}
+
+// isBrowserRequest reports whether the client is a browser making a page navigation.
+// XHR from the UI wizard sends Accept: application/json or */*, so those get a 401 instead.
+func isBrowserRequest(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "text/html")
 }
 
 // validateToken validates the token and returns its claims, whose org_id is the identity

--- a/enterprise/auth/auth0/provider_test.go
+++ b/enterprise/auth/auth0/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,11 +79,29 @@ func captureHandler(capturedUsername *string) auth0.Handler {
 	}
 }
 
+// denyHandler fails the test if the middleware lets a request through.
+func denyHandler(t *testing.T) auth0.Handler {
+	return func(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error {
+		t.Fatal("handler must not run for an unauthenticated request")
+
+		return nil
+	}
+}
+
+// requireNoSession checks a response did not sign anyone in. A cleared cookie is fine; a
+// populated one is not.
+func requireNoSession(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if session := auth0.FindCookie(rec, "if_session"); session != nil {
+		require.Empty(t, session.Value, "this response must not establish a session")
+	}
+}
+
 func TestAuth0ProviderMiddleware(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	privateKey := testoidc.GenerateKey()
 
 	p, issuerURL := setupProvider(t, privateKey)
 
@@ -299,9 +318,7 @@ func TestAuth0ProviderMachineScope(t *testing.T) {
 
 	const machineScope = "factory:machine"
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
+	privateKey := testoidc.GenerateKey()
 	issuerURL := testoidc.StartServer(t, privateKey, testKeyID)
 
 	newProvider := func(scope string) *auth0.Provider {
@@ -390,10 +407,7 @@ func TestAuth0ProviderMachineScope(t *testing.T) {
 func TestAuth0ProviderChallengeOrder(t *testing.T) {
 	t.Parallel()
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
-	p, _ := setupProvider(t, privateKey)
+	p, _ := setupProvider(t, testoidc.GenerateKey())
 
 	for _, test := range []struct {
 		setupFn func(*http.Request)
@@ -413,18 +427,52 @@ func TestAuth0ProviderChallengeOrder(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			next := func(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error {
-				t.Fatal("handler must not run for an unauthenticated request")
-
-				return nil
-			}
-
-			require.Error(t, p.Middleware(next)(t.Context(), w, r, nil))
+			require.Error(t, p.Middleware(denyHandler(t))(t.Context(), w, r, nil))
 
 			require.Equal(t, []string{
 				`Basic realm="Image Factory Enterprise", charset="UTF-8"`,
 				`Bearer realm="Image Factory Enterprise"`,
 			}, w.Header().Values("WWW-Authenticate"))
+		})
+	}
+}
+
+// TestBearerOnlyDeniesBrowserWithChallenge pins deny's false branch: with no /login route to
+// reach, an html-shaped client gets the same 401 as any other.
+func TestBearerOnlyDeniesBrowserWithChallenge(t *testing.T) {
+	t.Parallel()
+
+	p, _ := setupProvider(t, testoidc.GenerateKey())
+	require.False(t, p.BrowserLoginEnabled())
+
+	for _, test := range []struct {
+		headers map[string]string
+		name    string
+	}{
+		{
+			name:    "browser navigation",
+			headers: map[string]string{"Accept": "text/html,application/xhtml+xml", "Sec-Fetch-Mode": "navigate"},
+		},
+		{
+			name:    "htmx request",
+			headers: map[string]string{"Hx-Request": "true", "Hx-Current-Url": "https://factory.example.com/"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			for k, v := range test.headers {
+				r.Header.Set(k, v)
+			}
+
+			w := httptest.NewRecorder()
+
+			require.Error(t, p.Middleware(denyHandler(t))(t.Context(), w, r, nil))
+
+			require.Empty(t, w.Header().Get("Location"), "there is no /login to redirect to")
+			require.Empty(t, w.Header().Get("Hx-Redirect"))
+			require.NotEmpty(t, w.Header().Values("WWW-Authenticate"), "a denied browser still gets the challenge")
 		})
 	}
 }
@@ -495,9 +543,85 @@ func TestNewProviderValidation(t *testing.T) {
 	}
 }
 
+// TestNewProviderBrowserLoginFields asserts the browser-login fields are all-or-nothing.
+func TestNewProviderBrowserLoginFields(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+
+	base := auth0.Config{Domain: testDomain, Audience: testAudience}
+
+	full := base
+	full.ClientID = "client-id"
+	full.ClientSecret = "client-secret"
+	full.ExternalURL = "https://factory.example.com"
+	full.SessionKey = make([]byte, 32)
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*auth0.Config)
+		missing string
+	}{
+		{"no clientID", func(c *auth0.Config) { c.ClientID = "" }, "clientID"},
+		{"no clientSecret", func(c *auth0.Config) { c.ClientSecret = "" }, "clientSecret"},
+		{"no sessionKey", func(c *auth0.Config) { c.SessionKey = nil }, "sessionKey"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := full
+			tc.mutate(&cfg)
+
+			_, err := auth0.NewProvider(t.Context(), logger, cfg)
+			require.Error(t, err, "partial browser login config should be rejected")
+			require.ErrorContains(t, err, tc.missing)
+		})
+	}
+
+	t.Run("all three present", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := auth0.NewProvider(t.Context(), logger, full)
+		require.NoError(t, err)
+		require.True(t, p.BrowserLoginEnabled())
+		require.Equal(t, "/callback", p.CallbackPath(),
+			"the callback route is fixed, and Auth0 is told externalURL + this path")
+	})
+
+	t.Run("none present", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := auth0.NewProvider(t.Context(), logger, base)
+		require.NoError(t, err)
+		require.False(t, p.BrowserLoginEnabled())
+	})
+
+	// The callback URL and the logout returnTo are both derived from externalURL, so a bad
+	// value must fail at startup rather than 404 the user after a successful Auth0 login.
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*auth0.Config)
+		expects string
+	}{
+		{"no externalURL", func(c *auth0.Config) { c.ExternalURL = "" }, "externalURL must be absolute"},
+		{"relative externalURL", func(c *auth0.Config) { c.ExternalURL = "/factory" }, "externalURL must be absolute"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := full
+			tc.mutate(&cfg)
+
+			_, err := auth0.NewProvider(t.Context(), logger, cfg)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expects)
+		})
+	}
+}
+
 // TestExtractToken covers which Authorization headers yield a token candidate.
-// The Basic cases matter because OCI and Talos registry clients only speak Basic,
-// so the password field has to be accepted as a token.
+// The Basic cases are the point: treating any password as a token loops a browser's cached
+// credential through /login forever.
 func TestExtractToken(t *testing.T) {
 	t.Parallel()
 
@@ -514,8 +638,12 @@ func TestExtractToken(t *testing.T) {
 		{"bearer mixed case", "BeArEr " + jwt, jwt},
 		{"unsupported scheme", "Token " + jwt, ""},
 		{"scheme only", "Bearer", ""},
-		{"basic password", "Basic " + basicValue("ignored", jwt), jwt},
+		{"basic with JWT password", "Basic " + basicValue("ignored", jwt), jwt},
+		{"basic with htpasswd password", "Basic " + basicValue("developer", "SideroTest"), ""},
 		{"basic with empty password", "Basic " + basicValue("developer", ""), ""},
+		{"basic with two segments", "Basic " + basicValue("x", "header.payload"), ""},
+		{"basic with four segments", "Basic " + basicValue("x", "a.b.c.d"), ""},
+		{"basic with empty segment", "Basic " + basicValue("x", "a..c"), ""},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -533,4 +661,44 @@ func TestExtractToken(t *testing.T) {
 // basicValue builds the base64 credentials part of a Basic Authorization header.
 func basicValue(username, password string) string {
 	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+// TestSafeReturnTo asserts the post-login redirect is clamped to a site-relative path;
+// /login is unauthenticated, so ?return_to= is attacker controlled.
+func TestSafeReturnTo(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", "/"},
+		{"root", "/", "/"},
+		{"path", "/image/abc/v1.12.0/metal-amd64.iso", "/image/abc/v1.12.0/metal-amd64.iso"},
+		{"path with query", "/ui/wizard?step=2", "/ui/wizard?step=2"},
+		{"absolute URL", "https://evil.example/x", "/x"},
+		{"protocol relative", "//evil.example/x", "/x"},
+		{"backslash", `/\evil.example`, "/%5Cevil.example"},
+		{"backslash slash", `/\/evil.example`, "/%5C/evil.example"},
+		{"javascript scheme", "javascript:alert(1)", "/"},
+		{"relative", "foo/bar", "/"},
+		{"userinfo", "https://user:pass@evil.example/x", "/x"},
+		// url.Parse skips authority parsing when the rest starts with "///", so these
+		// keep their leading slashes and stay protocol-relative to a browser.
+		{"triple slash", "///evil.example", "/"},
+		{"quadruple slash", "////evil.example", "/"},
+		{"scheme with extra slashes", "http:////evil.example", "/"},
+		{"scheme relative with path", "//evil.example", "/"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := auth0.SafeReturnTo(test.input)
+
+			require.Equal(t, test.expected, got)
+			require.True(t, strings.HasPrefix(got, "/"), "result must be site-relative")
+			require.False(t, strings.HasPrefix(got, "//"), "result must not be protocol-relative")
+		})
+	}
 }

--- a/enterprise/auth/auth0/roundtrip_test.go
+++ b/enterprise/auth/auth0/roundtrip_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package auth0_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/siderolabs/image-factory/enterprise/auth/auth0"
+	"github.com/siderolabs/image-factory/internal/testoidc"
+	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
+)
+
+// testAuthCode is the authorization code the browser carries back from Auth0.
+const testAuthCode = "test-authorization-code"
+
+// fakeTenant serves /oauth/token, the half of the flow Auth0 performs once the browser hands
+// the code back.
+type fakeTenant struct {
+	// authorize is the /authorize query of the login in flight: the nonce to echo, and the
+	// challenge the code verifier has to hash to.
+	authorize url.Values
+
+	// tweak adjusts the token set before signing, for the tests that need a bad one.
+	tweak func(access, id *testoidc.TokenOptions)
+
+	// issuer is only known once the server is listening, so it is filled in afterwards.
+	issuer string
+}
+
+// serveToken answers the code exchange, asserting what Auth0 would reject.
+// assert, not require: this runs on the test server's goroutine, where FailNow may not be called.
+func (ft *fakeTenant) serveToken(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, "authorization_code", r.PostFormValue("grant_type"))
+		assert.Equal(t, testAuthCode, r.PostFormValue("code"))
+		assert.Equal(t, testCallbackURL, r.PostFormValue("redirect_uri"),
+			"Auth0 matches this against the redirect the code was issued for")
+		assert.Equal(t, testClientSecret, r.PostFormValue("client_secret"),
+			"the credentials belong in the body: a header would have x/oauth2 probe for the auth style first")
+
+		assert.Equal(t, ft.authorize.Get("code_challenge"),
+			oauth2.S256ChallengeFromVerifier(r.PostFormValue("code_verifier")), "PKCE verifier")
+
+		expiry := time.Now().Add(time.Hour)
+		access := testoidc.TokenOptions{
+			KeyID: testKeyID, Issuer: ft.issuer, Subject: testSubject,
+			Audience: []string{testAudience}, OrgID: testOrgID, Expiry: expiry,
+		}
+		// The ID token is audienced to the application rather than the API, and carries the nonce.
+		id := testoidc.TokenOptions{
+			KeyID: testKeyID, Issuer: ft.issuer, Subject: testSubject,
+			Audience: []string{testClientID}, Nonce: ft.authorize.Get("nonce"), Expiry: expiry,
+		}
+
+		if ft.tweak != nil {
+			ft.tweak(&access, &id)
+		}
+
+		// Signed with the key the JWKS server publishes, so the tokens verify.
+		key := testoidc.GenerateKey()
+
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"access_token": testoidc.SignToken(t, key, access),
+			"id_token":     testoidc.SignToken(t, key, id),
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}
+}
+
+// signIn runs /login and the callback the browser comes back to, returning the provider that
+// served them, the callback's response, and the error it reported.
+func signIn(t *testing.T, returnTo string, tweak func(access, id *testoidc.TokenOptions)) (browserProvider, *httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	tenant := &fakeTenant{tweak: tweak}
+	p := newBrowserProvider(t, map[string]http.HandlerFunc{"/oauth/token": tenant.serveToken(t)})
+
+	// The handler only runs once a callback reaches it, by which point both of these are set.
+	tenant.issuer = p.issuer.String()
+
+	q, stateCookie := p.login(t, "/login?return_to="+url.QueryEscape(returnTo))
+	tenant.authorize = q
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+		"/callback?code="+testAuthCode+"&state="+url.QueryEscape(q.Get("state")), nil)
+	req.AddCookie(stateCookie)
+
+	return p, rec, p.CallbackHandler()(t.Context(), rec, req, nil)
+}
+
+// TestBrowserLoginRoundTrip walks a login through to an authenticated request.
+func TestBrowserLoginRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const imagePath = "/image/abc/v1.12.0/metal-amd64.iso"
+
+	p, rec, err := signIn(t, imagePath, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t, imagePath, rec.Header().Get("Location"), "the user must land where they were headed")
+
+	cleared := auth0.FindCookie(rec, "if_auth_state")
+	require.NotNil(t, cleared, "the state cookie is single use and must be spent")
+	require.Empty(t, cleared.Value)
+
+	session := auth0.FindCookie(rec, "if_session")
+	require.NotNil(t, session, "a completed login must establish a session")
+
+	// The point of the round trip: the cookie the callback issued authenticates a request, as
+	// the identity carried by the access token it was exchanged for.
+	var username string
+
+	authed := httptest.NewRequestWithContext(t.Context(), http.MethodGet, imagePath, nil)
+	authed.Header.Set("Accept", "text/html")
+	authed.AddCookie(session)
+
+	rec = httptest.NewRecorder()
+	require.NoError(t, p.Middleware(captureHandler(&username))(t.Context(), rec, authed, nil))
+
+	require.Equal(t, testOrgID, username, "the org_id of the exchanged access token is the principal")
+	require.Empty(t, rec.Header().Get("Location"), "a signed-in browser must not be sent back to /login")
+}
+
+// TestBrowserLoginRejectsBadTokenSet: a token set that verifies as a JWT but does not belong
+// to this login, or to this factory, must not become a session.
+func TestBrowserLoginRejectsBadTokenSet(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		tweak func(access, id *testoidc.TokenOptions)
+		name  string
+	}{
+		{
+			// A token set lifted from another login: correctly signed, wrong flow. The nonce is
+			// what ties the ID token to the /login that started this one.
+			name:  "id token nonce from another login",
+			tweak: func(_, id *testoidc.TokenOptions) { id.Nonce = "nonce-from-another-login" },
+		},
+		{
+			// An access token for another API is rejected on every later request, so accepting
+			// it would hand out a session that authenticates nothing.
+			name:  "access token for another audience",
+			tweak: func(access, _ *testoidc.TokenOptions) { access.Audience = []string{"https://other-api.test"} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, rec, err := signIn(t, "/", tc.tweak)
+
+			// Terminal: a bounce through /login returns the same token set off Auth0's SSO session.
+			require.True(t, xerrors.TagIs[enterrors.RespondedTag](err), "got %v", err)
+			require.Equal(t, http.StatusForbidden, rec.Code)
+
+			requireNoSession(t, rec)
+		})
+	}
+}

--- a/enterprise/auth/auth0/session.go
+++ b/enterprise/auth/auth0/session.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// AES-256-GCM cookie I/O for the browser session and the PKCE login state.
+
+package auth0
+
+import (
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	sessionCookieName = "if_session"
+	stateCookieName   = "if_auth_state"
+
+	// maxCookieSize is the per-cookie limit browsers enforce; past it the cookie is dropped
+	// silently, so it is checked here where it can still be reported.
+	maxCookieSize = 4096
+
+	// stateMaxAge bounds a login attempt. Enforced on read as well as through MaxAge,
+	// which is only a request to the browser.
+	stateMaxAge = 10 * time.Minute
+)
+
+// sessionPayload is stored encrypted in the session cookie.
+type sessionPayload struct { //nolint:govet // keeping order for semantic clarity
+	AccessToken string    `json:"a"`
+	Expiry      time.Time `json:"e"`
+}
+
+// stateCookie carries the PKCE and CSRF material across the Auth0 round trip.
+type stateCookie struct { //nolint:govet // keeping order for semantic clarity
+	State        string    `json:"state"`
+	CodeVerifier string    `json:"code_verifier"`
+	Nonce        string    `json:"nonce"`
+	ReturnTo     string    `json:"return_to"`
+	IssuedAt     time.Time `json:"issued_at"`
+}
+
+// cookieAD binds a sealed cookie to its name and format version, so the session and state
+// cookies cannot be swapped for one another and a format change can be rejected outright.
+func cookieAD(name string) []byte {
+	return []byte("if-cookie-v1:" + name)
+}
+
+// setEncryptedCookie JSON-encodes and seals value into the named cookie.
+func setEncryptedCookie(w http.ResponseWriter, c http.Cookie, value any, gcm cipher.AEAD) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("auth0: marshal %s cookie: %w", c.Name, err)
+	}
+
+	c.Value = base64.RawURLEncoding.EncodeToString(gcm.Seal(nil, nil, raw, cookieAD(c.Name)))
+	c.HttpOnly = true
+
+	// The session cookie alone authenticates, so relaxing this to None needs a CSRF token first.
+	c.SameSite = http.SameSiteLaxMode
+
+	// Serialized once: http.SetCookie would only rebuild the same string.
+	header := c.String()
+	if len(header) > maxCookieSize {
+		return fmt.Errorf("auth0: %s cookie is %d bytes, over the %d browsers accept", c.Name, len(header), maxCookieSize)
+	}
+
+	w.Header().Add("Set-Cookie", header)
+
+	return nil
+}
+
+// readEncryptedCookie is the inverse of setEncryptedCookie.
+func readEncryptedCookie(r *http.Request, name string, gcm cipher.AEAD, value any) error {
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		return fmt.Errorf("auth0: %s cookie: %w", name, err)
+	}
+
+	sealed, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return fmt.Errorf("auth0: decode %s cookie: %w", name, err)
+	}
+
+	raw, err := gcm.Open(nil, nil, sealed, cookieAD(name))
+	if err != nil {
+		return fmt.Errorf("auth0: decrypt %s cookie: %w", name, err)
+	}
+
+	if err = json.Unmarshal(raw, value); err != nil {
+		return fmt.Errorf("auth0: unmarshal %s cookie: %w", name, err)
+	}
+
+	return nil
+}
+
+// clearCookie expires a cookie. path and secure must match what it was set with.
+func clearCookie(w http.ResponseWriter, name, path string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Path:     path,
+		Secure:   secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+func setSessionCookie(w http.ResponseWriter, payload sessionPayload, gcm cipher.AEAD, secure bool) error {
+	// MaxAge rather than Expires, which the browser evaluates against its own clock.
+	maxAge := int(time.Until(payload.Expiry).Seconds())
+	if maxAge <= 0 {
+		return fmt.Errorf("auth0: session expired %s ago", time.Since(payload.Expiry).Truncate(time.Second))
+	}
+
+	return setEncryptedCookie(w, http.Cookie{
+		Name:   sessionCookieName,
+		Path:   "/",
+		Secure: secure,
+		MaxAge: maxAge,
+	}, payload, gcm)
+}
+
+func clearSessionCookie(w http.ResponseWriter, secure bool) {
+	clearCookie(w, sessionCookieName, "/", secure)
+}
+
+// setStateCookie writes the short-lived state cookie, scoped to the callback path so
+// it is not sent on every request.
+func setStateCookie(w http.ResponseWriter, sc stateCookie, gcm cipher.AEAD, secure bool) error {
+	sc.IssuedAt = time.Now()
+
+	return setEncryptedCookie(w, http.Cookie{
+		Name:   stateCookieName,
+		Path:   callbackPath,
+		Secure: secure,
+		MaxAge: int(stateMaxAge.Seconds()),
+	}, sc, gcm)
+}
+
+func clearStateCookie(w http.ResponseWriter, secure bool) {
+	clearCookie(w, stateCookieName, callbackPath, secure)
+}
+
+// readStateCookie decrypts the state cookie. The age check is left to the caller, which
+// can still use ReturnTo from a cookie that has merely aged out.
+func readStateCookie(r *http.Request, gcm cipher.AEAD) (stateCookie, error) {
+	var sc stateCookie
+
+	return sc, readEncryptedCookie(r, stateCookieName, gcm, &sc)
+}
+
+func (sc stateCookie) expired() bool {
+	return time.Since(sc.IssuedAt) > stateMaxAge
+}
+
+// readSessionPayload returns http.ErrNoCookie when no session cookie was sent.
+func readSessionPayload(r *http.Request, gcm cipher.AEAD) (sessionPayload, error) {
+	var payload sessionPayload
+
+	return payload, readEncryptedCookie(r, sessionCookieName, gcm, &payload)
+}

--- a/enterprise/auth/auth0/session_internal_test.go
+++ b/enterprise/auth/auth0/session_internal_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// In-package: the cookie payloads are opaque from outside.
+
+package auth0
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCipher builds an AES-256-GCM AEAD from a random key.
+func newTestCipher(t *testing.T) cipher.AEAD {
+	t.Helper()
+
+	key := make([]byte, 32)
+	_, err := io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+
+	gcm, err := cipher.NewGCMWithRandomNonce(block)
+	require.NoError(t, err)
+
+	return gcm
+}
+
+// requestWithCookie builds a request carrying a single cookie by name and value.
+func requestWithCookie(t *testing.T, name, value string) *http.Request {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: name, Value: value})
+
+	return r
+}
+
+// cookieByName is FindCookie, failing the test when the cookie was never set.
+func cookieByName(t *testing.T, rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	t.Helper()
+
+	c := FindCookie(rec, name)
+	if c == nil {
+		t.Fatalf("cookie %q was not set", name)
+	}
+
+	return c
+}
+
+func TestSessionCookieRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	gcm := newTestCipher(t)
+
+	// Truncated to seconds: JSON does not preserve sub-second precision.
+	want := sessionPayload{
+		AccessToken: "access-token",
+		Expiry:      time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+	}
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, setSessionCookie(rec, want, gcm, true))
+
+	c := cookieByName(t, rec, sessionCookieName)
+	require.Equal(t, "/", c.Path, "session cookie must cover every route")
+	require.True(t, c.HttpOnly)
+	require.True(t, c.Secure)
+	require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+	require.NotContains(t, c.Value, want.AccessToken, "access token must not be readable in the cookie")
+
+	got, err := readSessionPayload(requestWithCookie(t, sessionCookieName, c.Value), gcm)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	// Secure is caller-controlled: forcing it on would make the cookie unusable over plain
+	// http in development.
+	rec = httptest.NewRecorder()
+	require.NoError(t, setSessionCookie(rec, want, gcm, false))
+	require.False(t, cookieByName(t, rec, sessionCookieName).Secure)
+}
+
+func TestReadSessionPayloadNoCookie(t *testing.T) {
+	t.Parallel()
+
+	payload, err := readSessionPayload(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), newTestCipher(t))
+	require.ErrorIs(t, err, http.ErrNoCookie, "callers tell an anonymous request from a broken one by this")
+	require.Zero(t, payload)
+}
+
+// TestReadSessionPayloadRejectsBadCookies covers a present but unusable cookie: each case must
+// error, since a zero-value session would authenticate as an empty identity.
+func TestReadSessionPayloadRejectsBadCookies(t *testing.T) {
+	t.Parallel()
+
+	gcm := newTestCipher(t)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, setSessionCookie(rec, sessionPayload{AccessToken: "access-token", Expiry: time.Now().Add(time.Hour)}, gcm, true))
+
+	valid := cookieByName(t, rec, sessionCookieName).Value
+
+	raw, err := base64.RawURLEncoding.DecodeString(valid)
+	require.NoError(t, err)
+
+	// Flip a bit in the ciphertext, past the 12-byte GCM nonce.
+	tampered := make([]byte, len(raw))
+	copy(tampered, raw)
+	tampered[len(tampered)-1] ^= 0xff
+
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"not base64", "!!!not-base64!!!"},
+		{"empty", ""},
+		{"shorter than the nonce", base64.RawURLEncoding.EncodeToString(raw[:8])},
+		{"truncated ciphertext", base64.RawURLEncoding.EncodeToString(raw[:len(raw)-4])},
+		{"tampered ciphertext", base64.RawURLEncoding.EncodeToString(tampered)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := readSessionPayload(requestWithCookie(t, sessionCookieName, tc.value), gcm)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, http.ErrNoCookie, "a present but broken cookie is not an anonymous request")
+		})
+	}
+
+	// A well-formed cookie from another key must fail too, so a key rotation or a
+	// replica given the wrong key logs users out rather than admitting the session.
+	t.Run("valid cookie under a different key", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := readSessionPayload(requestWithCookie(t, sessionCookieName, valid), newTestCipher(t))
+		require.Error(t, err)
+	})
+}
+
+func TestStateCookieRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	gcm := newTestCipher(t)
+
+	want := stateCookie{
+		State:        "state-value",
+		CodeVerifier: "code-verifier",
+		Nonce:        "nonce-value",
+		ReturnTo:     "/image/abc/v1.11.0/metal-amd64.iso",
+	}
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, setStateCookie(rec, want, gcm, true))
+
+	c := cookieByName(t, rec, stateCookieName)
+	require.Equal(t, callbackPath, c.Path, "state cookie must not be sent on every request")
+	require.True(t, c.HttpOnly)
+	require.True(t, c.Secure)
+	require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+	require.NotContains(t, c.Value, want.CodeVerifier, "the PKCE verifier must not be readable in the cookie")
+
+	got, err := readStateCookie(requestWithCookie(t, stateCookieName, c.Value), gcm)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), got.IssuedAt, time.Minute)
+
+	got.IssuedAt = time.Time{}
+	require.Equal(t, want, got)
+}
+
+// TestStateCookieExpires pins that the age limit is enforced on read, since MaxAge is only a
+// request to the browser. The cookie still decrypts, so ReturnTo survives.
+func TestStateCookieExpires(t *testing.T) {
+	t.Parallel()
+
+	gcm := newTestCipher(t)
+
+	stale := stateCookie{
+		IssuedAt: time.Now().Add(-stateMaxAge - time.Minute),
+		State:    "state-value",
+		ReturnTo: "/image/abc/v1.11.0/metal-amd64.iso",
+	}
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, setEncryptedCookie(rec, http.Cookie{Name: stateCookieName, Path: "/callback"}, stale, gcm))
+
+	got, err := readStateCookie(requestWithCookie(t, stateCookieName, cookieByName(t, rec, stateCookieName).Value), gcm)
+	require.NoError(t, err)
+	require.True(t, got.expired())
+	require.Equal(t, stale.ReturnTo, got.ReturnTo, "return_to must survive the age check")
+
+	require.False(t, stateCookie{IssuedAt: time.Now()}.expired())
+}
+
+// TestSessionCookieSizeIsChecked pins that an oversized cookie is reported rather than
+// written, since the browser would drop it silently.
+func TestSessionCookieSizeIsChecked(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := setSessionCookie(rec, sessionPayload{AccessToken: strings.Repeat("a", maxCookieSize), Expiry: time.Now().Add(time.Hour)}, newTestCipher(t), true)
+
+	require.ErrorContains(t, err, "browsers accept")
+	require.Empty(t, rec.Result().Cookies()) //nolint:bodyclose // httptest recorder response has no body to close
+}
+
+// TestClearCookies pins that clearing repeats the attributes the cookie was set with:
+// differ on any of them and the browser keeps the original.
+func TestClearCookies(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		clear func(*httptest.ResponseRecorder)
+		name  string
+		path  string
+	}{
+		{
+			name:  "session",
+			path:  "/",
+			clear: func(rec *httptest.ResponseRecorder) { clearSessionCookie(rec, true) },
+		},
+		{
+			name:  "state, scoped to the callback route",
+			path:  callbackPath,
+			clear: func(rec *httptest.ResponseRecorder) { clearStateCookie(rec, true) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			tc.clear(rec)
+
+			c := rec.Result().Cookies()[0] //nolint:bodyclose // no body on a recorder result
+			require.Equal(t, tc.path, c.Path, "must match the path it was set with")
+			require.Negative(t, c.MaxAge)
+			require.Empty(t, c.Value)
+			require.True(t, c.Secure, "attributes must match the ones it was set with")
+			require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	go.uber.org/zap v1.28.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.6.0.20260809190231-643e93b9c9be
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.40.0
@@ -458,7 +459,6 @@ require (
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/hack/dev/compose.yaml
+++ b/hack/dev/compose.yaml
@@ -46,6 +46,11 @@ services:
       - ALL
     cap_add:
       - DAC_OVERRIDE
+    # Only used when config.yaml selects the auth0 authentication provider;
+    # unset by default so the htpasswd dev setup needs no environment.
+    environment:
+      - IF_AUTHENTICATION_AUTH0_CLIENTSECRET=${IF_AUTHENTICATION_AUTH0_CLIENTSECRET:-}
+      - IF_AUTHENTICATION_AUTH0_SESSIONKEY=${IF_AUTHENTICATION_AUTH0_SESSIONKEY:-}
     ports:
       - "8080:8080"
     volumes:

--- a/internal/frontend/http/browserlogin.go
+++ b/internal/frontend/http/browserlogin.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package http
+
+import (
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+)
+
+// registerBrowserLogin adds /login, /logout and the callback route when the auth provider
+// serves them.
+func (f *Frontend) registerBrowserLogin(registerPublicRoute func(func(string, httprouter.Handle), string, Handler)) {
+	blp, ok := f.options.AuthProvider.(enterprise.BrowserLoginProvider)
+	if !ok || !blp.BrowserLoginEnabled() {
+		return
+	}
+
+	registerPublicRoute(f.router.GET, "/login", blp.LoginHandler())
+	registerPublicRoute(f.router.GET, "/logout", blp.LogoutHandler())
+	registerPublicRoute(f.router.POST, "/logout", blp.LogoutHandler())
+	registerPublicRoute(f.router.GET, blp.CallbackPath(), blp.CallbackHandler())
+}

--- a/internal/frontend/http/browserlogin_internal_test.go
+++ b/internal/frontend/http/browserlogin_internal_test.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// In-package: registerBrowserLogin is unexported, and NewFrontend cannot be stood up in a
+// unit test without a registry to pull from.
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/pkg/enterprise"
+)
+
+// stubBrowserLogin is an AuthProvider that also serves browser login on callbackPath.
+type stubBrowserLogin struct {
+	callbackPath string
+}
+
+func (stubBrowserLogin) Run(context.Context) error { return nil }
+
+func (stubBrowserLogin) Middleware(h enterprise.Handler) enterprise.Handler { return h }
+
+func (stubBrowserLogin) UsernameFromContext(context.Context) (string, bool) { return "", false }
+
+func (stubBrowserLogin) ContextWithUsername(ctx context.Context, _ string) context.Context {
+	return ctx
+}
+
+func (stubBrowserLogin) BrowserLoginEnabled() bool { return true }
+
+func (s stubBrowserLogin) CallbackPath() string { return s.callbackPath }
+
+func (stubBrowserLogin) LoginHandler() enterprise.Handler { return nopHandler }
+
+func (stubBrowserLogin) LogoutHandler() enterprise.Handler { return nopHandler }
+
+func (stubBrowserLogin) CallbackHandler() enterprise.Handler { return nopHandler }
+
+func nopHandler(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error {
+	return nil
+}
+
+// TestRegisterBrowserLoginRoutes pins the routes a browser-login provider gets. They are all
+// fixed paths, so a collision with an earlier route is a bug that panics at startup.
+func TestRegisterBrowserLoginRoutes(t *testing.T) {
+	t.Parallel()
+
+	f := &Frontend{router: httprouter.New()}
+	f.options.AuthProvider = stubBrowserLogin{callbackPath: "/callback"}
+
+	var registered []string
+
+	f.registerBrowserLogin(func(_ func(string, httprouter.Handle), path string, _ Handler) {
+		registered = append(registered, path)
+	})
+
+	require.Equal(t, []string{"/login", "/logout", "/logout", "/callback"}, registered)
+}
+
+// TestRegisterBrowserLoginSkipsPlainProvider pins that a provider without browser login
+// leaves the routes unregistered rather than panicking on its nil internals.
+func TestRegisterBrowserLoginSkipsPlainProvider(t *testing.T) {
+	t.Parallel()
+
+	f := &Frontend{router: httprouter.New()}
+
+	f.registerBrowserLogin(func(func(string, httprouter.Handle), string, Handler) {
+		t.Fatal("no route may be registered without a browser-login provider")
+	})
+}

--- a/internal/frontend/http/challenge_test.go
+++ b/internal/frontend/http/challenge_test.go
@@ -51,6 +51,15 @@ func TestUnauthorizedChallengeHeader(t *testing.T) {
 				`Bearer realm="Image Factory Enterprise"`,
 			},
 		},
+		{
+			// The provider skips the challenge on this path deliberately; adding one back
+			// would pop the browser's Basic auth dialog over the page htmx is leaving.
+			name: "an htmx redirect suppresses the fallback",
+			setHeader: func(w http.ResponseWriter) {
+				w.Header().Set("Hx-Redirect", "/login?return_to=%2F")
+			},
+			expected: nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -241,6 +241,8 @@ func NewFrontend(
 	frontend.router.ServeFiles("/favicons/*filepath", http.FS(ensure.Value(fs.Sub(faviconsFS, "favicons"))))
 	frontend.router.ServeFiles("/js/*filepath", http.FS(ensure.Value(fs.Sub(jsFS, "js"))))
 
+	frontend.registerBrowserLogin(registerPublicRoute)
+
 	return frontend, nil
 }
 
@@ -294,8 +296,9 @@ func (f *Frontend) wrapHandler(h Handler, requireAuth bool) httprouter.Handle {
 			}
 
 			if code == http.StatusUnauthorized {
-				// Fallback only: a provider that already picked its challenges keeps them.
-				if sw.Header().Get("WWW-Authenticate") == "" {
+				// Fallback only: a provider that picked its own challenges keeps them, and one
+				// redirecting htmx wants none — a challenge pops the browser's Basic dialog.
+				if sw.Header().Get("WWW-Authenticate") == "" && sw.Header().Get("Hx-Redirect") == "" {
 					sw.Header().Set("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
 				}
 			}

--- a/internal/integration/auth0_test.go
+++ b/internal/integration/auth0_test.go
@@ -13,7 +13,6 @@ package integration_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/rsa"
 	"net/http"
 	"testing"
@@ -65,8 +64,7 @@ func auth0SignToken(t *testing.T, privateKey *rsa.PrivateKey, iss, aud, orgID st
 func setupEnterpriseAuth0(t *testing.T, opts *cmd.Options) auth0TokenFixtures {
 	t.Helper()
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	privateKey := testoidc.GenerateKey()
 
 	serverURL := testoidc.StartServer(t, privateKey, auth0TestKeyID)
 
@@ -116,6 +114,12 @@ func TestIntegrationAuth0(t *testing.T) {
 		t.Parallel()
 
 		testAuth0Ownership(ctx, t, baseURL, fixtures)
+	})
+
+	t.Run("BrowserRoutesAbsent", func(t *testing.T) {
+		t.Parallel()
+
+		testAuth0BrowserRoutesAbsent(ctx, t, baseURL)
 	})
 }
 
@@ -295,4 +299,32 @@ func testAuth0Ownership(ctx context.Context, t *testing.T, baseURL string, fx au
 
 		assertRequiresAuth(t, resp)
 	})
+}
+
+// testAuth0BrowserRoutesAbsent pins that a bearer-token-only deployment serves no
+// browser-login routes.
+func testAuth0BrowserRoutesAbsent(ctx context.Context, t *testing.T, baseURL string) {
+	t.Helper()
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for _, path := range []string{"/login", "/logout"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+			require.NoError(t, err)
+
+			resp, err := noRedirect.Do(req)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		})
+	}
 }

--- a/internal/testoidc/testoidc.go
+++ b/internal/testoidc/testoidc.go
@@ -101,6 +101,10 @@ type TokenOptions struct {
 	// OrgID is omitted when empty, producing a token without an org_id claim.
 	OrgID string
 
+	// Nonce binds an ID token to the login that requested it. Omitted when empty, which is
+	// what an access token carries.
+	Nonce string
+
 	// Scope is the space-delimited scope claim Auth0 issues for client credentials.
 	// Omitted when empty.
 	Scope string
@@ -144,6 +148,10 @@ func SignToken(t *testing.T, privateKey *rsa.PrivateKey, opts TokenOptions) stri
 
 	if opts.Scope != "" {
 		extra["scope"] = opts.Scope
+	}
+
+	if opts.Nonce != "" {
+		extra["nonce"] = opts.Nonce
 	}
 
 	if len(opts.Permissions) > 0 {

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -181,6 +181,11 @@ type AuthProvider interface {
 	ContextWithUsername(ctx context.Context, username string) context.Context
 }
 
+// Auth0SessionKeySize is the AES-256 key length the Auth0 session cookies are sealed with.
+// Restated here rather than imported because this package imports the provider, not the
+// other way round.
+const Auth0SessionKeySize = 32
+
 // Auth0Config holds configuration for the Auth0 authentication provider.
 //
 // This restates cmd.Auth0Options rather than reusing it because auth0.Config lives behind
@@ -190,8 +195,42 @@ type Auth0Config struct {
 	Audience     string
 	MachineScope string
 
+	// Browser login, additive on top of the bearer-token validation Domain and Audience
+	// always enable. These two and SessionKey are all-or-nothing; a partial set fails at
+	// startup.
+	ClientID     string
+	ClientSecret string // inject via IF_AUTHENTICATION_AUTH0_CLIENTSECRET
+
+	// ExternalURL is http.externalURL, required regardless of the group above. The callback
+	// URL and the logout returnTo are derived from it.
+	ExternalURL string
+
 	// IssuerURLOverride replaces the default issuer URL constructed from Domain.
-	// It sets both the expected iss claim and the JWKS endpoint.
+	// It sets the expected iss claim and the JWKS, authorize and token endpoints.
 	// Intended for testing only; leave empty in production.
 	IssuerURLOverride string
+
+	// SessionKey is a 32-byte AES-256 key for the session and PKCE state cookies.
+	// Must be shared by all replicas, since cookies issued by one are read by another.
+	SessionKey []byte
+}
+
+// BrowserLoginProvider is an optional extension of AuthProvider for providers that can sign
+// a browser in. The frontend registers its routes as public.
+type BrowserLoginProvider interface {
+	// BrowserLoginEnabled reports whether the flow is configured.
+	BrowserLoginEnabled() bool
+
+	// LoginHandler returns the handler for GET /login.
+	LoginHandler() Handler
+
+	// CallbackHandler returns the handler the identity provider redirects back to.
+	CallbackHandler() Handler
+
+	// CallbackPath returns the route CallbackHandler must be registered on, fixed by the
+	// allow-listed redirect URL.
+	CallbackPath() string
+
+	// LogoutHandler returns the handler for /logout, registered on GET and POST.
+	LogoutHandler() Handler
 }

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -230,6 +230,10 @@ func NewAuth0Provider(ctx context.Context, logger *zap.Logger, cfg Auth0Config) 
 		Domain:            cfg.Domain,
 		Audience:          cfg.Audience,
 		MachineScope:      cfg.MachineScope,
+		ClientID:          cfg.ClientID,
+		ClientSecret:      cfg.ClientSecret,
+		ExternalURL:       cfg.ExternalURL,
+		SessionKey:        cfg.SessionKey,
 		IssuerURLOverride: cfg.IssuerURLOverride,
 	})
 }


### PR DESCRIPTION
This PR adds an OAuth2 authorization code flow with PKCE on top of the bearer token
provider, so a person hitting the factory in a browser is redirected to the Auth0 tenant
instead of getting an empty 401. Session state lives in an AES-GCM encrypted cookie keyed
by the shared sessionKey, so any replica can read it.

Auth0 rotates refresh tokens and answers a replay by revoking the whole grant family, which
reaches the user as being signed out at random. A single page load fires several requests
carrying the same cookie, so refreshes are deduplicated by token and the result cached
briefly afterwards, for the requests that started before the new cookie reached the browser.

Browser handling is opt-in via the BrowserLoginProvider interface, so a provider that does
not implement it keeps the plain 401 behavior.

Depends on https://github.com/siderolabs/image-factory/pull/524