### PR TITLE
feat: add WithTokenSource to include bearer tokens

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,6 +40,7 @@ type OverlayInfo struct {
 type Client struct {
 	baseURL      *url.URL
 	extraHeaders http.Header
+	tokenSource  TokenSource
 	client       http.Client
 }
 
@@ -56,6 +57,7 @@ func New(baseURL string, options ...Option) (*Client, error) {
 		baseURL:      bURL,
 		client:       opts.Client,
 		extraHeaders: opts.ExtraHeaders,
+		tokenSource:  opts.TokenSource,
 	}
 
 	return c, nil
@@ -303,6 +305,17 @@ func (c *Client) do(ctx context.Context, method, uri string, responseData any, o
 	}
 
 	maps.Copy(req.Header, c.extraHeaders)
+
+	if c.tokenSource != nil {
+		token, tokenErr := c.tokenSource(ctx)
+		if tokenErr != nil {
+			return fmt.Errorf("failed to get token: %w", tokenErr)
+		}
+
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -5,14 +5,24 @@
 package client
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 )
+
+// TokenSource returns the bearer token to use for the next request.
+//
+// It is called on every request, so it can be backed by a value that rotates over time (for
+// example, a token refreshed in the background). An empty token with a nil error leaves the
+// request unauthenticated.
+type TokenSource func(ctx context.Context) (string, error)
 
 // Options defines client options.
 type Options struct {
 	// ExtraHeaders represents extra headers to be added to each request.
 	ExtraHeaders http.Header
+	// TokenSource, when set, is called on every request to obtain a bearer token.
+	TokenSource TokenSource
 	// Client is the http client.
 	Client http.Client
 }
@@ -27,7 +37,16 @@ func WithClient(client http.Client) Option {
 	}
 }
 
-// WithBearerToken adds a bearer token to each request.
+// WithTokenSource sets a token source that is consulted on every request for a bearer token.
+//
+// Use this instead of WithBearerToken when the token can rotate over the client's lifetime.
+func WithTokenSource(ts TokenSource) Option {
+	return func(o *Options) {
+		o.TokenSource = ts
+	}
+}
+
+// WithBearerToken adds a static bearer token to each request.
 func WithBearerToken(token string) Option {
 	return func(o *Options) {
 		if o.ExtraHeaders == nil {


### PR DESCRIPTION
Add `WithTokenSource` to include bearer tokens that can change over the lifetime of a client or may not be immediately available during client creation.