### PR TITLE
fix: cache unauthenticated iPXE scripts, dedupe cache signing

### DIFF
--- a/internal/asset/asset.go
+++ b/internal/asset/asset.go
@@ -38,19 +38,20 @@ type BootAsset interface {
 
 // Builder is the asset builder.
 type Builder struct {
-	metricConcurrencyLatency prometheus.Histogram
-	cache                    cache.Cache
-	metricBuildLatency       prometheus.Histogram
-	sf                       singleflight.Group
-	metricAssetsCached       *prometheus.CounterVec
-	logger                   *zap.Logger
-	metricAssetsBuilt        *prometheus.CounterVec
-	metricAssetBytesCached   *prometheus.CounterVec
-	metricAssetBytesBuilt    *prometheus.CounterVec
-	metricAssetCachedErrors  *prometheus.CounterVec
-	semaphore                chan struct{}
-	artifactsManager         *artifacts.Manager
-	cacheMightFail           bool
+	metricConcurrencyLatency  prometheus.Histogram
+	cache                     cache.Cache
+	metricBuildLatency        prometheus.Histogram
+	sf                        singleflight.Group
+	metricAssetsCached        *prometheus.CounterVec
+	logger                    *zap.Logger
+	metricAssetsBuilt         *prometheus.CounterVec
+	metricAssetBytesCached    *prometheus.CounterVec
+	metricAssetBytesBuilt     *prometheus.CounterVec
+	metricAssetCachedErrors   *prometheus.CounterVec
+	metricAssetCachePutErrors *prometheus.CounterVec
+	semaphore                 chan struct{}
+	artifactsManager          *artifacts.Manager
+	cacheMightFail            bool
 }
 
 // Options configures the asset builder.
@@ -105,6 +106,14 @@ func NewBuilder(logger *zap.Logger, artifactsManager *artifacts.Manager, cache c
 			prometheus.CounterOpts{
 				Name:      "image_factory_assets_cached_errors_total",
 				Help:      "Number of errors retrieving assets from cache.",
+				Namespace: options.MetricsNamespace,
+			},
+			[]string{"talos_version", "output_kind", "arch"},
+		),
+		metricAssetCachePutErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name:      "image_factory_assets_cache_put_errors_total",
+				Help:      "Number of errors pushing built assets to the cache. A non-zero rate means assets are rebuilt on every request.",
 				Namespace: options.MetricsNamespace,
 			},
 			[]string{"talos_version", "output_kind", "arch"},
@@ -211,6 +220,10 @@ func (b *Builder) buildAndCache(reqID, profileHash string, prof profile.Profile,
 	b.metricAssetBytesBuilt.WithLabelValues(versionString, prof.Output.Kind.String(), prof.Arch).Add(float64(asset.Size()))
 
 	if err = b.cache.Put(ctx, profileHash, asset, filename); err != nil {
+		// The request still succeeds, so a cache that never accepts a write shows up only as
+		// every request rebuilding.
+		b.metricAssetCachePutErrors.WithLabelValues(versionString, prof.Output.Kind.String(), prof.Arch).Inc()
+
 		logger.Error("error putting asset to cache", zap.Error(err), zap.String("profile_hash", profileHash))
 	}
 
@@ -318,6 +331,7 @@ func (b *Builder) Collect(ch chan<- prometheus.Metric) {
 	b.metricAssetBytesCached.Collect(ch)
 
 	b.metricAssetCachedErrors.Collect(ch)
+	b.metricAssetCachePutErrors.Collect(ch)
 
 	b.metricBuildLatency.Collect(ch)
 	b.metricConcurrencyLatency.Collect(ch)

--- a/internal/asset/cache/registry/registry.go
+++ b/internal/asset/cache/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/image-factory/internal/asset/cache"
+	"github.com/siderolabs/image-factory/internal/ctxlog"
 	"github.com/siderolabs/image-factory/internal/image/signer"
 	"github.com/siderolabs/image-factory/internal/regtransport"
 	"github.com/siderolabs/image-factory/internal/remotewrap"
@@ -73,30 +74,52 @@ func New(logger *zap.Logger, options Options) (*Cache, error) {
 func (c *Cache) Get(ctx context.Context, profileID string) (cache.BootAsset, error) {
 	taggedRef := c.cacheRepository.Tag(profileID)
 
-	c.logger.Debug("heading cached image", zap.Stringer("ref", taggedRef))
+	// A cache hit does Head plus a signature verification, and either can dominate the
+	// request. Time them separately, and carry the request_id, so a slow hit is attributable
+	// to a phase and a caller rather than showing up as an unexplained gap.
+	logger := ctxlog.Logger(ctx, c.logger)
+
+	logger.Debug("heading cached image", zap.Stringer("ref", taggedRef))
+
+	headStart := time.Now()
 
 	desc, err := c.puller.Head(ctx, taggedRef)
-	if regtransport.IsStatusCodeError(err, http.StatusNotFound, http.StatusForbidden) {
-		// ignore 404/403, it means the image hasn't been pushed yet
-		return nil, cache.ErrCacheNotFound
-	}
 
-	if err != nil {
+	headLatency := time.Since(headStart)
+
+	switch {
+	case regtransport.IsStatusCodeError(err, http.StatusNotFound):
+		// the image hasn't been pushed yet
+		return nil, cache.ErrCacheNotFound
+	case regtransport.IsStatusCodeError(err, http.StatusForbidden):
+		// A 403 can mean an absent tag or a bad credential, so it stays a cache miss -- but
+		// log it, otherwise an unreadable cache looks exactly like a cold one.
+		logger.Warn("cache image not readable, treating as a cache miss", zap.Stringer("ref", taggedRef))
+
+		return nil, cache.ErrCacheNotFound
+	case err != nil:
 		// something is wrong
 		return nil, fmt.Errorf("failed to head cache image: %w", err)
 	}
 
 	digestRef := c.cacheRepository.Digest(desc.Digest.String())
 
+	verifyStart := time.Now()
+
 	err = c.imageSigner.VerifyImage(ctx, digestRef, c.puller)
+
+	verifyLatency := time.Since(verifyStart)
+
 	if err != nil {
 		// signature doesn't validate, skip the cache, but keep building
-		c.logger.Info("cache image signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef))
+		logger.Info("cache image signature doesn't validate", zap.Error(err), zap.Stringer("ref", taggedRef),
+			zap.Duration("head_latency", headLatency), zap.Duration("verify_latency", verifyLatency))
 
 		return nil, cache.ErrCacheNotFound
 	}
 
-	c.logger.Info("using cached image", zap.Stringer("ref", taggedRef))
+	logger.Info("using cached image", zap.Stringer("ref", taggedRef),
+		zap.Duration("head_latency", headLatency), zap.Duration("verify_latency", verifyLatency))
 
 	imgDesc, err := c.puller.Get(ctx, digestRef)
 	if err != nil {
@@ -134,7 +157,9 @@ func (c *Cache) Get(ctx context.Context, profileID string) (cache.BootAsset, err
 func (c *Cache) Put(ctx context.Context, profileID string, asset cache.BootAsset, _ string) error {
 	taggedRef := c.cacheRepository.Tag(profileID)
 
-	c.logger.Info("pushing cached image", zap.Stringer("ref", taggedRef))
+	logger := ctxlog.Logger(ctx, c.logger)
+
+	logger.Info("pushing cached image", zap.Stringer("ref", taggedRef))
 
 	layer, err := partial.CompressedToLayer(&layerWrapper{
 		src: asset,
@@ -161,7 +186,25 @@ func (c *Cache) Put(ctx context.Context, profileID string, asset cache.BootAsset
 
 	digestRef := c.cacheRepository.Digest(digest.String())
 
-	c.logger.Info("signing cache image", zap.Stringer("ref", digestRef))
+	// A cache manifest is content-addressed, so one signature over the digest stays valid for
+	// the life of the entry, and a miss on an entry that is already in the registry (a new
+	// Talos version whose asset is byte-identical, an object that lost its S3 metadata, a
+	// transient Get error) must not sign it again. Keyless signing writes each signature as a
+	// separate referrer, so re-signing grows a list that every later cache read has to walk:
+	// the metal-amd64 cmdline entry reached 205 referrers at ~0.68s each, a 140s cache hit.
+	//
+	// Asking the signer, rather than looking for an attached artifact, is what makes skipping
+	// safe: a referrer that is an SBOM, or a signature made under a since-rotated identity,
+	// does not satisfy the same check Get performs, so it is signed again instead of leaving
+	// an entry that never validates. Any error here means "not signed", so the failure
+	// direction is always to sign.
+	if err = c.imageSigner.VerifyImage(ctx, digestRef, c.puller); err == nil {
+		logger.Debug("cache image is already signed", zap.Stringer("ref", digestRef))
+
+		return nil
+	}
+
+	logger.Info("signing cache image", zap.Stringer("ref", digestRef))
 
 	if err := c.imageSigner.SignImage(
 		ctx,

--- a/internal/asset/cache/registry/registry_test.go
+++ b/internal/asset/cache/registry/registry_test.go
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package registry_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	costypes "github.com/sigstore/cosign/v3/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	assetregistry "github.com/siderolabs/image-factory/internal/asset/cache/registry"
+	"github.com/siderolabs/image-factory/internal/image/attestation"
+	"github.com/siderolabs/image-factory/internal/image/signer"
+	"github.com/siderolabs/image-factory/internal/remotewrap"
+)
+
+const testProfileHash = "some-profile-hash"
+
+type testAsset struct {
+	data []byte
+}
+
+func (a testAsset) Size() int64 { return int64(len(a.data)) }
+
+func (a testAsset) Reader() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(a.data)), nil }
+
+// referrerSigner counts SignImage calls and attaches the signature as an OCI referrer, the way
+// keyless signing does.
+type referrerSigner struct {
+	signer.Signer
+
+	attestor signer.ImageAttestor
+	// predicateType is what SignImage writes; VerifyImage always demands a signature
+	// predicate, so a stub configured with anything else models a non-signature referrer.
+	predicateType string
+	calls         int
+}
+
+func (s *referrerSigner) SignImage(ctx context.Context, imageRef name.Digest, pusher remotewrap.Pusher) error {
+	s.calls++
+
+	predicateType := s.predicateType
+	if predicateType == "" {
+		predicateType = costypes.CosignSignPredicateType
+	}
+
+	return s.attestor.AttestImage(ctx, imageRef, []name.Digest{imageRef}, predicateType, []byte(`{}`), pusher)
+}
+
+// VerifyImage checks the same referrer SignImage writes, the way the keyless signer does.
+func (s *referrerSigner) VerifyImage(ctx context.Context, imageRef name.Digest, puller remotewrap.Puller) error {
+	return s.attestor.VerifyImageAttestation(ctx, imageRef, costypes.CosignSignPredicateType, puller)
+}
+
+// tagSigner counts SignImage calls and attaches nothing, standing in for key-based signing,
+// which overwrites a fixed tag instead of accumulating referrers.
+type tagSigner struct {
+	signer.Signer
+
+	calls int
+}
+
+func (s *tagSigner) SignImage(context.Context, name.Digest, remotewrap.Pusher) error {
+	s.calls++
+
+	return nil
+}
+
+func testCache(t *testing.T, imageSigner signer.Signer) (*assetregistry.Cache, name.Repository) {
+	t.Helper()
+
+	server := httptest.NewServer(ggcrregistry.New())
+	t.Cleanup(server.Close)
+
+	// remotewrap appends its own transport after the caller's options, so a custom dialer
+	// would be discarded: address the test registry by its real host:port instead.
+	repository, err := name.NewRepository(server.Listener.Addr().String()+"/cache", name.Insecure)
+	require.NoError(t, err)
+
+	c, err := assetregistry.New(zaptest.NewLogger(t), assetregistry.Options{
+		CacheRepository:         repository,
+		NameOptions:             []name.Option{name.Insecure},
+		CacheImageSigner:        imageSigner,
+		RegistryRefreshInterval: time.Minute,
+	})
+	require.NoError(t, err)
+
+	return c, repository
+}
+
+func keySigner(t *testing.T) signer.Signer {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	s, err := signer.NewSigner(privateKey)
+	require.NoError(t, err)
+
+	return s
+}
+
+// referrerCount returns how many referrers are attached to the cached entry.
+func referrerCount(t *testing.T, repository name.Repository) int {
+	t.Helper()
+
+	desc, err := remote.Head(repository.Tag(testProfileHash))
+	require.NoError(t, err)
+
+	index, err := remote.Referrers(repository.Digest(desc.Digest.String()))
+	require.NoError(t, err)
+
+	manifest, err := index.IndexManifest()
+	require.NoError(t, err)
+
+	return len(manifest.Manifests)
+}
+
+// TestPutSignsOnce asserts that re-caching an entry which is already signed neither signs it
+// again nor grows its referrer list. Each keyless signature is a separate referrer and every
+// later cache read walks all of them, so an entry re-signed on every miss turns a cache hit
+// into minutes: the metal-amd64 cmdline entry reached 205 referrers and a 140s hit.
+func TestPutSignsOnce(t *testing.T) {
+	base := keySigner(t)
+
+	attestor, ok := base.(signer.ImageAttestor)
+	require.True(t, ok)
+
+	imageSigner := &referrerSigner{Signer: base, attestor: attestor}
+	c, repository := testCache(t, imageSigner)
+
+	asset := testAsset{data: []byte("talos.platform=metal console=ttyS0")}
+
+	for range 3 {
+		require.NoError(t, c.Put(t.Context(), testProfileHash, asset, "cmdline-metal-amd64"))
+	}
+
+	require.Equal(t, 1, imageSigner.calls, "an entry already carrying a signature must not be signed again")
+	require.Equal(t, 1, referrerCount(t, repository), "re-caching must not append another signature referrer")
+}
+
+// TestPutSignsWhenReferrerIsNotASignature covers an entry that already carries a referrer which
+// does not satisfy the signature check -- an SBOM, or a signature made under a rotated identity.
+// Treating any attached artifact as proof of signing would leave the entry unverifiable, so it
+// would be rebuilt on every request forever.
+func TestPutSignsWhenReferrerIsNotASignature(t *testing.T) {
+	base := keySigner(t)
+
+	attestor, ok := base.(signer.ImageAttestor)
+	require.True(t, ok)
+
+	imageSigner := &referrerSigner{Signer: base, attestor: attestor, predicateType: attestation.SPDXPredicateType}
+	c, repository := testCache(t, imageSigner)
+
+	asset := testAsset{data: []byte("talos.platform=metal")}
+
+	for range 3 {
+		require.NoError(t, c.Put(t.Context(), testProfileHash, asset, "cmdline-metal-amd64"))
+	}
+
+	require.Equal(t, 3, imageSigner.calls, "a referrer that is not a valid signature must not suppress signing")
+	require.Positive(t, referrerCount(t, repository))
+}
+
+// TestPutSignsEveryTimeWithoutReferrers covers key-based signing, which writes a fixed tag that
+// is overwritten rather than accumulated: nothing reports a referrer, so it keeps signing.
+func TestPutSignsEveryTimeWithoutReferrers(t *testing.T) {
+	imageSigner := &tagSigner{Signer: keySigner(t)}
+	c, _ := testCache(t, imageSigner)
+
+	asset := testAsset{data: []byte("talos.platform=metal")}
+
+	for range 3 {
+		require.NoError(t, c.Put(t.Context(), testProfileHash, asset, "cmdline-metal-amd64"))
+	}
+
+	require.Equal(t, 3, imageSigner.calls, "signatures that are not referrers must keep being written")
+}

--- a/internal/frontend/http/pxe.go
+++ b/internal/frontend/http/pxe.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/julienschmidt/httprouter"
@@ -20,6 +22,9 @@ import (
 
 	"github.com/siderolabs/image-factory/internal/profile"
 )
+
+// pxeCacheTTL is how long an unauthenticated iPXE script may be cached downstream.
+const pxeCacheTTL = time.Hour
 
 //go:embed standard.ipxe
 var standardIPXE string
@@ -99,6 +104,11 @@ func (f *Frontend) handlePXE(ctx context.Context, w http.ResponseWriter, r *http
 			u.User = url.UserPassword(username, password)
 			imageBaseURL = &u
 		}
+	} else {
+		// No credential in the script and nothing per-caller: the schematic ID is
+		// content-addressed and the version pinned. Bounded rather than immutable, so an
+		// imager bump still rolls out.
+		w.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(int(pxeCacheTTL.Seconds())))
 	}
 
 	if prof.SecureBootEnabled() {

--- a/internal/integration/pxe_test.go
+++ b/internal/integration/pxe_test.go
@@ -44,6 +44,9 @@ func downloadPXE(ctx context.Context, t *testing.T, baseURL string, schematicID,
 	if username, _ := authCredentials(); username != "" {
 		assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"),
 			"the script embeds the Basic credentials it was fetched with")
+	} else {
+		assert.Equal(t, "public, max-age=3600", resp.Header.Get("Cache-Control"),
+			"an unauthenticated script carries no credential and is identical for every caller")
 	}
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
An unauthenticated iPXE script carries no credential and is
identical for every caller, since the schematic ID is
content-addressed and the version pinned. Add
Cache-Control: public, max-age=3600 so it can be cached
downstream instead of hitting the origin on every boot.

registry.Put re-signed every cache entry on every write.
Keyless signing attaches each signature as a new OCI referrer,
so re-signing on a re-cached entry accumulates referrers
forever -- the metal-amd64 cmdline entry reached 205 referrers,
turning a cache hit into a 140s Get because it walks all of
them. Skip signing when VerifyImage already succeeds against
the existing referrer.

Also:
- add head/verify latency fields and request-id-scoped logging
  to Cache.Get, so a slow hit is attributable to a phase
- add a cache-put-errors metric so a cache that silently
  rejects writes shows up as a metric instead of an
  unexplained rebuild-every-request
- add registry_test.go covering sign-once, a non-signature
  referrer (must still sign), and key-based signing (must
  still sign every time, since it has no referrer to check)

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
