### PR TITLE
fix(auth0): drop Bearer challenge from 401 response

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -30,9 +30,8 @@ Details that decide whether a request authenticates:
 - URL userinfo is the same header by another name: HTTP clients encode `https://<user>:<password>@factory.example.com/...` into `Authorization: Basic`.
   That is how `GET /pxe/...` is authenticated, since iPXE cannot set request headers.
 - A missing or invalid credential is `401`.
-  With `htpasswd`, the response carries one `WWW-Authenticate: Basic` challenge.
-  With `auth0`, it carries separate Basic and Bearer challenges, in that order.
-  The Auth0 order is deliberate: OCI clients take the first scheme they recognize, and only the Basic form carries a usable token for those clients.
+  The response carries one `WWW-Authenticate: Basic` challenge, under both `htpasswd` and `auth0`.
+  No Bearer challenge is advertised, even under `auth0` where Bearer credentials are accepted: docker's registry client reads a Bearer challenge's realm as an OAuth token endpoint to fetch a token from, and the factory has no such endpoint, so advertising one makes `docker login` fail before it sends any credentials.
   With [browser login](#browser-login) configured, a page navigation is sent to `/login` with a `303` instead, and an XHR gets the `401` with no challenge on it.
 
 There are two alternatives to this header: the [`?token=` query parameter](#the-token-query-parameter), accepted on image downloads and PXE scripts only, and the session cookie [browser login](#browser-login) issues.

--- a/enterprise/auth/auth0/provider.go
+++ b/enterprise/auth/auth0/provider.go
@@ -295,13 +295,16 @@ func (p *Provider) Middleware(next Handler) Handler {
 	}
 }
 
-// setChallenge advertises Basic ahead of Bearer, as separate header values so a parser
-// cannot read "Bearer" as a parameter of the Basic challenge.
-// Order matters: OCI clients take the first scheme they recognize, and only Basic carries
-// a usable token here.
+// setChallenge advertises Basic only, matching the htpasswd provider.
+//
+// A Bearer challenge must not be advertised even though Bearer credentials are accepted:
+// docker's registry client (distribution/registry/client/auth) applies its token handler
+// before its basic handler, and that handler treats the challenge realm as the URL of an
+// OAuth token endpoint to fetch from. The factory has no such endpoint, so the fetch fails
+// and the whole request is aborted client-side — the caller's credentials are never sent,
+// and `docker login`/`docker pull` fail with no retry over Basic.
 func setChallenge(w http.ResponseWriter) {
 	w.Header().Add("WWW-Authenticate", `Basic realm="Image Factory Enterprise", charset="UTF-8"`)
-	w.Header().Add("WWW-Authenticate", `Bearer realm="Image Factory Enterprise"`)
 }
 
 // deny sends browsers to /login, preserving the URL they were trying to reach, and

--- a/enterprise/auth/auth0/provider_test.go
+++ b/enterprise/auth/auth0/provider_test.go
@@ -356,8 +356,9 @@ func TestAuth0ProviderIgnoresOAuthScopes(t *testing.T) {
 	}
 }
 
-// TestAuth0ProviderChallengeOrder pins Basic ahead of Bearer on a 401, since OCI clients
-// authenticate with the first scheme they recognize and only Basic is usable here.
+// TestAuth0ProviderChallengeOrder pins Basic as the only challenge on a 401: docker's
+// registry client runs its token handler first and would try to fetch a token from a
+// Bearer challenge's realm, aborting before it ever sends the caller's credentials.
 func TestAuth0ProviderChallengeOrder(t *testing.T) {
 	t.Parallel()
 
@@ -385,7 +386,6 @@ func TestAuth0ProviderChallengeOrder(t *testing.T) {
 
 			require.Equal(t, []string{
 				`Basic realm="Image Factory Enterprise", charset="UTF-8"`,
-				`Bearer realm="Image Factory Enterprise"`,
 			}, w.Header().Values("WWW-Authenticate"))
 		})
 	}

--- a/internal/frontend/http/challenge_test.go
+++ b/internal/frontend/http/challenge_test.go
@@ -24,7 +24,7 @@ import (
 // TestUnauthorizedChallengeHeader pins the WWW-Authenticate behavior on a 401.
 // The wrapper only supplies the Basic challenge as a fallback, so htpasswd (which sets
 // nothing) keeps the challenge OCI registry clients require, while a provider that set
-// its own keeps them — including their order, which is what those clients select on.
+// its own keeps them, verbatim and in order.
 func TestUnauthorizedChallengeHeader(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
docker's registry client applies its token handler before its basic
handler and reads a Bearer challenge's realm as an OAuth token
endpoint to fetch from. The factory has no such endpoint, so the
fetch fails and the request is aborted client-side: the caller's
credentials are never sent and there is no retry over Basic, making
docker login/pull fail against an auth0-backed deployment while the
htpasswd one (Basic only) worked.

Bearer credentials are still accepted; only the advertisement stops.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
