### PR TITLE
feat(enterprise): extend the download-token issuer to a second audience

### DIFF
--- a/enterprise/downloadtoken/frontend.go
+++ b/enterprise/downloadtoken/frontend.go
@@ -30,7 +30,7 @@ type AuthProvider interface {
 // Issuer creates signed JWT download tokens.
 // Defined locally to avoid an import cycle with pkg/enterprise.
 type Issuer interface {
-	Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error)
+	Issue(subject string, requestedTTL time.Duration) (token string, ttl time.Duration, jti string, err error)
 }
 
 // Frontend is the FrontendPlugin that issues download tokens.
@@ -87,7 +87,7 @@ func (f *Frontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Re
 		return nil
 	}
 
-	token, ttl, err := f.issuer.Issue(username, requestedTTL)
+	token, ttl, _, err := f.issuer.Issue(username, requestedTTL)
 	if err != nil {
 		if errors.Is(err, downloadtoken.ErrTTLOutOfRange) {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/downloadtoken/downloadtoken.go
+++ b/internal/downloadtoken/downloadtoken.go
@@ -22,11 +22,15 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 )
 
+const issuerName = "image-factory"
+
+// DownloadAudience and NodeAudience are the two token classes an Issuer can be built for.
 const (
-	issuerName = "image-factory"
-	audience   = "image-factory:download"
+	DownloadAudience = "image-factory:download"
+	NodeAudience     = "image-factory:node"
 )
 
 // ErrTTLOutOfRange is returned by Issue when the requested token lifetime is
@@ -57,26 +61,32 @@ func (t TTL) resolve(requested time.Duration) (time.Duration, error) {
 	return requested, nil
 }
 
-// Issuer creates and verifies ECDSA-signed download tokens (JWTs).
+// Issuer creates and verifies ECDSA-signed JWTs for one audience (DownloadAudience or
+// NodeAudience) — construct a separate Issuer per audience, each with its own key.
 type Issuer struct {
-	key      jose.JSONWebKey
 	signer   jose.Signer
+	audience string
+	key      jose.JSONWebKey
 	jwksJSON []byte
 	ttl      TTL
 }
 
 // GenerateIssuer creates an Issuer with a freshly generated ECDSA P-256 key pair.
-func GenerateIssuer(ttl TTL) (*Issuer, error) {
+func GenerateIssuer(ttl TTL, audience string) (*Issuer, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("downloadtoken: failed to generate ECDSA key: %w", err)
 	}
 
-	return NewIssuer(key, ttl)
+	return NewIssuer(key, ttl, audience)
 }
 
 // NewIssuer creates an Issuer from an existing ECDSA private key.
-func NewIssuer(privateKey *ecdsa.PrivateKey, ttl TTL) (*Issuer, error) {
+func NewIssuer(privateKey *ecdsa.PrivateKey, ttl TTL, audience string) (*Issuer, error) {
+	if audience != DownloadAudience && audience != NodeAudience {
+		return nil, fmt.Errorf("downloadtoken: audience must be %q or %q, got %q", DownloadAudience, NodeAudience, audience)
+	}
+
 	pubJWK := jose.JSONWebKey{
 		Key:       &privateKey.PublicKey,
 		Use:       "sig",
@@ -110,12 +120,13 @@ func NewIssuer(privateKey *ecdsa.PrivateKey, ttl TTL) (*Issuer, error) {
 		signer:   sig,
 		key:      pubJWK,
 		ttl:      ttl,
+		audience: audience,
 		jwksJSON: jwksJSON,
 	}, nil
 }
 
 // LoadIssuer reads a PEM-encoded ECDSA private key from path and creates an Issuer.
-func LoadIssuer(path string, ttl TTL) (*Issuer, error) {
+func LoadIssuer(path string, ttl TTL, audience string) (*Issuer, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("downloadtoken: failed to read key file: %w", err)
@@ -135,63 +146,75 @@ func LoadIssuer(path string, ttl TTL) (*Issuer, error) {
 		return nil, fmt.Errorf("downloadtoken: expected P-256 key, got %s", key.Curve.Params().Name)
 	}
 
-	return NewIssuer(key, ttl)
+	return NewIssuer(key, ttl, audience)
 }
 
 // Issue creates a signed JWT for the given subject (org_id or username), valid for
 // the requested lifetime. A non-positive requested lifetime means "unspecified" and
 // selects the configured default; a request outside the configured bounds returns
-// ErrTTLOutOfRange. The granted lifetime is returned alongside the token.
-func (i *Issuer) Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error) {
-	ttl, err := i.ttl.resolve(requestedTTL)
-	if err != nil {
-		return "", 0, err
+// ErrTTLOutOfRange. The granted lifetime and the token's unique ID (jti) are returned
+// alongside the token; the jti is unused for download tokens and is the revocation/listing
+// key for node tokens.
+func (i *Issuer) Issue(subject string, requestedTTL time.Duration) (token string, ttl time.Duration, jti string, err error) {
+	if subject == "" {
+		return "", 0, "", errors.New("downloadtoken: subject must not be empty")
 	}
 
+	ttl, err = i.ttl.resolve(requestedTTL)
+	if err != nil {
+		return "", 0, "", err
+	}
+
+	jti = uuid.NewString()
 	now := time.Now()
 
 	claims := jwt.Claims{
+		ID:       jti,
 		Subject:  subject,
 		Issuer:   issuerName,
-		Audience: jwt.Audience{audience},
+		Audience: jwt.Audience{i.audience},
 		IssuedAt: jwt.NewNumericDate(now),
 		Expiry:   jwt.NewNumericDate(now.Add(ttl)),
 	}
 
 	signed, err := jwt.Signed(i.signer).Claims(claims).Serialize()
 	if err != nil {
-		return "", 0, fmt.Errorf("downloadtoken: failed to sign token: %w", err)
+		return "", 0, "", fmt.Errorf("downloadtoken: failed to sign token: %w", err)
 	}
 
-	return signed, ttl, nil
+	return signed, ttl, jti, nil
 }
 
-// Verify parses and validates the JWT, returning the subject claim on success.
-func (i *Issuer) Verify(tokenStr string) (string, error) {
+// Verify parses and validates the JWT, returning the subject and jti claims on success.
+func (i *Issuer) Verify(tokenStr string) (subject, jti string, err error) {
 	tok, err := jwt.ParseSigned(tokenStr, []jose.SignatureAlgorithm{jose.ES256})
 	if err != nil {
-		return "", fmt.Errorf("downloadtoken: failed to parse token: %w", err)
+		return "", "", fmt.Errorf("downloadtoken: failed to parse token: %w", err)
 	}
 
 	var claims jwt.Claims
 
 	if err = tok.Claims(i.key, &claims); err != nil {
-		return "", fmt.Errorf("downloadtoken: failed to verify token: %w", err)
+		return "", "", fmt.Errorf("downloadtoken: failed to verify token: %w", err)
 	}
 
 	if err = claims.ValidateWithLeeway(jwt.Expected{
 		Issuer:      issuerName,
-		AnyAudience: jwt.Audience{audience},
+		AnyAudience: jwt.Audience{i.audience},
 		Time:        time.Now(),
 	}, 30*time.Second); err != nil {
-		return "", fmt.Errorf("downloadtoken: %w", err)
+		return "", "", fmt.Errorf("downloadtoken: %w", err)
 	}
 
 	if claims.Subject == "" {
-		return "", fmt.Errorf("downloadtoken: missing subject claim")
+		return "", "", fmt.Errorf("downloadtoken: missing subject claim")
 	}
 
-	return claims.Subject, nil
+	if claims.ID == "" {
+		return "", "", fmt.Errorf("downloadtoken: missing jti claim")
+	}
+
+	return claims.Subject, claims.ID, nil
 }
 
 // JWKS returns the pre-built JSON Web Key Set containing the public key.

--- a/internal/downloadtoken/downloadtoken_test.go
+++ b/internal/downloadtoken/downloadtoken_test.go
@@ -22,18 +22,62 @@ import (
 
 var defaultTTL = downloadtoken.TTL{Default: 5 * time.Minute, Min: 30 * time.Second, Max: 8 * time.Hour}
 
+func TestGenerateIssuerRejectsUnknownAudience(t *testing.T) {
+	t.Parallel()
+
+	_, err := downloadtoken.GenerateIssuer(defaultTTL, "not-a-real-audience")
+	require.Error(t, err)
+}
+
+func TestIssueRejectsEmptySubject(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
+	require.NoError(t, err)
+
+	token, _, _, issueErr := issuer.Issue("", 0)
+	require.Error(t, issueErr)
+	assert.Empty(t, token)
+}
+
 func TestRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	token, _, err := issuer.Issue("org_abc123", 0)
+	token, _, jti, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
+	require.NotEmpty(t, jti)
 
-	sub, err := issuer.Verify(token)
+	sub, gotJTI, err := issuer.Verify(token)
 	require.NoError(t, err)
 	assert.Equal(t, "org_abc123", sub)
+	assert.Equal(t, jti, gotJTI)
+}
+
+// TestAudienceIsolation checks a node-audience token is rejected by a download-audience
+// issuer, and vice versa, even when both share the same claims shape.
+func TestAudienceIsolation(t *testing.T) {
+	t.Parallel()
+
+	downloadIssuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
+	require.NoError(t, err)
+
+	nodeIssuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.NodeAudience)
+	require.NoError(t, err)
+
+	nodeToken, _, _, err := nodeIssuer.Issue("org_abc123", 0)
+	require.NoError(t, err)
+
+	_, _, err = downloadIssuer.Verify(nodeToken)
+	require.Error(t, err)
+
+	downloadToken, _, _, err := downloadIssuer.Issue("org_abc123", 0)
+	require.NoError(t, err)
+
+	_, _, err = nodeIssuer.Verify(downloadToken)
+	require.Error(t, err)
 }
 
 func TestExpiredToken(t *testing.T) {
@@ -41,13 +85,13 @@ func TestExpiredToken(t *testing.T) {
 
 	// Negative TTL makes the token already expired at issuance, well past
 	// the 30s clock-skew leeway used by Verify.
-	issuer, err := downloadtoken.GenerateIssuer(downloadtoken.TTL{Default: -time.Minute, Min: time.Second, Max: time.Hour})
+	issuer, err := downloadtoken.GenerateIssuer(downloadtoken.TTL{Default: -time.Minute, Min: time.Second, Max: time.Hour}, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	token, _, err := issuer.Issue("org_abc123", 0)
+	token, _, _, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
-	_, err = issuer.Verify(token)
+	_, _, err = issuer.Verify(token)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expired")
 }
@@ -55,10 +99,10 @@ func TestExpiredToken(t *testing.T) {
 func TestTamperedToken(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	token, _, err := issuer.Issue("org_abc123", 0)
+	token, _, _, err := issuer.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
 	// Corrupt the payload (second segment) so claims no longer match the signature.
@@ -67,23 +111,23 @@ func TestTamperedToken(t *testing.T) {
 
 	tampered := parts[0] + "." + parts[1] + "TAMPERED." + parts[2]
 
-	_, err = issuer.Verify(tampered)
+	_, _, err = issuer.Verify(tampered)
 	require.Error(t, err)
 }
 
 func TestWrongKey(t *testing.T) {
 	t.Parallel()
 
-	issuer1, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer1, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	issuer2, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer2, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	token, _, err := issuer1.Issue("org_abc123", 0)
+	token, _, _, err := issuer1.Issue("org_abc123", 0)
 	require.NoError(t, err)
 
-	_, err = issuer2.Verify(token)
+	_, _, err = issuer2.Verify(token)
 	require.Error(t, err)
 }
 
@@ -93,13 +137,13 @@ func TestNewIssuerFromKey(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	issuer, err := downloadtoken.NewIssuer(key, defaultTTL)
+	issuer, err := downloadtoken.NewIssuer(key, defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
-	token, _, err := issuer.Issue("alice", 0)
+	token, _, _, err := issuer.Issue("alice", 0)
 	require.NoError(t, err)
 
-	sub, err := issuer.Verify(token)
+	sub, _, err := issuer.Verify(token)
 	require.NoError(t, err)
 	assert.Equal(t, "alice", sub)
 }
@@ -107,7 +151,7 @@ func TestNewIssuerFromKey(t *testing.T) {
 func TestJWKS(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
 	jwksData := issuer.JWKS()
@@ -136,7 +180,7 @@ func TestJWKS(t *testing.T) {
 	assert.NotEmpty(t, doc.Keys[0].Kid, "JWKS should include a kid (key ID)")
 
 	// Verify the kid in the JWT header matches the JWKS kid.
-	token, _, err := issuer.Issue("test", 0)
+	token, _, _, err := issuer.Issue("test", 0)
 	require.NoError(t, err)
 
 	var header struct {
@@ -156,7 +200,7 @@ func TestJWKS(t *testing.T) {
 func TestRequestedTTL(t *testing.T) {
 	t.Parallel()
 
-	issuer, err := downloadtoken.GenerateIssuer(defaultTTL)
+	issuer, err := downloadtoken.GenerateIssuer(defaultTTL, downloadtoken.DownloadAudience)
 	require.NoError(t, err)
 
 	for _, test := range []struct {
@@ -175,7 +219,7 @@ func TestRequestedTTL(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			token, granted, err := issuer.Issue("org_abc123", test.requested)
+			token, granted, _, err := issuer.Issue("org_abc123", test.requested)
 
 			if test.expectErr {
 				require.ErrorIs(t, err, downloadtoken.ErrTTLOutOfRange)
@@ -186,7 +230,7 @@ func TestRequestedTTL(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, granted)
 
-			sub, err := issuer.Verify(token)
+			sub, _, err := issuer.Verify(token)
 			require.NoError(t, err)
 			assert.Equal(t, "org_abc123", sub)
 		})

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -388,7 +388,7 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string, state
 		// context so handlePXE can forward it into the asset URLs it emits.
 		if f.options.DownloadTokenIssuer != nil && (r.Method == http.MethodGet || r.Method == http.MethodHead) && tokenAcceptedOn(r.URL.Path) && r.URL.RawQuery != "" {
 			if tokenStr := r.URL.Query().Get("token"); tokenStr != "" {
-				if sub, err := f.options.DownloadTokenIssuer.Verify(tokenStr); err == nil {
+				if sub, _, err := f.options.DownloadTokenIssuer.Verify(tokenStr); err == nil {
 					*username = sub
 					ctx = authProvider.ContextWithUsername(ctx, sub)
 					ctx = context.WithValue(ctx, downloadTokenKey{}, tokenStr)

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -142,12 +142,12 @@ type SignatureWriter interface {
 // not enabled the issuer is nil and the download-token routes are not registered.
 type DownloadTokenIssuer interface {
 	// Issue creates a signed JWT for the given subject (org_id or username), valid for
-	// the requested lifetime, and returns the token along with the granted lifetime.
+	// the requested lifetime, and returns the token, granted lifetime, and the token's jti.
 	// A non-positive request selects the configured default.
-	Issue(subject string, requestedTTL time.Duration) (string, time.Duration, error)
+	Issue(subject string, requestedTTL time.Duration) (token string, ttl time.Duration, jti string, err error)
 
-	// Verify parses and validates the JWT, returning the subject claim on success.
-	Verify(tokenStr string) (string, error)
+	// Verify parses and validates the JWT, returning the subject and jti claims on success.
+	Verify(tokenStr string) (subject, jti string, err error)
 
 	// JWKS returns the pre-built JSON Web Key Set containing the public key.
 	JWKS() []byte

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -243,10 +243,10 @@ func NewAuth0Provider(ctx context.Context, logger *zap.Logger, cfg Auth0Config) 
 // fresh ECDSA P-256 key pair is generated (suitable for single-replica deployments).
 func NewDownloadTokenIssuer(keyPath string, ttl DownloadTokenTTL) (DownloadTokenIssuer, error) {
 	if keyPath != "" {
-		return downloadtoken.LoadIssuer(keyPath, ttl)
+		return downloadtoken.LoadIssuer(keyPath, ttl, downloadtoken.DownloadAudience)
 	}
 
-	return downloadtoken.GenerateIssuer(ttl)
+	return downloadtoken.GenerateIssuer(ttl, downloadtoken.DownloadAudience)
 }
 
 // NewDownloadTokenFrontend returns the FrontendPlugin for download token issuance.


### PR DESCRIPTION
This PR makes internal/downloadtoken.Issuer serve two token classes instead of one, by moving the audience from a package constant to a per-Issuer field and adding a jti claim to every issued token. This is prep for self-issued node tokens, which reuse this same issuer with their own key and a NodeAudience instead of standing up a separate package.