### PR TITLE
fix(enterprise): read the org_id claim from if_org_id

### DIFF
--- a/enterprise/auth/auth0/provider.go
+++ b/enterprise/auth/auth0/provider.go
@@ -137,7 +137,10 @@ func normalizeDomain(domain string) (string, error) {
 
 // customClaims holds Auth0-specific JWT claims beyond the standard registered set.
 type customClaims struct {
-	OrgID string `json:"org_id"`
+	// if_org_id, not org_id: Auth0 treats org_id as a protected claim name tied to native
+	// Organizations and silently drops attempts to set it from an Action, so both the M2M
+	// and browser-login paths mirror it into this custom claim name instead.
+	OrgID string `json:"if_org_id"`
 
 	// Auth0 puts granted scopes in scope for plain client-credentials tokens and in
 	// permissions when RBAC is enabled on the API, so both have to be consulted.

--- a/internal/testoidc/testoidc.go
+++ b/internal/testoidc/testoidc.go
@@ -98,7 +98,7 @@ type TokenOptions struct {
 	Issuer  string
 	Subject string
 
-	// OrgID is omitted when empty, producing a token without an org_id claim.
+	// OrgID is omitted when empty, producing a token without an if_org_id claim.
 	OrgID string
 
 	// Nonce binds an ID token to the login that requested it. Omitted when empty, which is
@@ -143,7 +143,7 @@ func SignToken(t *testing.T, privateKey *rsa.PrivateKey, opts TokenOptions) stri
 	extra := map[string]any{}
 
 	if opts.OrgID != "" {
-		extra["org_id"] = opts.OrgID
+		extra["if_org_id"] = opts.OrgID
 	}
 
 	if opts.Scope != "" {


### PR DESCRIPTION
This PR switches to reading if_org_id instead of org_id, since Auth0 silently drops any attempt to set org_id from a custom actions or metadata (it's reserved for native Organizations) and there's no other way to attach org identity to an M2M token on our plan.

Work ongoing to see if we're moving to enterprise auth0 later this week, but this can't wait until then.