### PR TITLE
feat: accept download token on /pxe/ and forward it

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -170,7 +170,8 @@ The lifetime can be requested with the `ttl` query parameter as a Go duration, e
 It must fall within `authentication.downloadTokenTTL.min` and `authentication.downloadTokenTTL.max`
 (`30s` and `8h` by default); anything else is rejected with `400`.
 
-The token is appended to an image URL as `?token=<access_token>` and is accepted only on `GET` and `HEAD` under `/image/`.
+The token is appended to an image or PXE URL as `?token=<access_token>` and is accepted only on `GET` and `HEAD` under `/image/`, and on `GET` under `/pxe/`, the only method that route registers.
+A `/pxe/` request forwards it into the asset URLs of the script it returns.
 One token covers every schematic owned by the caller, not just the URL it is used with; see [Authentication](authentication.md#download-tokens).
 
 ### `GET /.well-known/jwks.json`
@@ -554,13 +555,19 @@ Returns an iPXE script which downloads and boots Talos Linux with the specified 
 
 Access:
 
-| Auth     | `?token=`    | Machine scope | Ownership |
-| -------- | ------------ | ------------- | --------- |
-| required | not accepted | denied        | enforced  |
+| Auth     | `?token=` | Machine scope | Ownership |
+| -------- | --------- | ------------- | --------- |
+| required | accepted  | denied        | enforced  |
 
 The script embeds the schematic's kernel command line, which is schematic-derived customization, so a machine-scoped token is denied here for the same reason it cannot read a schematic definition.
-Download tokens are not accepted either.
-iPXE cannot send request headers, so an authenticated boot puts the credential in the URL: `https://<user>:<password>@pxe.talos.dev/pxe/...`, which the client encodes into `Authorization: Basic`.
+
+iPXE cannot send request headers, so the credential goes in the URL, and whichever one authenticated the request is carried into the asset URLs of the returned script:
+
+* a [download token](authentication.md#the-token-query-parameter) - `https://pxe.talos.dev/pxe/...?token=<token>` - is forwarded as `?token=` on the kernel, initramfs and UKI URLs, so no long-lived credential appears in the script.
+  The script expires with the token; nothing is minted here, so re-fetching it with an expiring token does not extend that lifetime.
+* Basic credentials - `https://<user>:<password>@pxe.talos.dev/pxe/...`, which the client encodes into `Authorization: Basic` - are embedded as userinfo on those same URLs.
+
+Either credential makes the body worth stealing, so every authenticated response from this route is `Cache-Control: no-store`.
 
 * `:schematic` is a schematic ID returned by `POST /schematics`
 * `:version` is a Talos Linux version, e.g. `v1.5.0`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -35,7 +35,7 @@ Details that decide whether a request authenticates:
   The Auth0 order is deliberate: OCI clients take the first scheme they recognize, and only the Basic form carries a usable token for those clients.
   With [browser login](#browser-login) configured, a page navigation is sent to `/login` with a `303` instead, and an XHR gets the `401` with no challenge on it.
 
-There are two alternatives to this header: the [`?token=` query parameter](#the-token-query-parameter), accepted on image downloads only, and the session cookie [browser login](#browser-login) issues.
+There are two alternatives to this header: the [`?token=` query parameter](#the-token-query-parameter), accepted on image downloads and PXE scripts only, and the session cookie [browser login](#browser-login) issues.
 
 ## htpasswd
 
@@ -186,8 +186,11 @@ Verification allows a further 30s of clock leeway.
 ### The `?token=` query parameter
 
 - Its value is the `access_token` from `POST /download-token`, and nothing else.
-- It is accepted only on `GET` and `HEAD` under `/image/`.
-  It does not work on `/pxe/`, on the `/v2/` registry, on schematic routes, or on the SBOM, VEX and scan routes: elsewhere the parameter is ignored and the [`Authorization` header](#the-authorization-header) is the only credential.
+- It is accepted only on `GET` and `HEAD` under `/image/`, and on `GET` under `/pxe/`, the only method that route registers.
+  It does not work on the `/v2/` registry, on schematic routes, or on the SBOM, VEX and scan routes: elsewhere the parameter is ignored and the [`Authorization` header](#the-authorization-header) is the only credential.
+- On `/pxe/` the same token is forwarded into the kernel, initramfs and UKI URLs of the generated script, so an iPXE boot needs no credential of its own.
+  Nothing is minted there: the script expires with the token it was fetched with, and re-fetching the script with an expiring token cannot extend that lifetime.
+  A boot fetches its assets seconds after the script, so the default `5m` covers it; request a longer lifetime for a script that is stored and reused.
 - It is not interchangeable with that header.
   A download token is signed with the factory's own key rather than issued by the provider, so it is rejected as `Authorization: Bearer`; conversely an Auth0 JWT or an htpasswd password is not a download token and does not work as `?token=`.
 - It is checked before the header.
@@ -197,6 +200,9 @@ Verification allows a further 30s of clock leeway.
 
 The subject of a download token is the caller identity — `org_id`, or the username under htpasswd — not a schematic and not a path.
 Ownership is then enforced the same way it is for any other request, which means one token grants read access to every image owned by that identity for its lifetime, not only the URL it was pasted into.
+
+Because `/pxe/` accepts one, that read access covers the kernel command line a schematic produces, and so the extensions and kernel arguments it is built from — which is why an Auth0 [machine-scoped token](#machine-credentials) is denied there.
+A leaked download token therefore exposes how the identity's images are built, not only the image bytes.
 
 Treat the URL as the credential it is.
 It carries the token in the query string, where proxy and CDN access logs tend to record it.

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -348,6 +348,26 @@ func requestIDFrom(r *http.Request) string {
 	return uuid.NewString()
 }
 
+// tokenAcceptedOn reports whether a download token may authenticate this path.
+//
+// Both paths only read artifacts owned by the token's subject: /image/ serves them,
+// and /pxe/ describes how to fetch them. Everywhere else the parameter is ignored so
+// a token cannot stand in for a full credential.
+func tokenAcceptedOn(path string) bool {
+	return strings.HasPrefix(path, "/image/") || strings.HasPrefix(path, "/pxe/")
+}
+
+// downloadTokenKey keys the verified download token on the request context.
+type downloadTokenKey struct{}
+
+// downloadTokenFromContext returns the download token that authenticated the request.
+// It is only ever set after Verify succeeded, so a caller may forward it as-is.
+func downloadTokenFromContext(ctx context.Context) (string, bool) {
+	token, ok := ctx.Value(downloadTokenKey{}).(string)
+
+	return token, ok
+}
+
 // withAuth wraps h with the auth middleware when authentication is required.
 //
 // The middleware stores the username on a context it derives internally, which
@@ -361,16 +381,17 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string, state
 	authProvider := f.options.AuthProvider
 
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
-		// Download token: if the request carries a valid JWT on an image
-		// download path, extract the subject as the authenticated identity.
+		// Download token: if the request carries a valid JWT on a path where tokens
+		// are accepted, extract the subject as the authenticated identity.
 		// Ownership is enforced normally by schematicFactory.Get() since the
-		// JWT subject is set on the context. Tokens are only accepted on
-		// GET/HEAD /image/ to prevent use on other endpoints.
-		if f.options.DownloadTokenIssuer != nil && (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.HasPrefix(r.URL.Path, "/image/") && r.URL.RawQuery != "" {
+		// JWT subject is set on the context. The verified token is also put on the
+		// context so handlePXE can forward it into the asset URLs it emits.
+		if f.options.DownloadTokenIssuer != nil && (r.Method == http.MethodGet || r.Method == http.MethodHead) && tokenAcceptedOn(r.URL.Path) && r.URL.RawQuery != "" {
 			if tokenStr := r.URL.Query().Get("token"); tokenStr != "" {
 				if sub, err := f.options.DownloadTokenIssuer.Verify(tokenStr); err == nil {
 					*username = sub
 					ctx = authProvider.ContextWithUsername(ctx, sub)
+					ctx = context.WithValue(ctx, downloadTokenKey{}, tokenStr)
 
 					return h(ctx, w, r, p)
 				}

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -77,10 +77,24 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, r *http
 		return err
 	}
 
-	// Embed credentials in image asset URLs so iPXE can authenticate when fetching kernel/initramfs.
+	// Image asset URLs carry a credential so iPXE can authenticate when fetching kernel/initramfs:
+	// the download token this request was authenticated with, or the Basic credentials it arrived
+	// with. Forwarding the token as-is means the script expires with it; nothing is minted here.
 	imageBaseURL := f.options.ExternalPXEURL
+
 	if f.options.AuthProvider != nil {
-		if username, password, ok := r.BasicAuth(); ok {
+		// The script body is a bearer credential whichever branch below runs, and the Basic
+		// credentials it may embed do not expire, so the response must never be stored. The
+		// token branch of withAuth never reaches pinCacheControl, and the htpasswd provider
+		// pins nothing, so this is the only place that sets it.
+		w.Header().Set("Cache-Control", "no-store")
+
+		if token, ok := downloadTokenFromContext(ctx); ok {
+			u := *f.options.ExternalPXEURL
+			// JoinPath copies the URL and rewrites only the path, so the query survives.
+			u.RawQuery = url.Values{"token": {token}}.Encode()
+			imageBaseURL = &u
+		} else if username, password, ok := r.BasicAuth(); ok {
 			u := *f.options.ExternalPXEURL
 			u.User = url.UserPassword(username, password)
 			imageBaseURL = &u

--- a/internal/frontend/http/templates/llms.txt
+++ b/internal/frontend/http/templates/llms.txt
@@ -163,7 +163,7 @@ Returns a vulnerability scan report. `:report` suffix: `.json`, `.table`, `.sari
 
 ### POST /download-token
 
-Registered only when Enterprise authentication is enabled. Returns a short-lived `{access_token, token_type, expires_in}` JWT for authenticated image URLs. Append it as `?token=<access_token>` only on `GET` or `HEAD /image/...`.
+Registered only when Enterprise authentication is enabled. Returns a short-lived `{access_token, token_type, expires_in}` JWT for authenticated image URLs. Append it as `?token=<access_token>` only on `GET` or `HEAD /image/...`, or on `GET /pxe/...`, which forwards it into the asset URLs of the script it returns.
 
 ### GET /.well-known/jwks.json
 

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -545,6 +546,12 @@ func testDownloadTokens(ctx context.Context, t *testing.T, baseURL string) {
 		assertRequiresAuth(t, resp)
 	})
 
+	t.Run("PXE", func(t *testing.T) {
+		t.Parallel()
+
+		testDownloadTokenPXE(ctx, t, baseURL, schematicID)
+	})
+
 	t.Run("JWKSEndpoint", func(t *testing.T) {
 		t.Parallel()
 
@@ -568,6 +575,92 @@ func testDownloadTokens(ctx context.Context, t *testing.T, baseURL string) {
 
 		require.NoError(t, json.Unmarshal(body, &doc))
 		assert.NotEmpty(t, doc.Keys)
+	})
+}
+
+// testDownloadTokenPXE verifies that /pxe accepts a download token and forwards that
+// same token into the asset URLs of the script it returns, so a boot needs no
+// credential of its own anywhere.
+func testDownloadTokenPXE(ctx context.Context, t *testing.T, baseURL, schematicID string) {
+	t.Helper()
+
+	const talosVersion = "v1.11.0"
+
+	for _, test := range []struct {
+		name       string
+		path       string
+		directives []string
+	}{
+		{name: "standard", path: "metal-amd64", directives: []string{"kernel", "initrd"}},
+		{name: "secureboot", path: "metal-amd64-secureboot", directives: []string{"kernel"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			token := getDownloadToken(ctx, t, baseURL)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+				baseURL+"/pxe/"+schematicID+"/"+talosVersion+"/"+test.path+"?token="+token, nil)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"),
+				"the script body is a bearer credential")
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			script := string(body)
+
+			if _, password := authCredentials(); password != "" {
+				assert.NotContains(t, script, password,
+					"the token path must not embed userinfo credentials")
+			}
+
+			assetURLs := pxeAssetURLs(t, script, test.directives...)
+			require.Len(t, assetURLs, len(test.directives))
+
+			for _, assetURL := range assetURLs {
+				parsed, err := url.Parse(assetURL)
+				require.NoError(t, err)
+
+				assert.Equal(t, token, parsed.Query().Get("token"))
+
+				// The forwarded token has to actually authenticate the asset fetch,
+				// which is the only assertion proving the script can boot.
+				assetReq, err := http.NewRequestWithContext(ctx, http.MethodHead, assetURL, nil)
+				require.NoError(t, err)
+
+				assetResp, err := http.DefaultClient.Do(assetReq) //nolint:bodyclose // closed by the cleanup below
+				require.NoError(t, err)
+
+				t.Cleanup(func() { assetResp.Body.Close() }) //nolint:errcheck
+
+				assert.Equal(t, http.StatusOK, assetResp.StatusCode, "fetching %s", assetURL)
+			}
+		})
+	}
+
+	t.Run("tampered", func(t *testing.T) {
+		t.Parallel()
+
+		tampered := tamperSignature(t, getDownloadToken(ctx, t, baseURL))
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			baseURL+"/pxe/"+schematicID+"/"+talosVersion+"/metal-amd64?token="+tampered, nil)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+		assertRequiresAuth(t, resp)
 	})
 }
 

--- a/internal/integration/pxe_test.go
+++ b/internal/integration/pxe_test.go
@@ -41,13 +41,19 @@ func downloadPXE(ctx context.Context, t *testing.T, baseURL string, schematicID,
 		resp.Body.Close()
 	})
 
+	if username, _ := authCredentials(); username != "" {
+		assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"),
+			"the script embeds the Basic credentials it was fetched with")
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	return string(body)
 }
 
-func checkPXENoRedirect(ctx context.Context, t *testing.T, pxe string, files ...string) {
+// pxeAssetURLs returns the asset URL of each named iPXE directive ("kernel", "initrd").
+func pxeAssetURLs(t *testing.T, pxe string, directives ...string) []string {
 	t.Helper()
 
 	scanner := bufio.NewScanner(strings.NewReader(pxe))
@@ -57,8 +63,8 @@ func checkPXENoRedirect(ctx context.Context, t *testing.T, pxe string, files ...
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
-		for _, file := range files {
-			if strings.HasPrefix(line, file+" ") {
+		for _, directive := range directives {
+			if strings.HasPrefix(line, directive+" ") {
 				fields := strings.Fields(line)
 				if len(fields) > 1 {
 					urls = append(urls, fields[1])
@@ -69,7 +75,13 @@ func checkPXENoRedirect(ctx context.Context, t *testing.T, pxe string, files ...
 
 	require.NoError(t, scanner.Err())
 
-	for _, testURL := range urls {
+	return urls
+}
+
+func checkPXENoRedirect(ctx context.Context, t *testing.T, pxe string, files ...string) {
+	t.Helper()
+
+	for _, testURL := range pxeAssetURLs(t, pxe, files...) {
 		downloadNoRedirect(ctx, t, testURL)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -177,8 +177,9 @@ func (c *Client) OverlaysVersions(ctx context.Context, talosVersion string) ([]O
 }
 
 // DownloadToken requests a short-lived JWT download token scoped to the
-// authenticated caller's identity. The token can be appended as ?token= to
-// any image download URL; one token covers all schematics owned by the caller.
+// authenticated caller's identity. The token can be appended as ?token= to any
+// image download URL, and to a PXE script URL, which forwards it into the asset
+// URLs of the script; one token covers all schematics owned by the caller.
 //
 // A positive ttl requests that lifetime, which the server accepts only within its
 // configured bounds; zero or less takes the server default.


### PR DESCRIPTION
iPXE cannot send request headers, so a script fetched with a download
token previously had to fall back to Basic userinfo in its asset URLs,
putting a non-expiring credential in the boot script. Forwarding the
same token as ?token= keeps the script's lifetime bound to the token;
nothing is minted, so re-fetching cannot extend it.

- tokenAcceptedOn now covers /pxe/, GET only (HEAD is unregistered)
- Cache-Control: no-store on every authenticated /pxe/ response, which
  also stops the Basic-auth script body from being cached

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
