### PR TITLE
fix: enforce canonical image references

### DIFF
--- a/internal/artifacts/versions.go
+++ b/internal/artifacts/versions.go
@@ -233,7 +233,7 @@ func extractExtensionList(r io.Reader, imageRegistry registryWithNamespace) ([]E
 				repoPath, tag := taggedRef.RepositoryStr(), taggedRef.TagStr()
 
 				extensions = append(extensions, ExtensionRef{
-					TaggedReference: imageRegistry.registry.Repo(repoPath).Tag(tag),
+					TaggedReference: taggedRef,
 					Digest:          digest,
 
 					imageDigest:   line,

--- a/internal/artifacts/versions_test.go
+++ b/internal/artifacts/versions_test.go
@@ -92,7 +92,7 @@ func TestExtractExtensionList(t *testing.T) {
 			// TaggedReference is the extension identity (matched against schematics), so
 			// the namespace must never leak into it.
 			assert.Equal(t, "siderolabs/gvisor", gvisor.TaggedReference.RepositoryStr())
-			assert.Equal(t, "harbor.example.com", gvisor.TaggedReference.RegistryStr())
+			assert.Equal(t, "ghcr.io", gvisor.TaggedReference.RegistryStr())
 			assert.Equal(t, test.expectedGvisorPullRef, gvisor.PullReference().String())
 			assert.Equal(t, "sha256:5ab365f2b98ab885b1d9a6ebb2e2b06d0a7887d2c173a2b7d3f9e0e4f2f4f1cb", gvisor.Digest)
 			assert.Equal(t, "Sidero Labs", gvisor.Author)

--- a/internal/integration/meta_test.go
+++ b/internal/integration/meta_test.go
@@ -54,6 +54,11 @@ func testMetaFrontend(ctx context.Context, t *testing.T, baseURL string) {
 				assert.Contains(t, names, "siderolabs/amd-ucode")
 				assert.Contains(t, names, "siderolabs/gvisor")
 				assert.Contains(t, names, "siderolabs/nvidia-open-gpu-kernel-modules")
+
+				// assert that published image refs are canonical
+				for _, ext := range extensions {
+					assert.Contains(t, ext.Ref, "ghcr.io/siderolabs/")
+				}
 			})
 		}
 


### PR DESCRIPTION
The tagged reference is exported over the API, it should never contain any local registry configuration.

Fixes #544