### PR TITLE
feat(enterprise): require auth0 clientID and clientSecret always

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -86,7 +86,19 @@ func (o AuthenticationOptions) validate() error {
 			return errors.New(`authentication.auth0.audience is required when authentication.provider is "auth0"`)
 		}
 
-		// Only the key's encoding is checked here; the provider validates the group.
+		if o.Auth0.ClientID == "" {
+			return errors.New(`authentication.auth0.clientID is required when authentication.provider is "auth0"`)
+		}
+
+		if o.Auth0.ClientSecret == "" {
+			return errors.New(`authentication.auth0.clientSecret is required when authentication.provider is "auth0"`)
+		}
+
+		if o.Auth0.MaxNodeAppsPerOrg <= 0 {
+			return fmt.Errorf("authentication.auth0.maxNodeAppsPerOrg must be positive, got %d", o.Auth0.MaxNodeAppsPerOrg)
+		}
+
+		// Only the key's encoding is checked here; the provider validates whether it's required.
 		if o.Auth0.SessionKey != "" {
 			key, err := o.Auth0.DecodedSessionKey()
 			if err != nil {
@@ -657,8 +669,8 @@ type AuthenticationOptions struct { //nolint:govet // keeping order for semantic
 	//
 	// It is required when provider is "auth0", and ignored otherwise.
 	//
-	// Domain and audience alone validate bearer tokens.
-	// The browser-login fields are optional, and add the sign-in routes on top when set.
+	// Domain, audience, clientID and clientSecret are always required.
+	// sessionKey is optional, and adds the browser sign-in routes on top when set.
 	Auth0 Auth0Options `koanf:"auth0"`
 
 	// DownloadTokenKeyPath is an optional path to a PEM-encoded ECDSA P-256 private key for signing download tokens.
@@ -705,15 +717,18 @@ type Auth0Options struct {
 	// Optional; when empty every valid token has full access.
 	MachineScope string `koanf:"machineScope"`
 
-	// ClientID is the Auth0 application Client ID used for the browser login flow.
+	// ClientID is the Auth0 application Client ID, used for the browser login flow and for the
+	// Management API calls that provision per-org node tokens.
 	//
-	// Optional; part of the browser-login group.
+	// Required. The application must be authorized in the Auth0 dashboard for the Management
+	// API with the `create:clients`, `read:clients`, `delete:clients` and `create:client_grants`
+	// scopes, regardless of whether browser login is also enabled.
 	ClientID string `koanf:"clientID"`
 
 	// ClientSecret is the Auth0 application Client Secret.
 	// Inject via IF_AUTHENTICATION_AUTH0_CLIENTSECRET environment variable.
 	//
-	// Optional; part of the browser-login group.
+	// Required; see ClientID.
 	ClientSecret string `koanf:"clientSecret"`
 
 	// SessionKey is the base64-encoded 32-byte AES-256 key used to encrypt session cookies.
@@ -723,13 +738,18 @@ type Auth0Options struct {
 	// All replicas must share the same key, since a session or in-progress login started
 	// on one replica has to be decrypted by whichever replica handles the next request.
 	//
-	// Optional; part of the browser-login group.
+	// Optional; enables the browser sign-in routes when set.
 	SessionKey string `koanf:"sessionKey"`
 
 	// issuerURLOverride replaces the issuer URL constructed from Domain, for the expected
 	// iss claim and for the JWKS, authorize and token endpoints.
 	// Unexported so koanf cannot reach it; see SetAuth0IssuerURL, built only under the integration tag.
 	issuerURLOverride string
+
+	// MaxNodeAppsPerOrg caps how many node tokens an org may have active at once.
+	//
+	// Enforced at creation time, on top of Auth0's own per-tenant client-count ceiling.
+	MaxNodeAppsPerOrg int `koanf:"maxNodeAppsPerOrg"`
 }
 
 // DecodedSessionKey returns the session key bytes, or nil when none is configured.
@@ -886,6 +906,9 @@ var DefaultOptions = Options{
 			Default: 5 * time.Minute,
 			Max:     8 * time.Hour,
 			Min:     30 * time.Second,
+		},
+		Auth0: Auth0Options{
+			MaxNodeAppsPerOrg: 10,
 		},
 	},
 

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -26,9 +26,12 @@ func auth0OptsWithSessionKey(sessionKey string) cmd.Options {
 			Provider:         "auth0",
 			DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
 			Auth0: cmd.Auth0Options{
-				Domain:     "tenant.auth0.com",
-				Audience:   "https://factory.sidero.dev",
-				SessionKey: sessionKey,
+				Domain:            "tenant.auth0.com",
+				Audience:          "https://factory.sidero.dev",
+				ClientID:          "client-id",
+				ClientSecret:      "client-secret",
+				MaxNodeAppsPerOrg: 10,
+				SessionKey:        sessionKey,
 			},
 		},
 	}
@@ -298,9 +301,15 @@ func TestOptionsValidate(t *testing.T) {
 			opts: cmd.Options{
 				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
 				Authentication: cmd.AuthenticationOptions{
-					Enabled:          true,
-					Provider:         "auth0",
-					Auth0:            cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0: cmd.Auth0Options{
+						Domain:            "tenant.auth0.com",
+						Audience:          "https://factory.sidero.dev",
+						ClientID:          "client-id",
+						ClientSecret:      "client-secret",
+						MaxNodeAppsPerOrg: 10,
+					},
 					DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
 				},
 			},
@@ -375,6 +384,55 @@ func TestOptionsValidate(t *testing.T) {
 				},
 			},
 			expectError: "authentication.auth0.audience is required",
+		},
+		{
+			name: "auth0 provider without a clientID",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0: cmd.Auth0Options{
+						Domain:       "tenant.auth0.com",
+						Audience:     "https://factory.sidero.dev",
+						ClientSecret: "client-secret",
+					},
+				},
+			},
+			expectError: "authentication.auth0.clientID is required",
+		},
+		{
+			name: "auth0 provider without a clientSecret",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0: cmd.Auth0Options{
+						Domain:   "tenant.auth0.com",
+						Audience: "https://factory.sidero.dev",
+						ClientID: "client-id",
+					},
+				},
+			},
+			expectError: "authentication.auth0.clientSecret is required",
+		},
+		{
+			name: "auth0 provider without a positive maxNodeAppsPerOrg",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:  true,
+					Provider: "auth0",
+					Auth0: cmd.Auth0Options{
+						Domain:       "tenant.auth0.com",
+						Audience:     "https://factory.sidero.dev",
+						ClientID:     "client-id",
+						ClientSecret: "client-secret",
+					},
+				},
+			},
+			expectError: "authentication.auth0.maxNodeAppsPerOrg must be positive",
 		},
 		{
 			name: "unknown auth provider",

--- a/enterprise/auth/auth0/browser.go
+++ b/enterprise/auth/auth0/browser.go
@@ -44,39 +44,11 @@ type browserLogin struct { //nolint:govet // keeping order for semantic clarity
 	secure bool // externalURL is https, so cookies can carry Secure
 }
 
-// browserLoginRequested reports whether the browser login settings are present, rejecting a
-// partial set.
-func (cfg Config) browserLoginRequested() (bool, error) {
-	fields := []struct {
-		name    string
-		present bool
-	}{
-		{"clientID", cfg.ClientID != ""},
-		{"clientSecret", cfg.ClientSecret != ""},
-		{"sessionKey", len(cfg.SessionKey) > 0},
-	}
-
-	var missing []string
-
-	for _, field := range fields {
-		if !field.present {
-			missing = append(missing, field.name)
-		}
-	}
-
-	// All three or none.
-	switch len(missing) {
-	case 0:
-		return true, nil
-	case len(fields):
-		return false, nil
-	default:
-		return false, fmt.Errorf(
-			"auth0: browser login requires clientID, clientSecret and sessionKey together (missing: %s); "+
-				"omit all three to serve machine-to-machine bearer tokens only",
-			strings.Join(missing, ", "),
-		)
-	}
+// browserLoginRequested reports whether the browser login settings are present.
+// clientID and clientSecret are validated separately, in NewProvider, since node-token
+// management needs them regardless of whether browser login is enabled.
+func (cfg Config) browserLoginRequested() bool {
+	return len(cfg.SessionKey) > 0
 }
 
 func newBrowserLogin(issuer string, keySet oidc.KeySet, tenantURL *url.URL, cfg Config) (*browserLogin, error) {

--- a/enterprise/auth/auth0/provider.go
+++ b/enterprise/auth/auth0/provider.go
@@ -180,6 +180,16 @@ func NewProvider(ctx context.Context, logger *zap.Logger, cfg Config) (*Provider
 		return nil, errors.New("auth0: audience must not be empty")
 	}
 
+	// Node-token management needs Management API credentials regardless of whether browser
+	// login (gated separately, on SessionKey) is enabled, so these are required unconditionally.
+	if cfg.ClientID == "" {
+		return nil, errors.New("auth0: clientID must not be empty")
+	}
+
+	if cfg.ClientSecret == "" {
+		return nil, errors.New("auth0: clientSecret must not be empty")
+	}
+
 	// Issuer URL doubles as the expected iss claim and as the base for every tenant endpoint.
 	issuer := cfg.IssuerURLOverride
 	if issuer == "" {
@@ -222,12 +232,7 @@ func NewProvider(ctx context.Context, logger *zap.Logger, cfg Config) (*Provider
 		logger:       providerLogger,
 	}
 
-	browserLoginRequested, err := cfg.browserLoginRequested()
-	if err != nil {
-		return nil, err
-	}
-
-	if browserLoginRequested {
+	if cfg.browserLoginRequested() {
 		if p.browser, err = newBrowserLogin(issuer, keySet, tenantURL, cfg); err != nil {
 			return nil, err
 		}

--- a/enterprise/auth/auth0/provider_test.go
+++ b/enterprise/auth/auth0/provider_test.go
@@ -49,6 +49,8 @@ func setupProvider(t *testing.T, privateKey *rsa.PrivateKey) (*auth0.Provider, s
 	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
 		Domain:            testDomain,
 		Audience:          testAudience,
+		ClientID:          testClientID,
+		ClientSecret:      testClientSecret,
 		IssuerURLOverride: issuerURL,
 	})
 	require.NoError(t, err)
@@ -325,6 +327,8 @@ func TestAuth0ProviderMachineScope(t *testing.T) {
 		p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
 			Domain:            testDomain,
 			Audience:          testAudience,
+			ClientID:          testClientID,
+			ClientSecret:      testClientSecret,
 			MachineScope:      scope,
 			IssuerURLOverride: issuerURL,
 		})
@@ -480,7 +484,9 @@ func TestBearerOnlyDeniesBrowserWithChallenge(t *testing.T) {
 func TestAuth0ProviderUsernameFromContext(t *testing.T) {
 	t.Parallel()
 
-	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{Domain: testDomain, Audience: testAudience})
+	p, err := auth0.NewProvider(t.Context(), zaptest.NewLogger(t), auth0.Config{
+		Domain: testDomain, Audience: testAudience, ClientID: testClientID, ClientSecret: testClientSecret,
+	})
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -506,7 +512,12 @@ func TestNewProviderValidation(t *testing.T) {
 	require.Error(t, err, "empty audience should be rejected")
 
 	_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: testDomain, Audience: testAudience})
-	require.NoError(t, err, "domain and audience alone should be a valid, bearer-token-only setup")
+	require.Error(t, err, "clientID and clientSecret are required even for a bearer-token-only setup")
+
+	_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{
+		Domain: testDomain, Audience: testAudience, ClientID: testClientID, ClientSecret: testClientSecret,
+	})
+	require.NoError(t, err, "domain, audience, clientID and clientSecret is a valid, bearer-token-only setup")
 
 	// The domain is the trust anchor, so anything that could point elsewhere is rejected
 	// rather than trimmed into shape.
@@ -517,13 +528,17 @@ func TestNewProviderValidation(t *testing.T) {
 		"tenant.auth0.com#frag",
 		"tenant.auth0.com/../evil.example",
 	} {
-		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: domain, Audience: testAudience})
+		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{
+			Domain: domain, Audience: testAudience, ClientID: testClientID, ClientSecret: testClientSecret,
+		})
 		require.Errorf(t, err, "domain %q should be rejected", domain)
 	}
 
 	// A scheme or trailing slash is what the Auth0 console shows, so accept it.
 	for _, domain := range []string{"https://" + testDomain, "https://" + testDomain + "/", testDomain + "/"} {
-		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{Domain: domain, Audience: testAudience})
+		_, err = auth0.NewProvider(t.Context(), logger, auth0.Config{
+			Domain: domain, Audience: testAudience, ClientID: testClientID, ClientSecret: testClientSecret,
+		})
 		require.NoErrorf(t, err, "domain %q should be accepted", domain)
 	}
 
@@ -543,19 +558,14 @@ func TestNewProviderValidation(t *testing.T) {
 	}
 }
 
-// TestNewProviderBrowserLoginFields asserts the browser-login fields are all-or-nothing.
-func TestNewProviderBrowserLoginFields(t *testing.T) {
+// TestNewProviderClientCredentialsRequired asserts clientID and clientSecret are required
+// unconditionally — node-token management needs them independent of browser login.
+func TestNewProviderClientCredentialsRequired(t *testing.T) {
 	t.Parallel()
 
 	logger := zaptest.NewLogger(t)
 
-	base := auth0.Config{Domain: testDomain, Audience: testAudience}
-
-	full := base
-	full.ClientID = "client-id"
-	full.ClientSecret = "client-secret"
-	full.ExternalURL = "https://factory.example.com"
-	full.SessionKey = make([]byte, 32)
+	base := auth0.Config{Domain: testDomain, Audience: testAudience, ClientID: testClientID, ClientSecret: testClientSecret}
 
 	for _, tc := range []struct {
 		name    string
@@ -564,21 +574,46 @@ func TestNewProviderBrowserLoginFields(t *testing.T) {
 	}{
 		{"no clientID", func(c *auth0.Config) { c.ClientID = "" }, "clientID"},
 		{"no clientSecret", func(c *auth0.Config) { c.ClientSecret = "" }, "clientSecret"},
-		{"no sessionKey", func(c *auth0.Config) { c.SessionKey = nil }, "sessionKey"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := full
+			cfg := base
 			tc.mutate(&cfg)
 
 			_, err := auth0.NewProvider(t.Context(), logger, cfg)
-			require.Error(t, err, "partial browser login config should be rejected")
+			require.Error(t, err, "missing client credentials should be rejected even with browser login disabled")
 			require.ErrorContains(t, err, tc.missing)
 		})
 	}
 
-	t.Run("all three present", func(t *testing.T) {
+	t.Run("present, sessionKey absent", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := auth0.NewProvider(t.Context(), logger, base)
+		require.NoError(t, err, "clientID and clientSecret alone, with no sessionKey, is a valid management-only setup")
+		require.False(t, p.BrowserLoginEnabled())
+	})
+}
+
+// TestNewProviderSessionKeyOptional asserts sessionKey is the sole field that toggles browser
+// login, independent of clientID/clientSecret which TestNewProviderClientCredentialsRequired
+// covers.
+func TestNewProviderSessionKeyOptional(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+
+	full := auth0.Config{
+		Domain:       testDomain,
+		Audience:     testAudience,
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+		ExternalURL:  "https://factory.example.com",
+		SessionKey:   make([]byte, 32),
+	}
+
+	t.Run("sessionKey present", func(t *testing.T) {
 		t.Parallel()
 
 		p, err := auth0.NewProvider(t.Context(), logger, full)
@@ -588,10 +623,13 @@ func TestNewProviderBrowserLoginFields(t *testing.T) {
 			"the callback route is fixed, and Auth0 is told externalURL + this path")
 	})
 
-	t.Run("none present", func(t *testing.T) {
+	t.Run("sessionKey absent", func(t *testing.T) {
 		t.Parallel()
 
-		p, err := auth0.NewProvider(t.Context(), logger, base)
+		cfg := full
+		cfg.SessionKey = nil
+
+		p, err := auth0.NewProvider(t.Context(), logger, cfg)
 		require.NoError(t, err)
 		require.False(t, p.BrowserLoginEnabled())
 	})

--- a/internal/integration/auth0_test.go
+++ b/internal/integration/auth0_test.go
@@ -72,6 +72,8 @@ func setupEnterpriseAuth0(t *testing.T, opts *cmd.Options) auth0TokenFixtures {
 	opts.Authentication.Provider = cmd.AuthProviderAuth0
 	opts.Authentication.Auth0.Domain = auth0TestDomain
 	opts.Authentication.Auth0.Audience = auth0TestAudience
+	opts.Authentication.Auth0.ClientID = "test-client-id"
+	opts.Authentication.Auth0.ClientSecret = "test-client-secret"
 	opts.SetAuth0IssuerURL(serverURL)
 
 	now := time.Now()

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -195,9 +195,9 @@ type Auth0Config struct {
 	Audience     string
 	MachineScope string
 
-	// Browser login, additive on top of the bearer-token validation Domain and Audience
-	// always enable. These two and SessionKey are all-or-nothing; a partial set fails at
-	// startup.
+	// ClientID and ClientSecret are always required: node-token management needs Management
+	// API credentials regardless of whether browser login (gated separately, on SessionKey)
+	// is enabled.
 	ClientID     string
 	ClientSecret string // inject via IF_AUTHENTICATION_AUTH0_CLIENTSECRET
 


### PR DESCRIPTION
This PR makes clientID and clientSecret required whenever the auth0 provider is configured, not just when browser login is also enabled. Node-token management (coming in the next PR) needs Management API credentials regardless of whether anyone logs in through a browser, so there's no longer a real "bearer-only, no app configured" deployment shape worth supporting. sessionKey is now the only field that toggles the interactive login routes on its own.

This would, in theory, break any existing auth0 config that only set domain and audience, but there aren't any bc this is all brand new.

Also adds maxNodeAppsPerOrg, unused until the node-token API lands, to avoid a second config-plumbing PR later.