### PR TITLE
feat(enterprise): theme and translate Auth0 logout/login-error pages

### DIFF
--- a/.disvulncheck.yaml
+++ b/.disvulncheck.yaml
@@ -5,4 +5,4 @@ ignore:
     reason: |
       No fix available; golang.org/x/crypto/openpgp only reachable via cosign legacy PGP signature verification,
       which IF does not use (sigstore-based verification).
-    date: 2026-08-11
+    date: 2026-08-19

--- a/enterprise/auth/auth0/browser.go
+++ b/enterprise/auth/auth0/browser.go
@@ -10,13 +10,11 @@
 package auth0
 
 import (
-	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/http"
 	"net/url"
 	"strings"
@@ -29,6 +27,7 @@ import (
 
 	"github.com/siderolabs/image-factory/internal/ctxlog"
 	enterrors "github.com/siderolabs/image-factory/pkg/enterprise/errors"
+	"github.com/siderolabs/image-factory/pkg/enterprise/pages"
 )
 
 // callbackPath is the route Auth0 redirects back to, appended to externalURL.
@@ -200,7 +199,7 @@ func (p *Provider) CallbackHandler() Handler {
 			logger.Debug("auth0: unusable state cookie", zap.Error(err))
 
 			if p.loginTerminal(r, err) {
-				return p.loginFailed(w, "Your browser did not keep the sign-in cookie. Check that cookies are enabled for this site.")
+				return p.loginFailed(w, r, "Your browser did not keep the sign-in cookie. Check that cookies are enabled for this site.")
 			}
 
 			http.Redirect(w, r, loginURL(""), http.StatusFound)
@@ -236,14 +235,14 @@ func (p *Provider) CallbackHandler() Handler {
 				zap.String("description", truncate(query.Get("error_description"), maxErrDescriptionLen)),
 			)
 
-			return p.loginFailed(w, "The identity provider rejected the sign-in request ("+errCode+").")
+			return p.loginFailed(w, r, "The identity provider rejected the sign-in request ("+errCode+").")
 		}
 
 		payload, err := p.exchange(ctx, query.Get("code"), sc)
 		if err != nil {
 			logger.Debug("auth0: code exchange failed", zap.Error(err))
 
-			return p.loginFailed(w, "Your account could not be signed in to this factory.")
+			return p.loginFailed(w, r, "Your account could not be signed in to this factory.")
 		}
 
 		if err = setSessionCookie(w, payload, p.browser.cipher, p.cookiesSecure(r)); err != nil {
@@ -319,46 +318,15 @@ func (p *Provider) exchange(ctx context.Context, code string, sc stateCookie) (s
 	return sessionPayload{AccessToken: token.AccessToken, Expiry: token.Expiry}, nil
 }
 
-// loginErrorPage is rendered for failures that would recur: Auth0's own SSO session
-// turns a bounce through /login into a redirect loop.
-//
-// TODO: this and logoutPage bypass internal/frontend/http/templates and getLocalizer, so
-// they are unstyled and English-only where every other user-facing page is neither.
-var loginErrorPage = template.Must(template.New("login-error").Parse(`<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Sign-in failed</title></head>
-<body>
-<h1>Sign-in failed</h1>
-<p>{{.}}</p>
-<p><a href="/logout">Sign out</a> to try again as a different user.</p>
-</body>
-</html>
-`))
-
 // loginFailed renders reason as a terminal error page, tagged so it is logged as a 403.
-func (p *Provider) loginFailed(w http.ResponseWriter, reason string) error {
-	if err := writeHTML(w, http.StatusForbidden, loginErrorPage, reason); err != nil {
+// Auth0's own SSO session turns a bounce through /login into a redirect loop, so this is
+// for failures that would otherwise recur.
+func (p *Provider) loginFailed(w http.ResponseWriter, r *http.Request, reason string) error {
+	if err := pages.RenderLoginError(w, r, http.StatusForbidden, reason); err != nil {
 		return err
 	}
 
 	return xerrors.NewTagged[enterrors.RespondedTag](errors.New(reason))
-}
-
-// writeHTML renders page into a buffer first, so a template failure becomes an error
-// rather than a half-written response.
-func writeHTML(w http.ResponseWriter, status int, page *template.Template, data any) error {
-	var buf bytes.Buffer
-
-	if err := page.Execute(&buf, data); err != nil {
-		return fmt.Errorf("auth0: render %s: %w", page.Name(), err)
-	}
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(status)
-
-	_, err := buf.WriteTo(w)
-
-	return err
 }
 
 // loginURL builds the /login target, carrying return_to so a failed attempt does not drop
@@ -371,24 +339,12 @@ func loginURL(returnTo string) string {
 	return "/login"
 }
 
-// logoutPage confirms a sign-out. The POST it submits is what actually logs the user
-// out, so an <img src="/logout"> or a link prefetcher cannot do it for them.
-var logoutPage = template.Must(template.New("logout").Parse(`<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Sign out</title></head>
-<body>
-<h1>Sign out</h1>
-<form method="POST" action="/logout"><button type="submit">Sign out</button></form>
-</body>
-</html>
-`))
-
 // LogoutHandler returns the handler for /logout. Only POST logs out; the Auth0 hand-off is
 // what drops the SSO session.
 func (p *Provider) LogoutHandler() Handler {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
 		if r.Method != http.MethodPost {
-			return writeHTML(w, http.StatusOK, logoutPage, nil)
+			return pages.RenderLogout(w, r, http.StatusOK)
 		}
 
 		// SameSite does not help here: this handler needs none of our cookies. An absent
@@ -396,7 +352,7 @@ func (p *Provider) LogoutHandler() Handler {
 		if site := r.Header.Get("Sec-Fetch-Site"); site != "" && site != "same-origin" {
 			ctxlog.Logger(ctx, p.logger).Warn("auth0: cross-origin logout rejected", zap.String("sec_fetch_site", site))
 
-			if err := writeHTML(w, http.StatusForbidden, logoutPage, nil); err != nil {
+			if err := pages.RenderLogout(w, r, http.StatusForbidden); err != nil {
 				return err
 			}
 

--- a/pkg/enterprise/pages/locales/active.en.yaml
+++ b/pkg/enterprise/pages/locales/active.en.yaml
@@ -1,0 +1,14 @@
+- id: auth.logout.title
+  translation: "Sign out"
+
+- id: auth.logout.button
+  translation: "Sign out"
+
+- id: auth.login_error.title
+  translation: "Sign-in failed"
+
+- id: auth.login_error.signout
+  translation: "Sign out"
+
+- id: auth.login_error.try_again
+  translation: " to try again as a different user."

--- a/pkg/enterprise/pages/locales/active.fr.yaml
+++ b/pkg/enterprise/pages/locales/active.fr.yaml
@@ -1,0 +1,14 @@
+- id: auth.logout.title
+  translation: "Déconnexion"
+
+- id: auth.logout.button
+  translation: "Se déconnecter"
+
+- id: auth.login_error.title
+  translation: "Échec de la connexion"
+
+- id: auth.login_error.signout
+  translation: "Se déconnecter"
+
+- id: auth.login_error.try_again
+  translation: " pour réessayer avec un autre compte."

--- a/pkg/enterprise/pages/locales/active.pl.yaml
+++ b/pkg/enterprise/pages/locales/active.pl.yaml
@@ -1,0 +1,14 @@
+- id: auth.logout.title
+  translation: "Wyloguj się"
+
+- id: auth.logout.button
+  translation: "Wyloguj się"
+
+- id: auth.login_error.title
+  translation: "Logowanie nie powiodło się"
+
+- id: auth.login_error.signout
+  translation: "Wyloguj się"
+
+- id: auth.login_error.try_again
+  translation: ", aby spróbować ponownie jako inny użytkownik."

--- a/pkg/enterprise/pages/locales/active.ru.yaml
+++ b/pkg/enterprise/pages/locales/active.ru.yaml
@@ -1,0 +1,14 @@
+- id: auth.logout.title
+  translation: "Выход"
+
+- id: auth.logout.button
+  translation: "Выйти"
+
+- id: auth.login_error.title
+  translation: "Не удалось войти"
+
+- id: auth.login_error.signout
+  translation: "Выйти"
+
+- id: auth.login_error.try_again
+  translation: ", чтобы повторить попытку от имени другого пользователя."

--- a/pkg/enterprise/pages/pages.go
+++ b/pkg/enterprise/pages/pages.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package pages renders the small set of standalone, themed HTML pages (sign-out
+// confirmation, sign-in failure) that an enterprise auth provider needs outside of the
+// main wizard.
+//
+// It deliberately does not depend on internal/frontend/http: pkg/enterprise already
+// imports the concrete auth providers to wire them up, so a provider importing
+// internal/frontend/http back would cycle. This package embeds its own minimal template
+// and locale set instead, so any current or future auth provider can render a themed,
+// translated page without copying markup.
+package pages
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"html/template"
+	"net/http"
+	"path/filepath"
+	"sync"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"go.yaml.in/yaml/v4"
+	"golang.org/x/text/language"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+//go:embed locales/*.yaml
+var localesFS embed.FS
+
+var templateFuncs = template.FuncMap{
+	"t": func(localizer *i18n.Localizer, key string) string {
+		translated, err := localizer.Localize(&i18n.LocalizeConfig{MessageID: key})
+		if err != nil {
+			return "missing translation"
+		}
+
+		return translated
+	},
+}
+
+var templatesOnce = sync.OnceValue(func() *template.Template {
+	return template.Must(template.New("").Funcs(templateFuncs).ParseFS(templatesFS, "templates/*.html"))
+})
+
+var localizerOnce = sync.OnceValue(func() *i18n.Bundle {
+	bundle := i18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("yaml", yaml.Unmarshal)
+
+	entries, err := localesFS.ReadDir("locales")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, entry := range entries {
+		if _, err := bundle.LoadMessageFileFS(localesFS, filepath.Join("locales", entry.Name())); err != nil {
+			panic(err)
+		}
+	}
+
+	return bundle
+})
+
+// localizer resolves the request's language the same way the main wizard does: query
+// param, then cookie, then Accept-Language.
+func localizer(r *http.Request) *i18n.Localizer {
+	lang := r.URL.Query().Get("lang")
+
+	if lang == "" {
+		if cookie, err := r.Cookie("lang"); err == nil {
+			lang = cookie.Value
+		}
+	}
+
+	if lang == "" {
+		lang = r.Header.Get("Accept-Language")
+	}
+
+	return i18n.NewLocalizer(localizerOnce(), lang, "en")
+}
+
+// render executes into a buffer first, so a template failure becomes an error rather than
+// a half-written response.
+func render(w http.ResponseWriter, status int, name string, data any) error {
+	var buf bytes.Buffer
+
+	if err := templatesOnce().ExecuteTemplate(&buf, name, data); err != nil {
+		return fmt.Errorf("pages: render %s: %w", name, err)
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+
+	_, err := buf.WriteTo(w)
+
+	return err
+}
+
+// RenderLogout renders the sign-out confirmation page at the given status.
+func RenderLogout(w http.ResponseWriter, r *http.Request, status int) error {
+	return render(w, status, "logout.html", struct{ Localizer *i18n.Localizer }{localizer(r)})
+}
+
+// RenderLoginError renders a terminal sign-in failure page at the given status. reason is
+// shown verbatim: it is provider-supplied diagnostic prose, not a fixed UI string, so it
+// is not translated.
+func RenderLoginError(w http.ResponseWriter, r *http.Request, status int, reason string) error {
+	return render(w, status, "login-error.html", struct {
+		Localizer *i18n.Localizer
+		Reason    string
+	}{localizer(r), reason})
+}

--- a/pkg/enterprise/pages/templates/login-error.html
+++ b/pkg/enterprise/pages/templates/login-error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ t .Localizer "auth.login_error.title" }}</title>
+<link href="/css/output.css" rel="stylesheet">
+</head>
+<body class="dark:bg-gray-900 antialiased">
+<main class="md:container md:mx-auto prose dark:prose-invert mt-4">
+<h1>{{ t .Localizer "auth.login_error.title" }}</h1>
+<p>{{ .Reason }}</p>
+<p><a class="text-blue-600 dark:text-blue-500 underline" href="/logout">{{ t .Localizer "auth.login_error.signout" }}</a>{{ t .Localizer "auth.login_error.try_again" }}</p>
+</main>
+</body>
+</html>

--- a/pkg/enterprise/pages/templates/logout.html
+++ b/pkg/enterprise/pages/templates/logout.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ t .Localizer "auth.logout.title" }}</title>
+<link href="/css/output.css" rel="stylesheet">
+</head>
+<body class="dark:bg-gray-900 antialiased">
+<main class="md:container md:mx-auto prose dark:prose-invert mt-4">
+<h1>{{ t .Localizer "auth.logout.title" }}</h1>
+<form method="POST" action="/logout">
+<button type="submit" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">{{ t .Localizer "auth.logout.button" }}</button>
+</form>
+</main>
+</body>
+</html>


### PR DESCRIPTION
This PR moves the /logout and login-error pages out of inline HTML in browser.go into a new pkg/enterprise/pages package with real templates and i18n, matching the rest of the wizard's look and locales.

Pulling it into its own package also means any future auth plugin can reuse these pages instead of rolling its own.