### PR TITLE
feat(enterprise): add self-issued node tokens

### DIFF
--- a/cmd/image-factory/cmd/options.go
+++ b/cmd/image-factory/cmd/options.go
@@ -62,7 +62,15 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("audit.mode must be one of %v, got %q", auditModeOptions, o.Audit.Mode)
 	}
 
-	return o.Authentication.validate()
+	if err := o.Authentication.validate(); err != nil {
+		return err
+	}
+
+	if o.Authentication.Enabled {
+		return o.Enterprise.NodeTokens.validate()
+	}
+
+	return nil
 }
 
 // validate checks the settings required by the selected provider, so that a misconfiguration
@@ -107,13 +115,19 @@ func (o AuthenticationOptions) validate() error {
 // validate checks that the download token lifetime bounds are sane and contain the default,
 // so that a bad range fails at startup rather than on the first token request.
 func (o DownloadTokenTTL) validate() error {
+	return validateTTLBounds("authentication.downloadTokenTTL", o.Min, o.Max, o.Default)
+}
+
+// validateTTLBounds checks that a [min, max] TTL range is sane and contains default. prefix
+// identifies the config path in error messages, e.g. "authentication.downloadTokenTTL".
+func validateTTLBounds(prefix string, minTTL, maxTTL, defaultTTL time.Duration) error {
 	switch {
-	case o.Min <= 0:
-		return fmt.Errorf("authentication.downloadTokenTTL.min must be positive, got %s", o.Min)
-	case o.Max < o.Min:
-		return fmt.Errorf("authentication.downloadTokenTTL.max %s is below .min %s", o.Max, o.Min)
-	case o.Default < o.Min || o.Default > o.Max:
-		return fmt.Errorf("authentication.downloadTokenTTL.default %s is outside [%s, %s]", o.Default, o.Min, o.Max)
+	case minTTL <= 0:
+		return fmt.Errorf("%s.min must be positive, got %s", prefix, minTTL)
+	case maxTTL < minTTL:
+		return fmt.Errorf("%s.max %s is below .min %s", prefix, maxTTL, minTTL)
+	case defaultTTL < minTTL || defaultTTL > maxTTL:
+		return fmt.Errorf("%s.default %s is outside [%s, %s]", prefix, defaultTTL, minTTL, maxTTL)
 	default:
 		return nil
 	}
@@ -758,6 +772,64 @@ type EnterpriseOptions struct {
 
 	// VEX contains configuration for VEX data fetching.
 	VEX VEXOptions `koanf:"vex"`
+
+	// NodeTokens contains configuration for self-issued node token management.
+	NodeTokens NodeTokenOptions `koanf:"nodeTokens"`
+}
+
+// NodeTokenOptions configures self-issued node token issuance, storage, and verification.
+type NodeTokenOptions struct {
+	// KeyPath is an optional path to a PEM-encoded ECDSA P-256 private key for signing node tokens.
+	// Kept separate from the download-token key so compromising one doesn't compromise the other.
+	// If unset, a fresh key is generated at startup, which only works for single-replica deployments.
+	KeyPath string `koanf:"keyPath"`
+
+	// Storage is the OCI repository used to persist the per-org node-token index
+	// (the list of active tokens; presence in the index is what makes a token valid).
+	Storage OCIRepositoryOptions `koanf:"storage"`
+
+	// TTL bounds the lifetime of issued node tokens.
+	TTL NodeTokenTTL `koanf:"ttl"`
+
+	// VerificationCacheRefreshInterval bounds how stale the in-memory verification cache may be before it's refreshed from storage.
+	// This is also the bound on how long a revoked token may keep working after revocation.
+	VerificationCacheRefreshInterval time.Duration `koanf:"verificationCacheRefreshInterval"`
+
+	// MaxPerOrg caps how many node tokens an org may have active at once.
+	MaxPerOrg int `koanf:"maxPerOrg"`
+}
+
+// NodeTokenTTL defines the validity duration for node tokens.
+//
+// Unlike download tokens, a node token isn't refreshed once it's written into a Talos machine
+// config, so its default lifetime is expected to be long (up to Max).
+type NodeTokenTTL struct {
+	// Max is the longest validity duration a caller may request.
+	Max time.Duration `koanf:"max"`
+
+	// Min is the shortest validity duration a caller may request.
+	Min time.Duration `koanf:"min"`
+
+	// Default is the validity duration granted when the caller requests no explicit TTL.
+	Default time.Duration `koanf:"default"`
+}
+
+// validate checks that the node token lifetime bounds are sane and contain the default,
+// and that the per-org cap is positive, so a bad config fails at startup rather than on
+// the first node-token request.
+func (o NodeTokenOptions) validate() error {
+	if err := validateTTLBounds("enterprise.nodeTokens.ttl", o.TTL.Min, o.TTL.Max, o.TTL.Default); err != nil {
+		return err
+	}
+
+	switch {
+	case o.MaxPerOrg <= 0:
+		return fmt.Errorf("enterprise.nodeTokens.maxPerOrg must be positive, got %d", o.MaxPerOrg)
+	case o.VerificationCacheRefreshInterval <= 0:
+		return fmt.Errorf("enterprise.nodeTokens.verificationCacheRefreshInterval must be positive, got %s", o.VerificationCacheRefreshInterval)
+	default:
+		return nil
+	}
 }
 
 // ExtraExtensionsOptions configures custom extensions offered alongside the official ones.
@@ -920,6 +992,20 @@ var DefaultOptions = Options{
 				Namespace:  "siderolabs/image-factory",
 				Repository: "spdx-cache",
 			},
+		},
+		NodeTokens: NodeTokenOptions{
+			Storage: OCIRepositoryOptions{
+				Registry:   "ghcr.io",
+				Namespace:  "siderolabs/image-factory",
+				Repository: "node-tokens",
+			},
+			TTL: NodeTokenTTL{
+				Default: 365 * 24 * time.Hour,
+				Max:     365 * 24 * time.Hour,
+				Min:     24 * time.Hour,
+			},
+			VerificationCacheRefreshInterval: 5 * time.Minute,
+			MaxPerOrg:                        10,
 		},
 		Scanner: ScannerOptions{
 			DatabaseURL:      "https://grype.anchore.io/databases",

--- a/cmd/image-factory/cmd/options_test.go
+++ b/cmd/image-factory/cmd/options_test.go
@@ -31,6 +31,7 @@ func auth0OptsWithSessionKey(sessionKey string) cmd.Options {
 				SessionKey: sessionKey,
 			},
 		},
+		Enterprise: cmd.EnterpriseOptions{NodeTokens: cmd.DefaultOptions.Enterprise.NodeTokens},
 	}
 }
 
@@ -215,6 +216,7 @@ func TestOCIRepositoryOptions(t *testing.T) {
 	})
 }
 
+//nolint:maintidx
 func TestOptionsValidate(t *testing.T) {
 	t.Parallel()
 
@@ -303,7 +305,25 @@ func TestOptionsValidate(t *testing.T) {
 					Auth0:            cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
 					DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
 				},
+				Enterprise: cmd.EnterpriseOptions{NodeTokens: cmd.DefaultOptions.Enterprise.NodeTokens},
 			},
+		},
+		{
+			name: "authentication enabled without a positive nodeTokens maxPerOrg",
+			opts: cmd.Options{
+				HTTP: cmd.HTTPOptions{ExternalURL: "https://factory.sidero.dev/"},
+				Authentication: cmd.AuthenticationOptions{
+					Enabled:          true,
+					Provider:         "auth0",
+					Auth0:            cmd.Auth0Options{Domain: "tenant.auth0.com", Audience: "https://factory.sidero.dev"},
+					DownloadTokenTTL: cmd.DefaultOptions.Authentication.DownloadTokenTTL,
+				},
+				Enterprise: cmd.EnterpriseOptions{NodeTokens: cmd.NodeTokenOptions{
+					TTL:                              cmd.DefaultOptions.Enterprise.NodeTokens.TTL,
+					VerificationCacheRefreshInterval: cmd.DefaultOptions.Enterprise.NodeTokens.VerificationCacheRefreshInterval,
+				}},
+			},
+			expectError: "enterprise.nodeTokens.maxPerOrg must be positive",
 		},
 		{
 			name: "download token TTL without bounds",

--- a/cmd/image-factory/cmd/service.go
+++ b/cmd/image-factory/cmd/service.go
@@ -126,7 +126,9 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 		return err
 	}
 
-	enterprisePlugins, spdxSource, err := buildEnterprisePlugins(ctx, eg, logger, configFactory, artifactsManager, assetBuilder, cacheImageSigner, authProvider, downloadTokenIssuer, opts)
+	enterprisePlugins, spdxSource, nodeTokenVerifier, err := buildEnterprisePlugins(
+		ctx, eg, logger, configFactory, artifactsManager, assetBuilder, cacheImageSigner, authProvider, downloadTokenIssuer, opts,
+	)
 	if err != nil {
 		return err
 	}
@@ -158,6 +160,7 @@ func RunFactory(ctx context.Context, logger *zap.Logger, opts Options) error {
 
 	frontendOptions.AuditSink = auditSink
 	frontendOptions.DownloadTokenIssuer = downloadTokenIssuer
+	frontendOptions.NodeTokenVerifier = nodeTokenVerifier
 	frontendOptions.InstallerSBOMSource = spdxSource
 
 	signatureWriter, err := buildSignatureWriter(logger, frontendOptions.CacheImageSigner, assetCache)
@@ -294,9 +297,9 @@ func buildEnterprisePlugins(
 	authProvider enterprise.AuthProvider,
 	downloadTokenIssuer enterprise.DownloadTokenIssuer,
 	opts Options,
-) ([]enterprise.FrontendPlugin, enterprise.SPDXSource, error) {
+) ([]enterprise.FrontendPlugin, enterprise.SPDXSource, enterprise.NodeTokenVerifier, error) {
 	if !enterprise.Enabled() {
-		return nil, nil, nil //nolint:nilnil
+		return nil, nil, nil, nil
 	}
 
 	spdxFrontend, spdxSource, err := enterprise.NewSpdxFrontend(logger, enterprise.SPDXOptions{
@@ -312,12 +315,12 @@ func buildEnterprisePlugins(
 		RegistryRefreshInterval: opts.Artifacts.RefreshInterval,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize SPDX frontend: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to initialize SPDX frontend: %w", err)
 	}
 
 	imageVerifyOptions, err := buildImageVerifyOptions(logger, opts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	vexFrontend, vexSource, err := enterprise.NewVEXFrontend(ctx, eg, logger, enterprise.VEXOptions{
@@ -331,7 +334,7 @@ func buildEnterprisePlugins(
 		VerifyOptions:    imageVerifyOptions,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize VEX frontend: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to initialize VEX frontend: %w", err)
 	}
 
 	scannerFrontend, err := enterprise.NewScannerFrontend(ctx, eg, logger, enterprise.ScannerOptions{
@@ -347,7 +350,7 @@ func buildEnterprisePlugins(
 		CacheCapacity:    opts.Enterprise.Scanner.Cache.Capacity,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize scanner frontend: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to initialize scanner frontend: %w", err)
 	}
 
 	plugins := []enterprise.FrontendPlugin{spdxFrontend, vexFrontend, scannerFrontend}
@@ -360,7 +363,32 @@ func buildEnterprisePlugins(
 		)
 	}
 
-	return plugins, spdxSource, nil
+	var nodeTokenVerifier enterprise.NodeTokenVerifier
+
+	if authProvider != nil {
+		var nodeTokenPlugins []enterprise.FrontendPlugin
+
+		nodeTokenPlugins, nodeTokenVerifier, err = enterprise.NewNodeTokenFrontends(authProvider, enterprise.NodeTokenOptions{
+			KeyPath: opts.Enterprise.NodeTokens.KeyPath,
+			TTL: enterprise.DownloadTokenTTL{
+				Default: opts.Enterprise.NodeTokens.TTL.Default,
+				Min:     opts.Enterprise.NodeTokens.TTL.Min,
+				Max:     opts.Enterprise.NodeTokens.TTL.Max,
+			},
+			StorageRepository:                opts.Enterprise.NodeTokens.Storage.String(),
+			StorageInsecure:                  opts.Enterprise.NodeTokens.Storage.Insecure,
+			RemoteOptions:                    remoteOptions(),
+			VerificationCacheRefreshInterval: opts.Enterprise.NodeTokens.VerificationCacheRefreshInterval,
+			MaxPerOrg:                        opts.Enterprise.NodeTokens.MaxPerOrg,
+		})
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to initialize node token frontends: %w", err)
+		}
+
+		plugins = append(plugins, nodeTokenPlugins...)
+	}
+
+	return plugins, spdxSource, nodeTokenVerifier, nil
 }
 
 func buildFrontendOptions(cacheImageSigner signer.Signer, authProvider enterprise.AuthProvider, opts Options) (frontendhttp.Options, error) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1274,6 +1274,121 @@ Capacity caps the number of cached objects before LRU eviction.
 
 ---
 
+### `enterprise.nodeTokens`
+
+NodeTokens contains configuration for self-issued node token management.
+
+---
+
+### `enterprise.nodeTokens.keyPath`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_NODETOKENS_KEYPATH`
+
+KeyPath is an optional path to a PEM-encoded ECDSA P-256 private key for signing node tokens.
+Kept separate from the download-token key so compromising one doesn't compromise the other.
+If unset, a fresh key is generated at startup, which only works for single-replica deployments.
+
+---
+
+### `enterprise.nodeTokens.storage`
+
+Storage is the OCI repository used to persist the per-org node-token index
+(the list of active tokens; presence in the index is what makes a token valid).
+
+---
+
+### `enterprise.nodeTokens.storage.registry`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_NODETOKENS_STORAGE_REGISTRY`
+
+Registry is the hostname of the container registry, e.g., `ghcr.io`.
+This is where images are stored.
+
+---
+
+### `enterprise.nodeTokens.storage.namespace`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_NODETOKENS_STORAGE_NAMESPACE`
+
+Namespace is the repository namespace or organization within the registry, e.g., `sidero-labs`.
+Some registries allow repositories without a namespace.
+
+---
+
+### `enterprise.nodeTokens.storage.repository`
+
+- **Type:** `string`
+- **Env:** `ENTERPRISE_NODETOKENS_STORAGE_REPOSITORY`
+
+Repository is the name of the repository inside the namespace, e.g., `talos`.
+Combined with Registry and Namespace, it forms the fully qualified repository path.
+
+---
+
+### `enterprise.nodeTokens.storage.insecure`
+
+- **Type:** `bool`
+- **Env:** `ENTERPRISE_NODETOKENS_STORAGE_INSECURE`
+
+Insecure allows connections to registries over HTTP or with invalid TLS certificates.
+
+---
+
+### `enterprise.nodeTokens.ttl`
+
+TTL bounds the lifetime of issued node tokens.
+
+---
+
+### `enterprise.nodeTokens.ttl.max`
+
+- **Type:** `time.Duration`
+- **Env:** `ENTERPRISE_NODETOKENS_TTL_MAX`
+
+Max is the longest validity duration a caller may request.
+
+---
+
+### `enterprise.nodeTokens.ttl.min`
+
+- **Type:** `time.Duration`
+- **Env:** `ENTERPRISE_NODETOKENS_TTL_MIN`
+
+Min is the shortest validity duration a caller may request.
+
+---
+
+### `enterprise.nodeTokens.ttl.default`
+
+- **Type:** `time.Duration`
+- **Env:** `ENTERPRISE_NODETOKENS_TTL_DEFAULT`
+
+Default is the validity duration granted when the caller requests no explicit TTL.
+
+---
+
+### `enterprise.nodeTokens.verificationCacheRefreshInterval`
+
+- **Type:** `time.Duration`
+- **Env:** `ENTERPRISE_NODETOKENS_VERIFICATIONCACHEREFRESHINTERVAL`
+
+VerificationCacheRefreshInterval bounds how stale the in-memory verification cache may be before it's refreshed from storage.
+This is also the bound on how long a revoked token may keep working after revocation.
+
+---
+
+### `enterprise.nodeTokens.maxPerOrg`
+
+- **Type:** `int`
+- **Env:** `ENTERPRISE_NODETOKENS_MAXPERORG`
+
+MaxPerOrg caps how many node tokens an org may have active at once.
+
+---
+
 ### `registry`
 
 Registry contains low-level tuning for the registry client (pull/push concurrency, debugging).
@@ -1441,6 +1556,19 @@ enterprise:
             namespace: ""
             registry: ""
             repository: ""
+    nodeTokens:
+        keyPath: ""
+        maxPerOrg: 10
+        storage:
+            insecure: false
+            namespace: siderolabs/image-factory
+            registry: ghcr.io
+            repository: node-tokens
+        ttl:
+            default: 8760h0m0s
+            max: 8760h0m0s
+            min: 24h0m0s
+        verificationCacheRefreshInterval: 5m0s
     scanner:
         cache:
             capacity: 4096
@@ -1573,6 +1701,16 @@ IF_ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_INSECURE=false
 IF_ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_NAMESPACE=
 IF_ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REGISTRY=
 IF_ENTERPRISE_EXTRAEXTENSIONS_MANIFEST_REPOSITORY=
+IF_ENTERPRISE_NODETOKENS_KEYPATH=
+IF_ENTERPRISE_NODETOKENS_MAXPERORG=10
+IF_ENTERPRISE_NODETOKENS_STORAGE_INSECURE=false
+IF_ENTERPRISE_NODETOKENS_STORAGE_NAMESPACE=siderolabs/image-factory
+IF_ENTERPRISE_NODETOKENS_STORAGE_REGISTRY=ghcr.io
+IF_ENTERPRISE_NODETOKENS_STORAGE_REPOSITORY=node-tokens
+IF_ENTERPRISE_NODETOKENS_TTL_DEFAULT=8760h0m0s
+IF_ENTERPRISE_NODETOKENS_TTL_MAX=8760h0m0s
+IF_ENTERPRISE_NODETOKENS_TTL_MIN=24h0m0s
+IF_ENTERPRISE_NODETOKENS_VERIFICATIONCACHEREFRESHINTERVAL=5m0s
 IF_ENTERPRISE_SCANNER_CACHE_CAPACITY=4096
 IF_ENTERPRISE_SCANNER_CACHE_TTL=15m0s
 IF_ENTERPRISE_SCANNER_DATABASEROOTDIR=/var/lib/grype

--- a/enterprise/nodetoken/frontend.go
+++ b/enterprise/nodetoken/frontend.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+// Package nodetoken provides HTTP handlers and backing storage for self-serve, self-issued
+// node token management.
+package nodetoken
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// maxCreateBodyBytes bounds the /node-tokens POST body, which only ever needs to carry a name.
+const maxCreateBodyBytes = 1 << 12
+
+// NodeTokenManager is the subset of Manager used by the HTTP frontends.
+type NodeTokenManager interface {
+	CreateNodeToken(ctx context.Context, orgID, name string) (id, token string, err error)
+	ListNodeTokens(ctx context.Context, orgID string) ([]Record, error)
+	RevokeNodeToken(ctx context.Context, orgID, id string) error
+}
+
+// AuthProvider is a subset of enterprise.AuthProvider used for identity extraction.
+// Defined locally to avoid an import cycle with pkg/enterprise.
+type AuthProvider interface {
+	UsernameFromContext(ctx context.Context) (string, bool)
+}
+
+// ListCreateFrontend is the FrontendPlugin that lists and creates node tokens.
+type ListCreateFrontend struct {
+	manager   NodeTokenManager
+	authProv  AuthProvider
+	maxPerOrg int
+}
+
+// NewListCreateFrontend creates the list/create node-token plugin.
+func NewListCreateFrontend(manager NodeTokenManager, authProv AuthProvider, maxPerOrg int) *ListCreateFrontend {
+	return &ListCreateFrontend{
+		manager:   manager,
+		authProv:  authProv,
+		maxPerOrg: maxPerOrg,
+	}
+}
+
+// Methods implements enterprise.FrontendPlugin.
+func (f *ListCreateFrontend) Methods() []string {
+	return []string{http.MethodGet, http.MethodPost}
+}
+
+// Path implements enterprise.FrontendPlugin.
+func (f *ListCreateFrontend) Path() string {
+	return "/node-tokens"
+}
+
+// requireOrgID extracts the authenticated org ID from ctx, or writes a 401 and reports ok=false.
+func requireOrgID(ctx context.Context, w http.ResponseWriter, authProv AuthProvider) (orgID string, ok bool) {
+	orgID, ok = authProv.UsernameFromContext(ctx)
+	if !ok {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+	}
+
+	return orgID, ok
+}
+
+// writeJSON sets the standard no-store JSON response headers and encodes v.
+func writeJSON(w http.ResponseWriter, v any) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+
+	return json.NewEncoder(w).Encode(v)
+}
+
+// Handle implements enterprise.FrontendPlugin.
+func (f *ListCreateFrontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, _ httprouter.Params) error {
+	orgID, ok := requireOrgID(ctx, w, f.authProv)
+	if !ok {
+		return nil
+	}
+
+	if r.Method == http.MethodPost {
+		return f.create(ctx, w, r, orgID)
+	}
+
+	return f.list(ctx, w, orgID)
+}
+
+func (f *ListCreateFrontend) list(ctx context.Context, w http.ResponseWriter, orgID string) error {
+	tokens, err := f.manager.ListNodeTokens(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(w, struct {
+		Tokens []Record `json:"tokens"`
+	}{Tokens: tokens})
+}
+
+// decodeCreateBody returns ok=false for both a malformed body and an empty name; the caller
+// responds with the same 400 either way, so the two don't need to be told apart.
+func decodeCreateBody(r *http.Request) (name string, ok bool) {
+	var body struct {
+		Name string `json:"name"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxCreateBodyBytes)).Decode(&body); err != nil {
+		return "", false
+	}
+
+	name = strings.TrimSpace(body.Name)
+
+	return name, name != ""
+}
+
+func (f *ListCreateFrontend) create(ctx context.Context, w http.ResponseWriter, r *http.Request, orgID string) error {
+	name, ok := decodeCreateBody(r)
+	if !ok {
+		http.Error(w, `a non-empty "name" is required`, http.StatusBadRequest)
+
+		return nil
+	}
+
+	// Racy against a concurrent create from the same org; a low-frequency admin action, so a
+	// retry after hitting the cap is an acceptable cost of not synchronizing this check.
+	existing, err := f.manager.ListNodeTokens(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	if len(existing) >= f.maxPerOrg {
+		http.Error(w, "node token limit reached for this organization", http.StatusConflict)
+
+		return nil
+	}
+
+	id, token, err := f.manager.CreateNodeToken(ctx, orgID, name)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(w, struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Token string `json:"token"`
+		OrgID string `json:"org_id"`
+	}{
+		ID:    id,
+		Name:  name,
+		Token: token,
+		OrgID: orgID,
+	})
+}
+
+// RevokeFrontend is the FrontendPlugin that revokes a node token.
+type RevokeFrontend struct {
+	manager  NodeTokenManager
+	authProv AuthProvider
+}
+
+// NewRevokeFrontend creates the node-token revocation plugin.
+func NewRevokeFrontend(manager NodeTokenManager, authProv AuthProvider) *RevokeFrontend {
+	return &RevokeFrontend{manager: manager, authProv: authProv}
+}
+
+// Methods implements enterprise.FrontendPlugin.
+func (f *RevokeFrontend) Methods() []string {
+	return []string{http.MethodPost}
+}
+
+// Path implements enterprise.FrontendPlugin.
+func (f *RevokeFrontend) Path() string {
+	return "/node-tokens/:id/revoke"
+}
+
+// Handle implements enterprise.FrontendPlugin.
+func (f *RevokeFrontend) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+	orgID, ok := requireOrgID(ctx, w, f.authProv)
+	if !ok {
+		return nil
+	}
+
+	err := f.manager.RevokeNodeToken(ctx, orgID, p.ByName("id"))
+
+	switch {
+	case err == nil:
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusNoContent)
+
+		return nil
+	case errors.Is(err, ErrNotFound):
+		http.Error(w, "node token not found", http.StatusNotFound)
+
+		return nil
+	default:
+		return err
+	}
+}

--- a/enterprise/nodetoken/frontend_test.go
+++ b/enterprise/nodetoken/frontend_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package nodetoken_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/enterprise/nodetoken"
+)
+
+const testOrgID = "org_test"
+
+var errBoom = errors.New("boom")
+
+type fakeAuthProvider struct {
+	orgID string
+	ok    bool
+}
+
+func (f fakeAuthProvider) UsernameFromContext(context.Context) (string, bool) {
+	return f.orgID, f.ok
+}
+
+type fakeManager struct {
+	listErr      error
+	createErr    error
+	revokeErr    error
+	createdName  string
+	createdOrgID string
+	revokedOrgID string
+	revokedID    string
+	tokens       []nodetoken.Record
+}
+
+func (f *fakeManager) ListNodeTokens(_ context.Context, _ string) ([]nodetoken.Record, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+
+	return f.tokens, nil
+}
+
+func (f *fakeManager) CreateNodeToken(_ context.Context, orgID, name string) (string, string, error) {
+	if f.createErr != nil {
+		return "", "", f.createErr
+	}
+
+	f.createdOrgID = orgID
+	f.createdName = name
+
+	return "new-token-id", "new-token-value", nil
+}
+
+func (f *fakeManager) RevokeNodeToken(_ context.Context, orgID, id string) error {
+	f.revokedOrgID = orgID
+	f.revokedID = id
+
+	return f.revokeErr
+}
+
+// doRequest runs a request through f.Handle and returns the recorded response, asserting that
+// Handle itself returned no error (i.e. the plugin answered the request rather than deferring
+// to the frontend's generic error handling).
+func doRequest(t *testing.T, f interface {
+	Handle(context.Context, http.ResponseWriter, *http.Request, httprouter.Params) error
+}, method, target, body string, params httprouter.Params,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), method, target, strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	err := f.Handle(t.Context(), w, r, params)
+	require.NoError(t, err)
+
+	return w
+}
+
+// TestListCreateFrontendListHappyPath checks GET returns the manager's node tokens as JSON.
+func TestListCreateFrontendListHappyPath(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{tokens: []nodetoken.Record{{ID: "abc", Name: "my-node"}}}
+	f := nodetoken.NewListCreateFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	w := doRequest(t, f, http.MethodGet, "/node-tokens", "", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Tokens []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"tokens"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Tokens, 1)
+	require.Equal(t, "abc", resp.Tokens[0].ID)
+	require.Equal(t, "my-node", resp.Tokens[0].Name)
+}
+
+// TestListCreateFrontendListRequiresAuth checks GET without a resolvable identity is rejected.
+func TestListCreateFrontendListRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	f := nodetoken.NewListCreateFrontend(&fakeManager{}, fakeAuthProvider{ok: false}, 10)
+
+	w := doRequest(t, f, http.MethodGet, "/node-tokens", "", nil)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestListCreateFrontendCreateHappyPath checks POST creates a token and returns it exactly once.
+func TestListCreateFrontendCreateHappyPath(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{}
+	f := nodetoken.NewListCreateFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens", `{"name":"my-node"}`, nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, testOrgID, mgr.createdOrgID)
+	require.Equal(t, "my-node", mgr.createdName)
+
+	var resp struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Token string `json:"token"`
+		OrgID string `json:"org_id"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "new-token-id", resp.ID)
+	require.Equal(t, "my-node", resp.Name)
+	require.Equal(t, "new-token-value", resp.Token)
+	require.Equal(t, testOrgID, resp.OrgID)
+}
+
+// TestListCreateFrontendCreateRejectsEmptyName checks an empty name is rejected before create.
+func TestListCreateFrontendCreateRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{}
+	f := nodetoken.NewListCreateFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens", `{"name":""}`, nil)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Empty(t, mgr.createdName)
+}
+
+// TestListCreateFrontendCreateRejectsMalformedBody checks non-JSON is rejected before create.
+func TestListCreateFrontendCreateRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{}
+	f := nodetoken.NewListCreateFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens", `not json`, nil)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestListCreateFrontendCreateRejectsAtCap checks create is refused once the org is at maxPerOrg.
+func TestListCreateFrontendCreateRejectsAtCap(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{tokens: []nodetoken.Record{{ID: "a"}, {ID: "b"}}}
+	f := nodetoken.NewListCreateFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true}, 2)
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens", `{"name":"my-node"}`, nil)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Empty(t, mgr.createdName)
+}
+
+// TestListCreateFrontendListSurfacesManagerError checks a list failure surfaces as an error.
+func TestListCreateFrontendListSurfacesManagerError(t *testing.T) {
+	t.Parallel()
+
+	f := nodetoken.NewListCreateFrontend(&fakeManager{listErr: errBoom}, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/node-tokens", nil)
+	w := httptest.NewRecorder()
+
+	err := f.Handle(t.Context(), w, r, nil)
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestListCreateFrontendCreateSurfacesManagerError checks a create failure surfaces as an error.
+func TestListCreateFrontendCreateSurfacesManagerError(t *testing.T) {
+	t.Parallel()
+
+	f := nodetoken.NewListCreateFrontend(&fakeManager{createErr: errBoom}, fakeAuthProvider{orgID: testOrgID, ok: true}, 10)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/node-tokens", strings.NewReader(`{"name":"my-node"}`))
+	w := httptest.NewRecorder()
+
+	err := f.Handle(t.Context(), w, r, nil)
+	require.ErrorIs(t, err, errBoom)
+}
+
+// TestRevokeFrontendHappyPath checks POST revokes the named token for the caller's org.
+func TestRevokeFrontendHappyPath(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{}
+	f := nodetoken.NewRevokeFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true})
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens/mytoken/revoke", "", httprouter.Params{{Key: "id", Value: "mytoken"}})
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Equal(t, testOrgID, mgr.revokedOrgID)
+	require.Equal(t, "mytoken", mgr.revokedID)
+}
+
+// TestRevokeFrontendRequiresAuth checks POST without a resolvable identity is rejected.
+func TestRevokeFrontendRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	f := nodetoken.NewRevokeFrontend(&fakeManager{}, fakeAuthProvider{ok: false})
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens/mytoken/revoke", "", httprouter.Params{{Key: "id", Value: "mytoken"}})
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRevokeFrontendMapsNotFoundToStatusNotFound checks the not-found sentinel maps to a 404,
+// not the generic 500 other manager errors get.
+func TestRevokeFrontendMapsNotFoundToStatusNotFound(t *testing.T) {
+	t.Parallel()
+
+	mgr := &fakeManager{revokeErr: nodetoken.ErrNotFound}
+	f := nodetoken.NewRevokeFrontend(mgr, fakeAuthProvider{orgID: testOrgID, ok: true})
+
+	w := doRequest(t, f, http.MethodPost, "/node-tokens/mytoken/revoke", "", httprouter.Params{{Key: "id", Value: "mytoken"}})
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestRevokeFrontendSurfacesOtherErrors checks a non-sentinel revoke failure surfaces as an error.
+func TestRevokeFrontendSurfacesOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	f := nodetoken.NewRevokeFrontend(&fakeManager{revokeErr: errBoom}, fakeAuthProvider{orgID: testOrgID, ok: true})
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/node-tokens/mytoken/revoke", nil)
+	w := httptest.NewRecorder()
+
+	err := f.Handle(t.Context(), w, r, httprouter.Params{{Key: "id", Value: "mytoken"}})
+	require.ErrorIs(t, err, errBoom)
+}

--- a/enterprise/nodetoken/manager.go
+++ b/enterprise/nodetoken/manager.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package nodetoken
+
+import (
+	"context"
+	"time"
+
+	"github.com/siderolabs/image-factory/internal/downloadtoken"
+)
+
+// Manager mints and tracks self-issued node tokens, backing NodeTokenManager.
+type Manager struct {
+	issuer  *downloadtoken.Issuer
+	storage *Storage
+}
+
+// NewManager creates a Manager from a node-audience token issuer and its backing storage.
+func NewManager(issuer *downloadtoken.Issuer, storage *Storage) *Manager {
+	return &Manager{issuer: issuer, storage: storage}
+}
+
+// CreateNodeToken mints a new node token for orgID and records it in the index under its jti.
+func (m *Manager) CreateNodeToken(ctx context.Context, orgID, name string) (id, token string, err error) {
+	token, _, jti, err := m.issuer.Issue(orgID, 0)
+	if err != nil {
+		return "", "", err
+	}
+
+	if err := m.storage.Create(ctx, orgID, Record{ID: jti, Name: name, CreatedAt: time.Now()}); err != nil {
+		return "", "", err
+	}
+
+	return jti, token, nil
+}
+
+// ListNodeTokens returns orgID's currently active node tokens.
+func (m *Manager) ListNodeTokens(ctx context.Context, orgID string) ([]Record, error) {
+	return m.storage.List(ctx, orgID)
+}
+
+// RevokeNodeToken removes id from orgID's index, taking it out of circulation once the
+// verification cache next refreshes.
+func (m *Manager) RevokeNodeToken(ctx context.Context, orgID, id string) error {
+	return m.storage.Revoke(ctx, orgID, id)
+}
+
+// Verify reports the org ID a bearer credential authenticates, or ok=false if it isn't a
+// currently valid node token. Satisfies NodeTokenVerifier.
+func (m *Manager) Verify(ctx context.Context, tokenStr string) (orgID string, ok bool) {
+	orgID, jti, err := m.issuer.Verify(tokenStr)
+	if err != nil {
+		return "", false
+	}
+
+	valid, err := m.storage.Valid(ctx, orgID, jti)
+	if err != nil || !valid {
+		return "", false
+	}
+
+	return orgID, true
+}

--- a/enterprise/nodetoken/manager_test.go
+++ b/enterprise/nodetoken/manager_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package nodetoken_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/enterprise/nodetoken"
+	"github.com/siderolabs/image-factory/internal/downloadtoken"
+)
+
+// newTestIssuer creates a NodeAudience Issuer for tests.
+func newTestIssuer(t *testing.T) *downloadtoken.Issuer {
+	t.Helper()
+
+	issuer, err := downloadtoken.GenerateIssuer(downloadtoken.TTL{Default: time.Hour, Min: time.Minute, Max: 24 * time.Hour}, downloadtoken.NodeAudience)
+	require.NoError(t, err)
+
+	return issuer
+}
+
+func newTestManager(t *testing.T) *nodetoken.Manager {
+	t.Helper()
+
+	return nodetoken.NewManager(newTestIssuer(t), newTestStorage(t, time.Minute))
+}
+
+func TestManagerCreateNodeTokenIsVerifiable(t *testing.T) {
+	t.Parallel()
+
+	issuer := newTestIssuer(t)
+	storage := newTestStorage(t, time.Minute)
+	mgr := nodetoken.NewManager(issuer, storage)
+	ctx := t.Context()
+
+	id, token, err := mgr.CreateNodeToken(ctx, "org_a", "my-node")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+	require.NotEmpty(t, token)
+
+	sub, jti, err := issuer.Verify(token)
+	require.NoError(t, err)
+	require.Equal(t, "org_a", sub)
+	require.Equal(t, id, jti)
+
+	valid, err := storage.Valid(ctx, "org_a", jti)
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
+func TestManagerListAndRevokeNodeToken(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+	ctx := t.Context()
+
+	id, _, err := mgr.CreateNodeToken(ctx, "org_a", "my-node")
+	require.NoError(t, err)
+
+	tokens, err := mgr.ListNodeTokens(ctx, "org_a")
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, id, tokens[0].ID)
+	require.Equal(t, "my-node", tokens[0].Name)
+
+	require.NoError(t, mgr.RevokeNodeToken(ctx, "org_a", id))
+
+	tokens, err = mgr.ListNodeTokens(ctx, "org_a")
+	require.NoError(t, err)
+	require.Empty(t, tokens)
+}
+
+func TestManagerRevokeNodeTokenNotFound(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+
+	err := mgr.RevokeNodeToken(t.Context(), "org_a", "does-not-exist")
+	require.ErrorIs(t, err, nodetoken.ErrNotFound)
+}
+
+func TestManagerVerifyAcceptsValidNodeToken(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+	ctx := t.Context()
+
+	_, token, err := mgr.CreateNodeToken(ctx, "org_a", "my-node")
+	require.NoError(t, err)
+
+	orgID, ok := mgr.Verify(ctx, token)
+	require.True(t, ok)
+	require.Equal(t, "org_a", orgID)
+}
+
+func TestManagerVerifyRejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+
+	_, ok := mgr.Verify(t.Context(), "not-a-token")
+	require.False(t, ok)
+}
+
+func TestManagerVerifyRejectsWrongAudience(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+	ctx := t.Context()
+
+	downloadIssuer, err := downloadtoken.GenerateIssuer(downloadtoken.TTL{Default: time.Hour, Min: time.Minute, Max: 24 * time.Hour}, downloadtoken.DownloadAudience)
+	require.NoError(t, err)
+
+	token, _, _, err := downloadIssuer.Issue("org_a", 0)
+	require.NoError(t, err)
+
+	_, ok := mgr.Verify(ctx, token)
+	require.False(t, ok)
+}
+
+func TestManagerVerifyRejectsRevokedToken(t *testing.T) {
+	t.Parallel()
+
+	issuer := newTestIssuer(t)
+	storage := newTestStorage(t, time.Millisecond)
+	ctx := t.Context()
+
+	mgr := nodetoken.NewManager(issuer, storage)
+
+	id, token, err := mgr.CreateNodeToken(ctx, "org_a", "my-node")
+	require.NoError(t, err)
+	require.NoError(t, mgr.RevokeNodeToken(ctx, "org_a", id))
+
+	require.Eventually(t, func() bool {
+		_, ok := mgr.Verify(ctx, token)
+
+		return !ok
+	}, time.Second, time.Millisecond)
+}

--- a/enterprise/nodetoken/storage.go
+++ b/enterprise/nodetoken/storage.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package nodetoken
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/siderolabs/image-factory/internal/regtransport"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
+)
+
+// IndexMediaType is the media type for the per-org node-token index stored in the OCI registry.
+const IndexMediaType types.MediaType = "application/vnd.sidero.dev-image.node-token-index+json"
+
+// maxWriteAttempts bounds the read-apply-push-reread retry loop used for index writes.
+// OCI registries don't guarantee compare-and-swap tag updates, so a concurrent writer can
+// clobber this one's push; retrying converts that into "try again a few times," which is fine
+// for a low-frequency admin action.
+const maxWriteAttempts = 5
+
+// ErrNotFound is returned when a token ID isn't present in an org's index.
+var ErrNotFound = errors.New("nodetoken: token not found")
+
+// Record is one entry in an org's node-token index. Presence in the index is what makes the
+// token valid; revoking a token removes its Record rather than marking it separately.
+type Record struct {
+	CreatedAt time.Time `json:"created_at"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+}
+
+// index is the JSON document stored under an org's tag.
+type index struct {
+	Tokens []Record `json:"tokens"`
+}
+
+// orgCache is the last index read for one org, used to serve verification without a registry
+// round-trip on every request.
+type orgCache struct {
+	fetchedAt time.Time
+	tokens    []Record
+}
+
+// Storage is a registry-backed, per-org index of active node tokens.
+//
+// Each org's index lives under a mutable tag (the org ID) in a dedicated repository, distinct
+// from the cache/artifact registries so it's never subject to their GC policies. Verification
+// reads go through an in-memory cache refreshed at most every refreshInterval, so revoking a
+// token has a bounded propagation delay rather than taking effect instantly.
+type Storage struct {
+	pusher          remotewrap.Pusher
+	puller          remotewrap.Puller
+	cache           map[string]orgCache
+	repository      name.Repository
+	refreshInterval time.Duration
+	mu              sync.Mutex
+}
+
+// NewStorage creates a new registry-backed node-token index storage, mirroring the
+// schematic/SPDX registry storage constructors: it builds its own pusher/puller from the given
+// repository and remote options rather than taking them pre-built.
+func NewStorage(repository name.Repository, refreshInterval time.Duration, remoteOpts []remote.Option) (*Storage, error) {
+	pusher, err := remotewrap.NewPusher(refreshInterval, nil, remoteOpts)
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to create pusher: %w", err)
+	}
+
+	puller, err := remotewrap.NewPuller(refreshInterval, nil, remoteOpts)
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to create puller: %w", err)
+	}
+
+	return &Storage{
+		pusher:          pusher,
+		puller:          puller,
+		repository:      repository,
+		refreshInterval: refreshInterval,
+		cache:           map[string]orgCache{},
+	}, nil
+}
+
+// List returns the currently active tokens for an org, always reading through to the registry
+// so create/list/revoke round-trips in the UI see their own writes immediately.
+func (s *Storage) List(ctx context.Context, orgID string) ([]Record, error) {
+	tokens, err := s.readIndex(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.setCache(orgID, tokens)
+
+	return tokens, nil
+}
+
+// Create adds a new token record to orgID's index.
+func (s *Storage) Create(ctx context.Context, orgID string, record Record) error {
+	return s.mutate(ctx, orgID, func(tokens []Record) ([]Record, error) {
+		return append(tokens, record), nil
+	})
+}
+
+// Revoke removes id from orgID's index. Returns ErrNotFound if id isn't present.
+func (s *Storage) Revoke(ctx context.Context, orgID, id string) error {
+	return s.mutate(ctx, orgID, func(tokens []Record) ([]Record, error) {
+		idx := -1
+
+		for i, t := range tokens {
+			if t.ID == id {
+				idx = i
+
+				break
+			}
+		}
+
+		if idx == -1 {
+			return nil, ErrNotFound
+		}
+
+		return append(tokens[:idx:idx], tokens[idx+1:]...), nil
+	})
+}
+
+// Valid reports whether jti is currently a live (non-revoked) token for orgID, consulting the
+// in-memory cache and refreshing it from the registry if it's older than refreshInterval.
+func (s *Storage) Valid(ctx context.Context, orgID, jti string) (bool, error) {
+	tokens, err := s.cachedIndex(ctx, orgID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, t := range tokens {
+		if t.ID == jti {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *Storage) cachedIndex(ctx context.Context, orgID string) ([]Record, error) {
+	s.mu.Lock()
+	cached, ok := s.cache[orgID]
+	s.mu.Unlock()
+
+	if ok && time.Since(cached.fetchedAt) < s.refreshInterval {
+		return cached.tokens, nil
+	}
+
+	tokens, err := s.readIndex(ctx, orgID)
+	if err != nil {
+		// Serve the stale cache rather than failing verification outright on a transient
+		// registry error; an empty, never-populated cache still surfaces the error.
+		if ok {
+			return cached.tokens, nil
+		}
+
+		return nil, err
+	}
+
+	s.setCache(orgID, tokens)
+
+	return tokens, nil
+}
+
+func (s *Storage) setCache(orgID string, tokens []Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cache[orgID] = orgCache{tokens: tokens, fetchedAt: time.Now()}
+}
+
+// mutate implements the read-apply-push-reread retry loop: read the current index, apply fn,
+// push the result, then read back to confirm the push landed as written before returning.
+func (s *Storage) mutate(ctx context.Context, orgID string, fn func([]Record) ([]Record, error)) error {
+	var lastErr error
+
+	for range maxWriteAttempts {
+		current, err := s.readIndex(ctx, orgID)
+		if err != nil {
+			return err
+		}
+
+		updated, err := fn(current)
+		if err != nil {
+			return err
+		}
+
+		if pushErr := s.pushIndex(ctx, orgID, updated); pushErr != nil {
+			lastErr = pushErr
+
+			continue
+		}
+
+		// A failure here means the push may or may not have landed, so it's not safe to loop
+		// back and reapply fn against a fresh read — if the push did land, that would apply
+		// the mutation a second time (e.g. appending the same token twice).
+		reread, err := s.readIndex(ctx, orgID)
+		if err != nil {
+			return fmt.Errorf("nodetoken: index update for org %q may not have applied cleanly, failed to confirm: %w", orgID, err)
+		}
+
+		if !recordsEqual(reread, updated) {
+			lastErr = fmt.Errorf("nodetoken: lost race updating index for org %q", orgID)
+
+			continue
+		}
+
+		s.setCache(orgID, updated)
+
+		return nil
+	}
+
+	return fmt.Errorf("nodetoken: failed to update index for org %q after %d attempts: %w", orgID, maxWriteAttempts, lastErr)
+}
+
+func (s *Storage) readIndex(ctx context.Context, orgID string) ([]Record, error) {
+	ref := s.repository.Tag(orgID)
+
+	desc, err := s.puller.Get(ctx, ref)
+	if err != nil {
+		// GHCR (and others) answer an anonymous pull of a tag that's never been pushed with
+		// 403 DENIED rather than 404, to avoid leaking whether a private repo exists at all.
+		if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("nodetoken: failed to read index for org %q: %w", orgID, err)
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to read index image for org %q: %w", orgID, err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to read index layers for org %q: %w", orgID, err)
+	}
+
+	if len(layers) != 1 {
+		return nil, fmt.Errorf("nodetoken: unexpected layer count %d for org %q index", len(layers), orgID)
+	}
+
+	r, err := layers[0].Compressed()
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to read index layer for org %q: %w", orgID, err)
+	}
+
+	defer r.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to read index data for org %q: %w", orgID, err)
+	}
+
+	var idx index
+
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("nodetoken: failed to parse index for org %q: %w", orgID, err)
+	}
+
+	return idx.Tokens, nil
+}
+
+func (s *Storage) pushIndex(ctx context.Context, orgID string, tokens []Record) error {
+	data, err := json.Marshal(index{Tokens: tokens})
+	if err != nil {
+		return fmt.Errorf("nodetoken: failed to marshal index for org %q: %w", orgID, err)
+	}
+
+	layer, err := partial.CompressedToLayer(&layerWrapper{content: data})
+	if err != nil {
+		return fmt.Errorf("nodetoken: failed to create index layer for org %q: %w", orgID, err)
+	}
+
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return fmt.Errorf("nodetoken: failed to append index layer for org %q: %w", orgID, err)
+	}
+
+	if err := s.pusher.Push(ctx, s.repository.Tag(orgID), img); err != nil {
+		return fmt.Errorf("nodetoken: failed to push index for org %q: %w", orgID, err)
+	}
+
+	return nil
+}
+
+// recordsEqual compares two token sets by ID only, ignoring order and other fields — sufficient
+// for mutate's reread check since a jti is unique per issued token and never reused.
+func recordsEqual(a, b []Record) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	seen := make(map[string]struct{}, len(a))
+
+	for _, r := range a {
+		seen[r.ID] = struct{}{}
+	}
+
+	for _, r := range b {
+		if _, ok := seen[r.ID]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// layerWrapper adapts raw JSON content to the v1.Layer interface expected by the OCI push path.
+type layerWrapper struct {
+	content []byte
+}
+
+// Digest returns the hash of the compressed layer.
+func (w *layerWrapper) Digest() (v1.Hash, error) {
+	hash, _, err := v1.SHA256(bytes.NewReader(w.content))
+
+	return hash, err
+}
+
+// Compressed returns an io.ReadCloser for the compressed layer contents.
+func (w *layerWrapper) Compressed() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(w.content)), nil
+}
+
+// Size returns the compressed size of the layer.
+func (w *layerWrapper) Size() (int64, error) {
+	return int64(len(w.content)), nil
+}
+
+// MediaType returns the media type for the layer.
+func (w *layerWrapper) MediaType() (types.MediaType, error) {
+	return IndexMediaType, nil
+}

--- a/enterprise/nodetoken/storage_test.go
+++ b/enterprise/nodetoken/storage_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build enterprise
+
+package nodetoken_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/image-factory/enterprise/nodetoken"
+)
+
+// newTestStorage stands up an in-process OCI registry and a Storage pointed at it.
+func newTestStorage(t *testing.T, refreshInterval time.Duration) *nodetoken.Storage {
+	t.Helper()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+
+	return newTestStorageAt(t, strings.TrimPrefix(srv.URL, "http://"), refreshInterval)
+}
+
+// newTestStorageAt creates a Storage pointed at an already-running registry host, so multiple
+// instances (simulating multiple factory replicas) can share one backing registry.
+func newTestStorageAt(t *testing.T, host string, refreshInterval time.Duration) *nodetoken.Storage {
+	t.Helper()
+
+	repo, err := name.NewRepository(host+"/node-tokens", name.Insecure)
+	require.NoError(t, err)
+
+	storage, err := nodetoken.NewStorage(repo, refreshInterval, []remote.Option{})
+	require.NoError(t, err)
+
+	return storage
+}
+
+func TestStorageCreateListRevoke(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStorage(t, time.Minute)
+	ctx := t.Context()
+
+	tokens, err := s.List(ctx, "org_a")
+	require.NoError(t, err)
+	require.Empty(t, tokens)
+
+	err = s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	err = s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-2", Name: "node-2"})
+	require.NoError(t, err)
+
+	tokens, err = s.List(ctx, "org_a")
+	require.NoError(t, err)
+	require.Len(t, tokens, 2)
+
+	require.NoError(t, s.Revoke(ctx, "org_a", "jti-1"))
+
+	tokens, err = s.List(ctx, "org_a")
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, "jti-2", tokens[0].ID)
+}
+
+func TestStorageRevokeMissingReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStorage(t, time.Minute)
+	ctx := t.Context()
+
+	err := s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	err = s.Revoke(ctx, "org_a", "does-not-exist")
+	require.ErrorIs(t, err, nodetoken.ErrNotFound)
+}
+
+func TestStorageOrgsAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStorage(t, time.Minute)
+	ctx := t.Context()
+
+	err := s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	tokens, err := s.List(ctx, "org_b")
+	require.NoError(t, err)
+	require.Empty(t, tokens)
+}
+
+func TestStorageValid(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStorage(t, time.Minute)
+	ctx := t.Context()
+
+	err := s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	valid, err := s.Valid(ctx, "org_a", "jti-1")
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	valid, err = s.Valid(ctx, "org_a", "jti-unknown")
+	require.NoError(t, err)
+	require.False(t, valid)
+}
+
+// TestStorageValidCacheDelaysRevocation checks that a revoke's effect on Valid is bounded by
+// refreshInterval, not instant, on a replica other than the one that performed the revoke —
+// the same instance sees its own write immediately (mutate refreshes its own cache), so this
+// uses two Storage instances against the same registry to simulate two factory replicas.
+func TestStorageValidCacheDelaysRevocation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	writer := newTestStorageAt(t, host, time.Hour)
+	reader := newTestStorageAt(t, host, time.Hour)
+
+	ctx := t.Context()
+
+	err := writer.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	valid, err := reader.Valid(ctx, "org_a", "jti-1")
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	require.NoError(t, writer.Revoke(ctx, "org_a", "jti-1"))
+
+	// reader's cache was warmed above and refreshInterval is an hour, so it still reports the
+	// token as valid immediately after the other replica's revoke.
+	valid, err = reader.Valid(ctx, "org_a", "jti-1")
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
+func TestStorageValidRefreshesAfterInterval(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStorage(t, time.Millisecond)
+	ctx := t.Context()
+
+	err := s.Create(ctx, "org_a", nodetoken.Record{ID: "jti-1", Name: "node-1"})
+	require.NoError(t, err)
+
+	valid, err := s.Valid(ctx, "org_a", "jti-1")
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	require.NoError(t, s.Revoke(ctx, "org_a", "jti-1"))
+
+	require.Eventually(t, func() bool {
+		valid, err := s.Valid(ctx, "org_a", "jti-1")
+
+		return err == nil && !valid
+	}, time.Second, time.Millisecond)
+}

--- a/internal/frontend/http/http.go
+++ b/internal/frontend/http/http.go
@@ -72,6 +72,7 @@ type Options struct {
 	InstallerSBOMSource              enterprise.SPDXSource
 	AuthProvider                     enterprise.AuthProvider
 	DownloadTokenIssuer              enterprise.DownloadTokenIssuer
+	NodeTokenVerifier                enterprise.NodeTokenVerifier
 	ExternalURL                      *url.URL
 	ExternalPXEURL                   *url.URL
 	AuditSink                        audit.Sink
@@ -357,6 +358,12 @@ func tokenAcceptedOn(path string) bool {
 	return strings.HasPrefix(path, "/image/") || strings.HasPrefix(path, "/pxe/")
 }
 
+// nodeTokenAcceptedOn reports whether path is on the pull-only registry surface a node
+// token may authenticate: schematic-derived images and the OCI registry API.
+func nodeTokenAcceptedOn(path string) bool {
+	return strings.HasPrefix(path, "/image/") || path == "/v2" || strings.HasPrefix(path, "/v2/")
+}
+
 // downloadTokenKey keys the verified download token on the request context.
 type downloadTokenKey struct{}
 
@@ -398,6 +405,19 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string, state
 			}
 		}
 
+		// Node token: a self-issued, long-lived credential nodes present to the registry,
+		// scoped to the same pull-only surface as a machine-scoped Auth0 token.
+		if f.options.NodeTokenVerifier != nil && (r.Method == http.MethodGet || r.Method == http.MethodHead) && nodeTokenAcceptedOn(r.URL.Path) {
+			if tokenStr := extractBearerOrBasicToken(r); tokenStr != "" {
+				if orgID, ok := f.options.NodeTokenVerifier.Verify(ctx, tokenStr); ok {
+					*username = orgID
+					ctx = authProvider.ContextWithUsername(ctx, orgID)
+
+					return h(ctx, w, r, p)
+				}
+			}
+		}
+
 		err := authProvider.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 			*username, _ = authProvider.UsernameFromContext(ctx)
 
@@ -416,6 +436,24 @@ func (f *Frontend) withAuth(h Handler, requireAuth bool, username *string, state
 
 		return err
 	}
+}
+
+// extractBearerOrBasicToken pulls a bearer credential from the Authorization header, checking
+// both the Bearer scheme and HTTP Basic auth, since OCI/registry clients commonly send a token
+// as the Basic password rather than a Bearer header.
+func extractBearerOrBasicToken(r *http.Request) string {
+	scheme, value, _ := strings.Cut(r.Header.Get("Authorization"), " ")
+
+	// RFC 9110 makes the scheme case-insensitive; some clients send "bearer".
+	if strings.EqualFold(scheme, "Bearer") {
+		return value
+	}
+
+	if _, password, ok := r.BasicAuth(); ok {
+		return password
+	}
+
+	return ""
 }
 
 // audit records one entry for an authenticated request; a sink failure is logged

--- a/pkg/enterprise/enterprise.go
+++ b/pkg/enterprise/enterprise.go
@@ -157,6 +157,24 @@ type DownloadTokenIssuer interface {
 // caller does not ask for one, and the bounds a caller may request within.
 type DownloadTokenTTL = downloadtoken.TTL
 
+// NodeTokenVerifier reports the org ID a bearer credential authenticates, or ok=false if it
+// isn't a currently valid, self-issued node token.
+type NodeTokenVerifier interface {
+	Verify(ctx context.Context, tokenStr string) (orgID string, ok bool)
+}
+
+// NodeTokenOptions holds configuration for self-issued node token issuance, storage, and
+// verification.
+type NodeTokenOptions struct {
+	KeyPath                          string
+	StorageRepository                string
+	RemoteOptions                    []remote.Option
+	TTL                              DownloadTokenTTL
+	VerificationCacheRefreshInterval time.Duration
+	MaxPerOrg                        int
+	StorageInsecure                  bool
+}
+
 // Handler is the type of HTTP handlers used by the enterprise frontend.
 type Handler = func(ctx context.Context, w http.ResponseWriter, r *http.Request, p httprouter.Params) error
 

--- a/pkg/enterprise/enterprise_off.go
+++ b/pkg/enterprise/enterprise_off.go
@@ -77,3 +77,8 @@ func NewDownloadTokenFrontend(_ DownloadTokenIssuer, _ AuthProvider) FrontendPlu
 func NewJWKSFrontend(_ DownloadTokenIssuer) FrontendPlugin {
 	return nil
 }
+
+// NewNodeTokenFrontends returns nil when enterprise is not enabled.
+func NewNodeTokenFrontends(_ AuthProvider, _ NodeTokenOptions) ([]FrontendPlugin, NodeTokenVerifier, error) {
+	return nil, nil, nil
+}

--- a/pkg/enterprise/enterprise_on.go
+++ b/pkg/enterprise/enterprise_on.go
@@ -23,6 +23,7 @@ import (
 	"github.com/siderolabs/image-factory/enterprise/checksum"
 	enterprisedt "github.com/siderolabs/image-factory/enterprise/downloadtoken"
 	"github.com/siderolabs/image-factory/enterprise/installerattestation"
+	"github.com/siderolabs/image-factory/enterprise/nodetoken"
 	"github.com/siderolabs/image-factory/enterprise/scanner"
 	scannerbuilder "github.com/siderolabs/image-factory/enterprise/scanner/builder"
 	"github.com/siderolabs/image-factory/enterprise/spdx"
@@ -257,4 +258,47 @@ func NewDownloadTokenFrontend(issuer DownloadTokenIssuer, authProvider AuthProvi
 // NewJWKSFrontend returns the FrontendPlugin for the JWKS public key endpoint.
 func NewJWKSFrontend(issuer DownloadTokenIssuer) FrontendPlugin {
 	return enterprisedt.NewJWKSFrontend(issuer)
+}
+
+// NewNodeTokenFrontends returns the node-token FrontendPlugins together with a NodeTokenVerifier.
+func NewNodeTokenFrontends(authProvider AuthProvider, opts NodeTokenOptions) ([]FrontendPlugin, NodeTokenVerifier, error) {
+	var (
+		issuer *downloadtoken.Issuer
+		err    error
+	)
+
+	if opts.KeyPath != "" {
+		issuer, err = downloadtoken.LoadIssuer(opts.KeyPath, opts.TTL, downloadtoken.NodeAudience)
+	} else {
+		issuer, err = downloadtoken.GenerateIssuer(opts.TTL, downloadtoken.NodeAudience)
+	}
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize node token issuer: %w", err)
+	}
+
+	var repoOpts []name.Option
+
+	if opts.StorageInsecure {
+		repoOpts = append(repoOpts, name.Insecure)
+	}
+
+	repo, err := name.NewRepository(opts.StorageRepository, repoOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse node token storage repository: %w", err)
+	}
+
+	storage, err := nodetoken.NewStorage(repo, opts.VerificationCacheRefreshInterval, opts.RemoteOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize node token storage: %w", err)
+	}
+
+	manager := nodetoken.NewManager(issuer, storage)
+
+	plugins := []FrontendPlugin{
+		nodetoken.NewListCreateFrontend(manager, authProvider, opts.MaxPerOrg),
+		nodetoken.NewRevokeFrontend(manager, authProvider),
+	}
+
+	return plugins, manager, nil
 }


### PR DESCRIPTION
This PR adds the actual node-token backend. Three parts:
- self-issued JWTs, similar to the download tokens, but with longer TTL and different audience
- a per-org index kept in the registry so tokens can be listed and revoked
- the /node-tokens API to drive it all.

Verification is checked inline the same way download token verification already is, so it doesn't care which auth provider is configured. Storage defaults to the same Sidero-hosted registry schematics already use, so self-hosted deployments don't need anything new to run it. Node token creation isn't Auth0-only. Any configured auth provider will enable it. Although, if we ever ship a provider that doesn't have any mapping to org IDs, we'll need to revisit.