### PR TITLE
feat: make download token TTL configurable

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -87,7 +87,22 @@ func (o AuthenticationOptions) validate() error {
 		return fmt.Errorf("authentication.provider must be one of %v, got %q", authProviderOptions, o.Provider)
 	}
 
-	return nil
+	return o.DownloadTokenTTL.validate()
+}
+
+// validate checks that the download token lifetime bounds are sane and contain the default,
+// so that a bad range fails at startup rather than on the first token request.
+func (o DownloadTokenTTL) validate() error {
+	switch {
+	case o.Min <= 0:
+		return fmt.Errorf("authentication.downloadTokenTTL.min must be positive, got %s", o.Min)
+	case o.Max < o.Min:
+		return fmt.Errorf("authentication.downloadTokenTTL.max %s is below .min %s", o.Max, o.Min)
+	case o.Default < o.Min || o.Default > o.Max:
+		return fmt.Errorf("authentication.downloadTokenTTL.default %s is outside [%s, %s]", o.Default, o.Min, o.Max)
+	default:
+		return nil
+	}
 }
 
 // Options configures the behavior of the image factory.
@@ -633,8 +648,23 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	// If empty, a key pair is generated on startup (single-replica deployments only).
 	DownloadTokenKeyPath string `koanf:"downloadTokenKeyPath"`
 
-	// DownloadTokenTTL is the validity duration for download tokens.
-	DownloadTokenTTL time.Duration `koanf:"downloadTokenTTL"`
+	// DownloadTokenTTL defines the validity duration for download tokens.
+	DownloadTokenTTL DownloadTokenTTL `koanf:"downloadTokenTTL"`
+}
+
+// DownloadTokenTTL defines the validity duration for download tokens.
+//
+// A caller picks a lifetime with POST /download-token?ttl=<duration> (e.g. ?ttl=1h);
+// requests outside [min, max] are rejected with HTTP 400.
+type DownloadTokenTTL struct {
+	// Max is the longest validity duration a caller may request.
+	Max time.Duration `koanf:"max"`
+
+	// Min is the shortest validity duration a caller may request.
+	Min time.Duration `koanf:"min"`
+
+	// Default is the validity duration granted when the caller requests no explicit TTL.
+	Default time.Duration `koanf:"default"`
 }
 
 // Auth0Options holds configuration for the Auth0 authentication provider.
@@ -804,8 +834,12 @@ var DefaultOptions = Options{
 	},
 
 	Authentication: AuthenticationOptions{
-		Provider:         AuthProviderHTPasswd,
-		DownloadTokenTTL: 5 * time.Minute,
+		Provider: AuthProviderHTPasswd,
+		DownloadTokenTTL: DownloadTokenTTL{
+			Default: 5 * time.Minute,
+			Max:     8 * time.Hour,
+			Min:     30 * time.Second,
+		},
 	},
 
 	Audit: AuditOptions{

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -278,11 +279,59 @@ func TestOptionsValidate(t *testing.T) {
 			opts: cmd.Options{
 				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
 				Authentication: cmd.AuthenticationOptions{
-					Enabled:  true,
-					Provider: "auth0",
-					Auth0:    cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
+					Enabled:          true,
+					Provider:         "auth0",
+					Auth0:            cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
+					DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
 				},
 			},
+		},
+		{
+			name: "download token TTL without bounds",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:          true,
+					Provider:         "htpasswd",
+					HTPasswdPath:     "/etc/factory/htpasswd",
+					DownloadTokenTTL: cmd.DownloadTokenTTL{Default: 5 * time.Minute},
+				},
+			},
+			expectError: "authentication.downloadTokenTTL.min must be positive",
+		},
+		{
+			name: "download token TTL max below min",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:      true,
+					Provider:     "htpasswd",
+					HTPasswdPath: "/etc/factory/htpasswd",
+					DownloadTokenTTL: cmd.DownloadTokenTTL{
+						Default: 5 * time.Minute,
+						Min:     time.Hour,
+						Max:     time.Minute,
+					},
+				},
+			},
+			expectError: "is below .min",
+		},
+		{
+			name: "download token TTL default outside bounds",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:      true,
+					Provider:     "htpasswd",
+					HTPasswdPath: "/etc/factory/htpasswd",
+					DownloadTokenTTL: cmd.DownloadTokenTTL{
+						Default: 24 * time.Hour,
+						Min:     30 * time.Second,
+						Max:     8 * time.Hour,
+					},
+				},
+			},
+			expectError: "is outside [30s, 8h0m0s]",
 		},
 		{
 			name: "auth0 provider without a domain",

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -264,11 +264,13 @@ func buildDownloadTokenIssuer(opts Options) (enterprise.DownloadTokenIssuer, err
 		return nil, nil //nolint:nilnil
 	}
 
-	if opts.Authentication.DownloadTokenTTL <= 0 {
-		return nil, fmt.Errorf("downloadTokenTTL must be positive, got %s", opts.Authentication.DownloadTokenTTL)
-	}
+	ttl := opts.Authentication.DownloadTokenTTL
 
-	return enterprise.NewDownloadTokenIssuer(opts.Authentication.DownloadTokenKeyPath, opts.Authentication.DownloadTokenTTL)
+	return enterprise.NewDownloadTokenIssuer(opts.Authentication.DownloadTokenKeyPath, enterprise.DownloadTokenTTL{
+		Default: ttl.Default,
+		Min:     ttl.Min,
+		Max:     ttl.Max,
+	})
 }
 
 func buildEnterprisePlugins(

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,7 +161,11 @@ A successful response is `200 OK` with `Content-Type: application/json` and `Cac
 }
 ```
 
-`expires_in` is `authentication.downloadTokenTTL` in seconds, `5m` by default.
+`expires_in` is `authentication.downloadTokenTTL.default` in seconds, `5m` by default.
+
+The lifetime can be requested with the `ttl` query parameter as a Go duration, e.g. `POST /download-token?ttl=1h`.
+It must fall within `authentication.downloadTokenTTL.min` and `authentication.downloadTokenTTL.max`
+(`30s` and `8h` by default); anything else is rejected with `400`.
 
 The token is appended to an image URL as `?token=<access_token>` and is accepted only on `GET` and `HEAD` under `/image/`.
 One token covers every schematic owned by the caller, not just the URL it is used with; see [Authentication](authentication.md#download-tokens).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -133,6 +133,13 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" https://factory.example.com/do
 {"access_token":"eyJ...","token_type":"Bearer","expires_in":300}
 ```
 
+A shorter or longer lifetime is requested with the `ttl` query parameter, as a Go duration:
+
+```shell
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "https://factory.example.com/download-token?ttl=1h"
+{"access_token":"eyJ...","token_type":"Bearer","expires_in":3600}
+```
+
 Then append it to an image URL:
 
 ```shell
@@ -140,7 +147,8 @@ curl -LO "https://factory.example.com/image/<schematic>/v1.13.0/metal-amd64.iso?
 ```
 
 Tokens are signed with ECDSA P-256, and the public key is served unauthenticated at `/.well-known/jwks.json` so that a proxy in front of the factory can verify one without holding the private key.
-`authentication.downloadTokenTTL` sets the lifetime, default `5m`; verification allows a further 30s of clock leeway.
+`authentication.downloadTokenTTL.default` sets the lifetime granted when the caller asks for none, default `5m`; a requested lifetime outside `authentication.downloadTokenTTL.min` … `.max` (`30s` … `8h` by default) is rejected with `400`.
+Verification allows a further 30s of clock leeway.
 
 ### The `?token=` query parameter
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -944,10 +944,34 @@ If empty, a key pair is generated on startup (single-replica deployments only).
 
 ### `authentication.downloadTokenTTL`
 
-- **Type:** `time.Duration`
-- **Env:** `AUTHENTICATION_DOWNLOADTOKENTTL`
+DownloadTokenTTL defines the validity duration for download tokens.
 
-DownloadTokenTTL is the validity duration for download tokens.
+---
+
+### `authentication.downloadTokenTTL.max`
+
+- **Type:** `time.Duration`
+- **Env:** `AUTHENTICATION_DOWNLOADTOKENTTL_MAX`
+
+Max is the longest validity duration a caller may request.
+
+---
+
+### `authentication.downloadTokenTTL.min`
+
+- **Type:** `time.Duration`
+- **Env:** `AUTHENTICATION_DOWNLOADTOKENTTL_MIN`
+
+Min is the shortest validity duration a caller may request.
+
+---
+
+### `authentication.downloadTokenTTL.default`
+
+- **Type:** `time.Duration`
+- **Env:** `AUTHENTICATION_DOWNLOADTOKENTTL_DEFAULT`
+
+Default is the validity duration granted when the caller requests no explicit TTL.
 
 ---
 
@@ -1310,7 +1334,10 @@ authentication:
         domain: ""
         machineScope: ""
     downloadTokenKeyPath: ""
-    downloadTokenTTL: 5m0s
+    downloadTokenTTL:
+        default: 5m0s
+        max: 8h0m0s
+        min: 30s
     enabled: false
     htpasswdPath: ""
     provider: htpasswd
@@ -1447,7 +1474,9 @@ IF_AUTHENTICATION_AUTH0_AUDIENCE=
 IF_AUTHENTICATION_AUTH0_DOMAIN=
 IF_AUTHENTICATION_AUTH0_MACHINESCOPE=
 IF_AUTHENTICATION_DOWNLOADTOKENKEYPATH=
-IF_AUTHENTICATION_DOWNLOADTOKENTTL=5m0s
+IF_AUTHENTICATION_DOWNLOADTOKENTTL_DEFAULT=5m0s
+IF_AUTHENTICATION_DOWNLOADTOKENTTL_MAX=8h0m0s
+IF_AUTHENTICATION_DOWNLOADTOKENTTL_MIN=30s
 IF_AUTHENTICATION_ENABLED=false
 IF_AUTHENTICATION_HTPASSWDPATH=
 IF_AUTHENTICATION_PROVIDER=htpasswd

--- a/enterprise/downloadtoken/frontend.go
+++ b/enterprise/downloadtoken/frontend.go
@@ -11,10 +11,14 @@ package downloadtoken
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+
+	"github.com/siderolabs/image-factory/internal/downloadtoken"
 )
 
 // AuthProvider is a subset of enterprise.AuthProvider used for identity extraction.
@@ -26,8 +30,7 @@ type AuthProvider interface {
 // Issuer creates signed JWT download tokens.
 // Defined locally to avoid an import cycle with pkg/enterprise.
 type Issuer interface {
-	Issue(subject string) (string, error)
-	TTL() time.Duration
+	Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error)
 }
 
 // Frontend is the FrontendPlugin that issues download tokens.
@@ -51,8 +54,23 @@ func (f *Frontend) Path() string {
 	return "/download-token"
 }
 
+// parseTTL parses the ttl query parameter; an absent parameter means "unspecified" and
+// yields a zero duration, for which the issuer grants its configured default.
+func parseTTL(raw string) (time.Duration, bool) {
+	if raw == "" {
+		return 0, true
+	}
+
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		return 0, false
+	}
+
+	return ttl, true
+}
+
 // Handle implements enterprise.FrontendPlugin.
-func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) error {
+func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
 	username, ok := f.authProv.UsernameFromContext(ctx)
 	if !ok {
 		http.Error(w, "authentication required", http.StatusUnauthorized)
@@ -60,8 +78,23 @@ func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, _ *http.Re
 		return nil
 	}
 
-	token, err := f.issuer.Issue(username)
+	rawTTL := r.URL.Query().Get("ttl")
+
+	requestedTTL, ok := parseTTL(rawTTL)
+	if !ok {
+		http.Error(w, fmt.Sprintf("invalid ttl %q: expected a positive Go duration, e.g. 30m", rawTTL), http.StatusBadRequest)
+
+		return nil
+	}
+
+	token, ttl, err := f.issuer.Issue(username, requestedTTL)
 	if err != nil {
+		if errors.Is(err, downloadtoken.ErrTTLOutOfRange) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return nil
+		}
+
 		return err
 	}
 
@@ -75,6 +108,6 @@ func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, _ *http.Re
 	}{
 		AccessToken: token,
 		TokenType:   "Bearer",
-		ExpiresIn:   int(f.issuer.TTL().Seconds()),
+		ExpiresIn:   int(ttl.Seconds()),
 	})
 }

--- a/internal/downloadtoken/downloadtoken.go
+++ b/internal/downloadtoken/downloadtoken.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -28,16 +29,44 @@ const (
 	audience   = "image-factory:download"
 )
 
+// ErrTTLOutOfRange is returned by Issue when the requested token lifetime is
+// outside the configured [TTL.Min, TTL.Max] range.
+var ErrTTLOutOfRange = errors.New("downloadtoken: requested TTL out of range")
+
+// TTL bounds the lifetime of issued tokens.
+type TTL struct {
+	// Default is used when the caller does not request a lifetime.
+	Default time.Duration
+
+	// Min and Max bound the lifetime a caller may request.
+	Min time.Duration
+	Max time.Duration
+}
+
+// resolve maps a requested lifetime onto the configured bounds.
+// A non-positive request means "unspecified" and yields the default.
+func (t TTL) resolve(requested time.Duration) (time.Duration, error) {
+	if requested <= 0 {
+		return t.Default, nil
+	}
+
+	if requested < t.Min || requested > t.Max {
+		return 0, fmt.Errorf("%w: %s is outside [%s, %s]", ErrTTLOutOfRange, requested, t.Min, t.Max)
+	}
+
+	return requested, nil
+}
+
 // Issuer creates and verifies ECDSA-signed download tokens (JWTs).
 type Issuer struct {
 	key      jose.JSONWebKey
 	signer   jose.Signer
 	jwksJSON []byte
-	ttl      time.Duration
+	ttl      TTL
 }
 
 // GenerateIssuer creates an Issuer with a freshly generated ECDSA P-256 key pair.
-func GenerateIssuer(ttl time.Duration) (*Issuer, error) {
+func GenerateIssuer(ttl TTL) (*Issuer, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("downloadtoken: failed to generate ECDSA key: %w", err)
@@ -47,7 +76,7 @@ func GenerateIssuer(ttl time.Duration) (*Issuer, error) {
 }
 
 // NewIssuer creates an Issuer from an existing ECDSA private key.
-func NewIssuer(privateKey *ecdsa.PrivateKey, ttl time.Duration) (*Issuer, error) {
+func NewIssuer(privateKey *ecdsa.PrivateKey, ttl TTL) (*Issuer, error) {
 	pubJWK := jose.JSONWebKey{
 		Key:       &privateKey.PublicKey,
 		Use:       "sig",
@@ -86,7 +115,7 @@ func NewIssuer(privateKey *ecdsa.PrivateKey, ttl time.Duration) (*Issuer, error)
 }
 
 // LoadIssuer reads a PEM-encoded ECDSA private key from path and creates an Issuer.
-func LoadIssuer(path string, ttl time.Duration) (*Issuer, error) {
+func LoadIssuer(path string, ttl TTL) (*Issuer, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("downloadtoken: failed to read key file: %w", err)
@@ -109,8 +138,16 @@ func LoadIssuer(path string, ttl time.Duration) (*Issuer, error) {
 	return NewIssuer(key, ttl)
 }
 
-// Issue creates a signed JWT for the given subject (org_id or username).
-func (i *Issuer) Issue(subject string) (string, error) {
+// Issue creates a signed JWT for the given subject (org_id or username), valid for
+// the requested lifetime. A non-positive requested lifetime means "unspecified" and
+// selects the configured default; a request outside the configured bounds returns
+// ErrTTLOutOfRange. The granted lifetime is returned alongside the token.
+func (i *Issuer) Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error) {
+	ttl, err := i.ttl.resolve(requestedTTL)
+	if err != nil {
+		return "", 0, err
+	}
+
 	now := time.Now()
 
 	claims := jwt.Claims{
@@ -118,15 +155,15 @@ func (i *Issuer) Issue(subject string) (string, error) {
 		Issuer:   issuerName,
 		Audience: jwt.Audience{audience},
 		IssuedAt: jwt.NewNumericDate(now),
-		Expiry:   jwt.NewNumericDate(now.Add(i.ttl)),
+		Expiry:   jwt.NewNumericDate(now.Add(ttl)),
 	}
 
 	signed, err := jwt.Signed(i.signer).Claims(claims).Serialize()
 	if err != nil {
-		return "", fmt.Errorf("downloadtoken: failed to sign token: %w", err)
+		return "", 0, fmt.Errorf("downloadtoken: failed to sign token: %w", err)
 	}
 
-	return signed, nil
+	return signed, ttl, nil
 }
 
 // Verify parses and validates the JWT, returning the subject claim on success.
@@ -155,11 +192,6 @@ func (i *Issuer) Verify(tokenStr string) (string, error) {
 	}
 
 	return claims.Subject, nil
-}
-
-// TTL returns the token validity duration.
-func (i *Issuer) TTL() time.Duration {
-	return i.ttl
 }
 
 // JWKS returns the pre-built JSON Web Key Set containing the public key.

--- a/internal/downloadtoken/downloadtoken_test.go
+++ b/internal/downloadtoken/downloadtoken_test.go
@@ -20,13 +20,15 @@ import (
 	"github.com/siderolabs/image-factory/internal/downloadtoken"
 )
 
+var defaultTTL = downloadtoken.TTL{Default: 5 * time.Minute, Min: 30 * time.Second, Max: 8 * time.Hour}
+
 func TestRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(5 * time.Minute)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
 	require.NoError(t, err)
 
-	token, err := issuer.Issue("org_abc123")
+	token, _, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
 	sub, err := issuer.Verify(token)
@@ -39,10 +41,10 @@ func TestExpiredToken(t *testing.T) {
 
 	// Negative TTL makes the token already expired at issuance, well past
 	// the 30s clock-skew leeway used by Verify.
-	issuer, err := downloadtoken.GenerateIssuer(-time.Minute)
+	issuer, err := downloadtoken.GenerateIssuer(downloadtoken.TTL{Default: -time.Minute, Min: time.Second, Max: time.Hour})
 	require.NoError(t, err)
 
-	token, err := issuer.Issue("org_abc123")
+	token, _, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
 	_, err = issuer.Verify(token)
@@ -53,10 +55,10 @@ func TestExpiredToken(t *testing.T) {
 func TestTamperedToken(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(5 * time.Minute)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
 	require.NoError(t, err)
 
-	token, err := issuer.Issue("org_abc123")
+	token, _, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
 	// Corrupt the payload (second segment) so claims no longer match the signature.
@@ -72,13 +74,13 @@ func TestTamperedToken(t *testing.T) {
 func TestWrongKey(t *testing.T) {
 	t.Parallel()
 
-	issuer1, err := downloadtoken.GenerateIssuer(5 * time.Minute)
+	issuer1, err := downloadtoken.GenerateIssuer(defaultTTL)
 	require.NoError(t, err)
 
-	issuer2, err := downloadtoken.GenerateIssuer(5 * time.Minute)
+	issuer2, err := downloadtoken.GenerateIssuer(defaultTTL)
 	require.NoError(t, err)
 
-	token, err := issuer1.Issue("org_abc123")
+	token, _, err := issuer1.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
 	_, err = issuer2.Verify(token)
@@ -91,10 +93,10 @@ func TestNewIssuerFromKey(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	issuer, err := downloadtoken.NewIssuer(key, 5*time.Minute)
+	issuer, err := downloadtoken.NewIssuer(key, defaultTTL)
 	require.NoError(t, err)
 
-	token, err := issuer.Issue("alice")
+	token, _, err := issuer.Issue("alice", 0)
 	require.NoError(t, err)
 
 	sub, err := issuer.Verify(token)
@@ -105,7 +107,7 @@ func TestNewIssuerFromKey(t *testing.T) {
 func TestJWKS(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(5 * time.Minute)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
 	require.NoError(t, err)
 
 	jwksData := issuer.JWKS()
@@ -134,7 +136,7 @@ func TestJWKS(t *testing.T) {
 	assert.NotEmpty(t, doc.Keys[0].Kid, "JWKS should include a kid (key ID)")
 
 	// Verify the kid in the JWT header matches the JWKS kid.
-	token, err := issuer.Issue("test")
+	token, _, err := issuer.Issue("test", 0)
 	require.NoError(t, err)
 
 	var header struct {
@@ -149,6 +151,46 @@ func TestJWKS(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(headerBytes, &header))
 	assert.Equal(t, doc.Keys[0].Kid, header.Kid, "JWT kid header should match JWKS kid")
+}
+
+func TestRequestedTTL(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name      string
+		requested time.Duration
+		expected  time.Duration
+		expectErr bool
+	}{
+		{name: "unspecified", requested: 0, expected: defaultTTL.Default},
+		{name: "in range", requested: time.Hour, expected: time.Hour},
+		{name: "at min", requested: defaultTTL.Min, expected: defaultTTL.Min},
+		{name: "at max", requested: defaultTTL.Max, expected: defaultTTL.Max},
+		{name: "below min", requested: time.Second, expectErr: true},
+		{name: "above max", requested: 24 * time.Hour, expectErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			token, granted, err := issuer.Issue("org_abc123", test.requested)
+
+			if test.expectErr {
+				require.ErrorIs(t, err, downloadtoken.ErrTTLOutOfRange)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, granted)
+
+			sub, err := issuer.Verify(token)
+			require.NoError(t, err)
+			assert.Equal(t, "org_abc123", sub)
+		})
+	}
 }
 
 func splitJWT(token string) []string {

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -398,6 +398,51 @@ func testDownloadTokens(ctx context.Context, t *testing.T, baseURL string) {
 		assertRequiresAuth(t, resp)
 	})
 
+	t.Run("RequestedTTL", func(t *testing.T) {
+		t.Parallel()
+
+		for _, test := range []struct {
+			name       string
+			ttl        string
+			expectCode int
+			expiresIn  int
+		}{
+			{name: "in range", ttl: "1h", expectCode: http.StatusOK, expiresIn: 3600},
+			{name: "below min", ttl: "1s", expectCode: http.StatusBadRequest},
+			{name: "above max", ttl: "24h", expectCode: http.StatusBadRequest},
+			{name: "not a duration", ttl: "forever", expectCode: http.StatusBadRequest},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/download-token?ttl="+test.ttl, nil)
+				require.NoError(t, err)
+
+				addTestAuth(req)
+
+				resp, err := http.DefaultClient.Do(req)
+				require.NoError(t, err)
+
+				t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+				require.Equal(t, test.expectCode, resp.StatusCode)
+
+				if test.expectCode != http.StatusOK {
+					return
+				}
+
+				var result struct {
+					AccessToken string `json:"access_token"`
+					ExpiresIn   int    `json:"expires_in"`
+				}
+
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+				assert.Equal(t, test.expiresIn, result.ExpiresIn)
+				assert.NotEmpty(t, result.AccessToken)
+			})
+		}
+	})
+
 	t.Run("TokenAndDownload", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,6 +14,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/siderolabs/image-factory/pkg/schematic"
 )
@@ -178,12 +179,21 @@ func (c *Client) OverlaysVersions(ctx context.Context, talosVersion string) ([]O
 // DownloadToken requests a short-lived JWT download token scoped to the
 // authenticated caller's identity. The token can be appended as ?token= to
 // any image download URL; one token covers all schematics owned by the caller.
-func (c *Client) DownloadToken(ctx context.Context) (string, error) {
+//
+// A positive ttl requests that lifetime, which the server accepts only within its
+// configured bounds; zero or less takes the server default.
+func (c *Client) DownloadToken(ctx context.Context, ttl time.Duration) (string, error) {
 	var response struct {
 		AccessToken string `json:"access_token"`
 	}
 
-	if err := c.do(ctx, http.MethodPost, "/download-token", &response); err != nil {
+	var opts []requestOption
+
+	if ttl > 0 {
+		opts = append(opts, WithQueryParams(url.Values{"ttl": {ttl.String()}}))
+	}
+
+	if err := c.do(ctx, http.MethodPost, "/download-token", &response, opts...); err != nil {
 		return "", err
 	}
 

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/image-factory/internal/artifacts"
 	"github.com/siderolabs/image-factory/internal/asset"
 	assetcache "github.com/siderolabs/image-factory/internal/asset/cache"
+	"github.com/siderolabs/image-factory/internal/downloadtoken"
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	"github.com/siderolabs/image-factory/internal/image/verify"
 	"github.com/siderolabs/image-factory/internal/installer"
@@ -140,18 +141,21 @@ type SignatureWriter interface {
 // The implementation lives behind the enterprise build tag; when enterprise is
 // not enabled the issuer is nil and the download-token routes are not registered.
 type DownloadTokenIssuer interface {
-	// Issue creates a signed JWT for the given subject (org_id or username).
-	Issue(subject string) (string, error)
+	// Issue creates a signed JWT for the given subject (org_id or username), valid for
+	// the requested lifetime, and returns the token along with the granted lifetime.
+	// A non-positive request selects the configured default.
+	Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error)
 
 	// Verify parses and validates the JWT, returning the subject claim on success.
 	Verify(tokenStr string) (string, error)
 
-	// TTL returns the token validity duration.
-	TTL() time.Duration
-
 	// JWKS returns the pre-built JSON Web Key Set containing the public key.
 	JWKS() []byte
 }
+
+// DownloadTokenTTL is the token lifetime configuration: the default granted when the
+// caller does not ask for one, and the bounds a caller may request within.
+type DownloadTokenTTL = downloadtoken.TTL
 
 // Handler is the type of HTTP handlers used by the enterprise frontend.
 type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -9,7 +9,6 @@ package enterprise
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -65,7 +64,7 @@ func NewAuth0Provider(_ context.Context, _ *zap.Logger, _ Auth0Config) (AuthProv
 }
 
 // NewDownloadTokenIssuer returns nil when enterprise is not enabled.
-func NewDownloadTokenIssuer(_ string, _ time.Duration) (DownloadTokenIssuer, error) {
+func NewDownloadTokenIssuer(_ string, _ DownloadTokenTTL) (DownloadTokenIssuer, error) {
 	return nil, errors.New("download tokens are not supported in the non-enterprise version")
 }
 

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/prometheus/client_golang/prometheus"
@@ -238,7 +237,7 @@ func NewAuth0Provider(ctx context.Context, logger *zap.Logger, cfg Auth0Config) 
 // NewDownloadTokenIssuer creates a new download token issuer.
 // If keyPath is non-empty the key is loaded from the PEM file; otherwise a
 // fresh ECDSA P-256 key pair is generated (suitable for single-replica deployments).
-func NewDownloadTokenIssuer(keyPath string, ttl time.Duration) (DownloadTokenIssuer, error) {
+func NewDownloadTokenIssuer(keyPath string, ttl DownloadTokenTTL) (DownloadTokenIssuer, error) {
 	if keyPath != "" {
 		return downloadtoken.LoadIssuer(keyPath, ttl)
 	}


### PR DESCRIPTION
Allow callers to request a lifetime via `?ttl=` on `POST /download-token`,
bounded by new `authentication.downloadTokenTTL.{min,max,default}` config.
Previously the TTL was a single fixed value, forcing deployments to pick
one lifetime for all tokens; invalid bounds now fail validation at startup
instead of on first token request.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
